### PR TITLE
Increase item creation loop and refactor tributes API

### DIFF
--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -131,7 +131,7 @@ pub async fn game_create(Json(payload): Json<Game>) -> impl IntoResponse {
             payload.clone().identifier // Game to link to,
         ).await.expect("Failed to create game area");
 
-        for _ in 0..2 {
+        for _ in 0..3 {
             // Insert an item
             let new_item: Item = Item::new_random(None);
             let new_item_id: RecordId = RecordId::from(("item", &new_item.identifier));

--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -1,4 +1,4 @@
-use crate::tributes::{tribute_create, tribute_delete, tribute_detail, tribute_log, tribute_record_create, tribute_update, TributeOwns};
+use crate::tributes::{tribute_record_create, TributeOwns, TRIBUTES_ROUTER};
 use crate::DATABASE;
 use announcers::{summarize, summarize_stream};
 use axum::extract::Path;
@@ -37,10 +37,8 @@ pub static GAMES_ROUTER: LazyLock<Router> = LazyLock::new(|| {
         .route("/{game_identifier}/publish", put(publish_game))
         .route("/{game_identifier}/summarize", get(game_summary))
         .route("/{game_identifier}/summarize/{day}", get(game_day_summary))
-        .route("/{game_identifier}/tributes", get(game_tributes).post(tribute_create))
-        .route("/{game_identifier}/tributes/{tribute_identifier}", get(tribute_detail).delete(tribute_delete).put(tribute_update))
-        .route("/{game_identifier}/tributes/{tribute_identifier}/log", get(tribute_log))
         .route("/{game_identifier}/unpublish", put(unpublish_game))
+        .nest("/{game_identifier}/tributes", TRIBUTES_ROUTER.clone())
 });
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -468,9 +466,8 @@ async fn save_game(game: &Game) -> Option<Game> {
     for mut area in areas {
         let id = RecordId::from(("area", area.identifier.clone()));
         let items = area.items.clone();
+        let _ = save_area_items(items, id.clone()).await;
         area.items = vec![];
-
-        let _ = save_items(items, id.clone()).await;
 
         DATABASE
             .update::<Option<AreaDetails>>(id)
@@ -487,7 +484,7 @@ async fn save_game(game: &Game) -> Option<Game> {
         if !tribute.is_alive() { items.clear(); }
         tribute.items = vec![];
 
-        let _ = save_items(items, id.clone()).await;
+        let _ = save_tribute_items(items, id.clone()).await;
 
         DATABASE
             .update::<Option<Tribute>>(id)
@@ -495,18 +492,15 @@ async fn save_game(game: &Game) -> Option<Game> {
             .await.expect("Failed to update tributes");
     }
 
-    tracing::debug!("Saving game: {}", saved_game.private);
     DATABASE
         .update::<Option<Game>>(game_identifier.clone())
         .content(saved_game)
         .await.expect("Failed to update game")
 }
 
-async fn save_items(items: Vec<Item>, owner: RecordId) {
-    let is_area = owner.table() == "area";
+async fn save_area_items(items: Vec<Item>, owner: RecordId) {
     let _ = DATABASE
-        .query("DELETE FROM $table WHERE in = $owner")
-        .bind(("table", if is_area { "items" } else { "owns" }))
+        .query("DELETE FROM items WHERE in = $owner")
         .bind(("owner", owner.clone()))
         .await.expect("Failed to delete items");
 
@@ -525,21 +519,43 @@ async fn save_items(items: Vec<Item>, owner: RecordId) {
         }
 
         if item.quantity > 0 {
-            if is_area {
-                let _: Vec<TributeOwns> = DATABASE.insert("items").relation(
-                    AreaItem {
-                        area: owner.clone(),
-                        item: item_identifier.clone(),
-                    }
-                ).await.expect("Failed to update Items relation");
-            } else {
-                let _: Vec<TributeOwns> = DATABASE.insert("owns").relation(
-                    TributeOwns {
-                        tribute: owner.clone(),
-                        item: item_identifier.clone(),
-                    }
-                ).await.expect("Failed to update Owns relation");
-            }
+            let _: Vec<TributeOwns> = DATABASE.insert("items").relation(
+                AreaItem {
+                    area: owner.clone(),
+                    item: item_identifier.clone(),
+                }
+            ).await.expect("Failed to update Items relation");
+        }
+    }
+}
+
+async fn save_tribute_items(items: Vec<Item>, owner: RecordId) {
+    let _ = DATABASE
+        .query("DELETE FROM owns WHERE in = $owner")
+        .bind(("owner", owner.clone()))
+        .await.expect("Failed to delete items");
+
+    for item in items {
+        let item_identifier = RecordId::from(("item", item.identifier.clone()));
+        if item.quantity == 0 {
+            DATABASE
+                .delete::<Option<Item>>(item_identifier.clone())
+                .await.expect("Failed to delete item");
+            return;
+        } else {
+            DATABASE
+                .update::<Option<Item>>(item_identifier.clone())
+                .content(item.clone())
+                .await.expect("Failed to update item");
+        }
+
+        if item.quantity > 0 {
+            let _: Vec<TributeOwns> = DATABASE.insert("owns").relation(
+                TributeOwns {
+                    tribute: owner.clone(),
+                    item: item_identifier.clone(),
+                }
+            ).await.expect("Failed to update Owns relation");
         }
     }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -4,7 +4,6 @@ pub mod logging;
 pub mod messages;
 mod users;
 
-use crate::tributes::TRIBUTES_ROUTER;
 use crate::users::USERS_ROUTER;
 use axum::error_handling::HandleErrorLayer;
 use axum::extract::Request;
@@ -122,7 +121,6 @@ async fn main() {
 
     let api_routes = Router::new()
         .nest("/games", GAMES_ROUTER.clone().layer(middleware::from_fn(surreal_jwt)))
-        .nest("/tributes", TRIBUTES_ROUTER.clone().layer(middleware::from_fn(surreal_jwt)))
         .nest("/users", USERS_ROUTER.clone());
 
     let router = Router::new()

--- a/game/src/items/mod.rs
+++ b/game/src/items/mod.rs
@@ -102,7 +102,7 @@ impl Item {
     pub fn new_weapon(name: &str) -> Item {
         let mut rng = SmallRng::from_entropy();
 
-        let quantity = rng.gen_range(1..=2);
+        let quantity = 1;
         let attribute = Attribute::Strength;
         let effect = rng.gen_range(1..=5);
 
@@ -150,7 +150,7 @@ impl Item {
         let mut rng = SmallRng::from_entropy();
 
         let item_type = ItemType::Weapon;
-        let quantity = rng.gen_range(1..=3);
+        let quantity = 1;
         let attribute = Attribute::Defense;
         let effect = rng.gen_range(1..=7);
 

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -133,20 +133,17 @@ impl OwnsItems for Tribute {
     }
 
     fn use_item(&mut self, item: &Item) -> Result<(), ItemError> {
-        let used_item = self.items
-            .iter_mut()
-            .find(|i| i.identifier == item.identifier);
+        let index = self.items.iter()
+            .position(|i| i.identifier == item.identifier)
+            .ok_or(ItemError::ItemNotFound)?;
 
-        if let Some(used_item) = used_item {
-            if used_item.quantity == 0 {
-                return Err(ItemError::ItemNotUsable);
-            }
+        let current_quantity = self.items[index].quantity;
 
-            used_item.quantity = used_item.quantity.saturating_sub(1);
-            if used_item.quantity == 0 {
-                self.remove_item(item)
-            } else { Ok(()) }
+        if current_quantity > 1 {
+            self.items[index].quantity -= 1;
+            Ok(())
         } else {
+            self.items.remove(index);
             Err(ItemError::ItemNotFound)
         }
     }


### PR DESCRIPTION
```
### Description
This pull request includes the following changes:
1. Increased the item creation loop count from 2 to 3, improving initial game setup to better align with updated gameplay requirements.
2. Refactored the tributes API:
   - Consolidated tribute routes under a nested router for improved clarity.
   - Improved item handling by refining `use_item` logic and splitting functions for saving area and tribute items.
   - Updated tribute log to include game identifiers, enhancing consistency across components.

### Checklist
- [ ] Tests are added where needed.
- [ ] The code is linted and follows the project's coding standards.
- [ ] Documentation is updated accordingly.

### Related Issues
_No related issues._

### Additional Notes
N/A
```