### PR TITLE
feat(api): add input validation

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -24,6 +24,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 uuid = { version = "1.16.0", features = ["v4"] }
 time = { version = "0.3.41", features = ["serde"] }
+validator = { version = "0.18", features = ["derive"] }
 
 [target.'cfg(windows)'.dependencies]
 surrealdb = { version = "2.2.1", features = ["kv-mem"] }

--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -375,6 +375,11 @@ pub async fn game_update(
     state: State<AppState>,
     Json(payload): Json<EditGame>,
 ) -> Result<Json<Game>, AppError> {
+    // Validate input
+    if let Err(e) = validator::Validate::validate(&payload) {
+        return Err(AppError::BadRequest(format!("Invalid input: {}", e)));
+    }
+
     let response = state
         .db
         .query(

--- a/api/src/tributes.rs
+++ b/api/src/tributes.rs
@@ -127,6 +127,11 @@ pub async fn tribute_update(
     state: State<AppState>,
     Json(payload): Json<EditTribute>,
 ) -> Result<StatusCode, AppError> {
+    // Validate input
+    if let Err(e) = validator::Validate::validate(&payload) {
+        return Err(AppError::BadRequest(format!("Invalid input: {}", e)));
+    }
+
     let response = state
         .db
         .query("UPDATE tribute SET name = $name WHERE identifier = $identifier;")

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,9 +1,11 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
+use validator::Validate;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Validate)]
 pub struct CreateGame {
+    #[validate(length(min = 1, max = 100, message = "Game name must be 1-100 characters"))]
     pub name: Option<String>,
 }
 
@@ -12,14 +14,26 @@ pub type DeleteTribute = String;
 pub struct DeleteGame(pub String, pub String); // Identifier, name
 
 /// Used to edit a tribute. Contains the identifier, name, avatar, and game identifier of the tribute.
-// TODO: Change to named fields for clarity
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct EditTribute(pub String, pub String, pub String, pub String);
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+pub struct EditTribute(
+    #[validate(length(min = 1, message = "Tribute identifier required"))]
+    pub String,
+    #[validate(length(min = 1, max = 50, message = "Name must be 1-50 characters"))]
+    pub String,
+    pub String,
+    pub String,
+);
 
 /// This struct is used to edit a game
 /// It contains the identifier, name, and a boolean indicating if the game is private
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
-pub struct EditGame(pub String, pub String, pub bool);
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Validate)]
+pub struct EditGame(
+    #[validate(length(min = 1, message = "Game identifier required"))]
+    pub String,
+    #[validate(length(min = 1, max = 100, message = "Name must be 1-100 characters"))]
+    pub String,
+    pub bool,
+);
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct GameArea {


### PR DESCRIPTION
Adds input validation for game and tribute names using the validator crate.

- Validates EditGame and EditTribute payloads before processing
- Game name: 1-100 characters
- Tribute name: 1-50 characters
- Returns BadRequest error for invalid input