### PR TITLE
feat(auth): Implement JWT refresh token mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "chrono",
  "futures",
  "game",
+ "jsonwebtoken",
  "serde",
  "serde_json",
  "shared",

--- a/announcers/src/lib.rs
+++ b/announcers/src/lib.rs
@@ -47,7 +47,9 @@ pub async fn summarize(log: &str) -> Result<String, AnnouncerError> {
     }
 }
 
-pub async fn summarize_stream(log: &str) -> Pin<Box<dyn Stream<Item = Result<String, String>> + Send>> {
+pub async fn summarize_stream(
+    log: &str,
+) -> Pin<Box<dyn Stream<Item = Result<String, String>> + Send>> {
     let log_prompt = prompt(log);
     let ollama = Ollama::default();
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -25,7 +25,7 @@ tower_governor = "0.4"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 uuid = { version = "1.16.0", features = ["v4"] }
-time = { version = "0.3.41", features = ["serde"] }
+time = { version = "0.3.41", features = ["serde", "macros"] }
 validator = { version = "0.18", features = ["derive"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,6 +10,7 @@ base64-url = "3.0.0"
 chrono = { version = "0.4.41", features = ["serde"] }
 futures = "0.3.31"
 game = { path = "../game" }
+jsonwebtoken = "9.3.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 shared = { path = "../shared" }

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -1,0 +1,184 @@
+use crate::{AppError, AppState};
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+use surrealdb::sql::Thing;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+// JWT secret from schemas/users.surql
+const JWT_SECRET: &str =
+    "6dxLjU0m8ZmAzaLEk_qAeMpeD5ZAjGYlCjlvDi5DcgdJLATIHuCReUu7CbGyCDhRSp3btd7Ezob7RPYe6fUtsA";
+
+pub static AUTH_ROUTER: LazyLock<Router<AppState>> =
+    LazyLock::new(|| Router::new().route("/refresh", post(refresh_token)));
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RefreshToken {
+    pub token: String,
+    pub user_id: Thing,
+    pub username: String,
+    pub expires_at: String,
+    pub revoked: bool,
+    pub created_at: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RefreshTokenRequest {
+    pub refresh_token: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+}
+
+impl RefreshToken {
+    /// Generate a new refresh token for a user
+    pub fn new(user_id: Thing, username: String) -> Self {
+        let token = Uuid::new_v4().to_string();
+        let now = OffsetDateTime::now_utc();
+        let expires_at = now + time::Duration::days(7);
+
+        RefreshToken {
+            token,
+            user_id,
+            username,
+            expires_at: expires_at.to_string(),
+            revoked: false,
+            created_at: now.to_string(),
+        }
+    }
+
+    /// Check if the refresh token is valid (not expired and not revoked)
+    pub fn is_valid(&self) -> bool {
+        if self.revoked {
+            return false;
+        }
+
+        let now = OffsetDateTime::now_utc();
+        if let Ok(expires_at) = OffsetDateTime::parse(
+            &self.expires_at,
+            &time::format_description::well_known::Rfc3339,
+        ) {
+            expires_at > now
+        } else {
+            false
+        }
+    }
+}
+
+/// Store a refresh token in the database
+pub async fn store_refresh_token(
+    state: &AppState,
+    refresh_token: &RefreshToken,
+) -> Result<(), AppError> {
+    let _: Option<RefreshToken> = state
+        .db
+        .create("refresh_token")
+        .content(refresh_token)
+        .await
+        .map_err(|e| AppError::DbError(format!("Failed to store refresh token: {}", e)))?;
+    Ok(())
+}
+
+/// Retrieve a refresh token from the database by token string
+pub async fn get_refresh_token(state: &AppState, token: &str) -> Result<RefreshToken, AppError> {
+    let mut result = state
+        .db
+        .query("SELECT * FROM refresh_token WHERE token = $token LIMIT 1")
+        .bind(("token", token))
+        .await
+        .map_err(|e| AppError::DbError(format!("Failed to query refresh token: {}", e)))?;
+
+    let tokens: Vec<RefreshToken> = result
+        .take(0)
+        .map_err(|e| AppError::DbError(format!("Failed to parse refresh token: {}", e)))?;
+
+    tokens
+        .into_iter()
+        .next()
+        .ok_or_else(|| AppError::Unauthorized("Invalid refresh token".to_string()))
+}
+
+/// Revoke a refresh token in the database
+pub async fn revoke_refresh_token(state: &AppState, token: &str) -> Result<(), AppError> {
+    let _: Option<RefreshToken> = state
+        .db
+        .query("UPDATE refresh_token SET revoked = true WHERE token = $token")
+        .bind(("token", token))
+        .await
+        .map_err(|e| AppError::DbError(format!("Failed to revoke refresh token: {}", e)))?
+        .take(0)
+        .map_err(|e| AppError::DbError(format!("Failed to parse revoked token: {}", e)))?;
+    Ok(())
+}
+
+/// Generate a new access token for a user
+async fn generate_access_token(
+    _state: &AppState,
+    user_id: &Thing,
+    username: &str,
+) -> Result<String, AppError> {
+    // Create JWT claims matching SurrealDB's format
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    let exp = now + 3600; // 1 hour expiration
+
+    let claims = serde_json::json!({
+        "iss": "SurrealDB",
+        "iat": now,
+        "nbf": now,
+        "exp": exp,
+        "ns": "hangry-games",
+        "db": "games",
+        "ac": "user",
+        "id": user_id.to_string(),
+        "sub": username,
+    });
+
+    // Sign the JWT with HS512 algorithm
+    let header = Header::new(Algorithm::HS512);
+    let token = encode(
+        &header,
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .map_err(|e| AppError::InternalServerError(format!("Failed to generate JWT: {}", e)))?;
+
+    Ok(token)
+}
+
+/// Refresh endpoint: exchange a refresh token for new access + refresh tokens
+async fn refresh_token(
+    State(state): State<AppState>,
+    Json(payload): Json<RefreshTokenRequest>,
+) -> Result<Json<TokenResponse>, AppError> {
+    // Retrieve the refresh token from the database
+    let token = get_refresh_token(&state, &payload.refresh_token).await?;
+
+    // Validate the token
+    if !token.is_valid() {
+        return Err(AppError::Unauthorized(
+            "Refresh token expired or revoked".to_string(),
+        ));
+    }
+
+    // Revoke the old refresh token (token rotation)
+    revoke_refresh_token(&state, &payload.refresh_token).await?;
+
+    // Generate new refresh token
+    let new_refresh_token = RefreshToken::new(token.user_id.clone(), token.username.clone());
+    store_refresh_token(&state, &new_refresh_token).await?;
+
+    // Generate new access token
+    let access_token = generate_access_token(&state, &token.user_id, &token.username).await?;
+
+    Ok(Json(TokenResponse {
+        access_token,
+        refresh_token: new_refresh_token.token,
+    }))
+}

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -8,6 +8,7 @@ use std::sync::LazyLock;
 use surrealdb::sql::Thing;
 use time::OffsetDateTime;
 use uuid::Uuid;
+use validator::Validate;
 
 // JWT secret from schemas/users.surql
 const JWT_SECRET: &str =
@@ -21,13 +22,16 @@ pub struct RefreshToken {
     pub token: String,
     pub user_id: Thing,
     pub username: String,
-    pub expires_at: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub expires_at: OffsetDateTime,
     pub revoked: bool,
-    pub created_at: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Validate)]
 pub struct RefreshTokenRequest {
+    #[validate(length(min = 36, max = 36, message = "Invalid refresh token format"))]
     pub refresh_token: String,
 }
 
@@ -48,9 +52,9 @@ impl RefreshToken {
             token,
             user_id,
             username,
-            expires_at: expires_at.to_string(),
+            expires_at,
             revoked: false,
-            created_at: now.to_string(),
+            created_at: now,
         }
     }
 
@@ -61,14 +65,7 @@ impl RefreshToken {
         }
 
         let now = OffsetDateTime::now_utc();
-        if let Ok(expires_at) = OffsetDateTime::parse(
-            &self.expires_at,
-            &time::format_description::well_known::Rfc3339,
-        ) {
-            expires_at > now
-        } else {
-            false
-        }
+        self.expires_at > now
     }
 }
 
@@ -119,11 +116,7 @@ pub async fn revoke_refresh_token(state: &AppState, token: &str) -> Result<(), A
 }
 
 /// Generate a new access token for a user
-async fn generate_access_token(
-    _state: &AppState,
-    user_id: &Thing,
-    username: &str,
-) -> Result<String, AppError> {
+fn generate_access_token(user_id: &Thing, username: &str) -> Result<String, AppError> {
     // Create JWT claims matching SurrealDB's format
     let now = OffsetDateTime::now_utc().unix_timestamp();
     let exp = now + 3600; // 1 hour expiration
@@ -157,6 +150,11 @@ async fn refresh_token(
     State(state): State<AppState>,
     Json(payload): Json<RefreshTokenRequest>,
 ) -> Result<Json<TokenResponse>, AppError> {
+    // Validate the request
+    payload
+        .validate()
+        .map_err(|e| AppError::ValidationError(e.to_string()))?;
+
     // Retrieve the refresh token from the database
     let token = get_refresh_token(&state, &payload.refresh_token).await?;
 
@@ -175,10 +173,73 @@ async fn refresh_token(
     store_refresh_token(&state, &new_refresh_token).await?;
 
     // Generate new access token
-    let access_token = generate_access_token(&state, &token.user_id, &token.username).await?;
+    let access_token = generate_access_token(&token.user_id, &token.username)?;
 
     Ok(Json(TokenResponse {
         access_token,
         refresh_token: new_refresh_token.token,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_refresh_token_generation() {
+        let user_id = Thing::from(("user".to_string(), "test123".to_string()));
+        let username = "testuser".to_string();
+
+        let token = RefreshToken::new(user_id.clone(), username.clone());
+
+        assert_eq!(token.user_id, user_id);
+        assert_eq!(token.username, username);
+        assert_eq!(token.token.len(), 36); // UUID v4 length
+        assert!(!token.revoked);
+        assert!(token.expires_at > OffsetDateTime::now_utc());
+    }
+
+    #[test]
+    fn test_expired_token_invalid() {
+        let user_id = Thing::from(("user".to_string(), "test123".to_string()));
+        let username = "testuser".to_string();
+        let token_str = Uuid::new_v4().to_string();
+
+        // Create a token that expired 1 day ago
+        let now = OffsetDateTime::now_utc();
+        let expired = now - time::Duration::days(1);
+
+        let token = RefreshToken {
+            token: token_str,
+            user_id,
+            username,
+            expires_at: expired,
+            revoked: false,
+            created_at: now - time::Duration::days(8),
+        };
+
+        assert!(!token.is_valid());
+    }
+
+    #[test]
+    fn test_revoked_token_invalid() {
+        let user_id = Thing::from(("user".to_string(), "test123".to_string()));
+        let username = "testuser".to_string();
+        let token_str = Uuid::new_v4().to_string();
+
+        // Create a token that's not expired but is revoked
+        let now = OffsetDateTime::now_utc();
+        let expires_at = now + time::Duration::days(7);
+
+        let token = RefreshToken {
+            token: token_str,
+            user_id,
+            username,
+            expires_at,
+            revoked: true,
+            created_at: now,
+        };
+
+        assert!(!token.is_valid());
+    }
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -34,6 +34,8 @@ pub enum AppError {
     DbError(String),
     #[error("Invalid status")]
     InvalidStatus(String),
+    #[error("Validation error")]
+    ValidationError(String),
 }
 
 impl IntoResponse for AppError {
@@ -46,6 +48,7 @@ impl IntoResponse for AppError {
             AppError::GameFull(message) => (StatusCode::BAD_REQUEST, message),
             AppError::DbError(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
             AppError::InvalidStatus(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
+            AppError::ValidationError(message) => (StatusCode::BAD_REQUEST, message),
         };
         (status, Json(json!({ "error": error_message }))).into_response()
     }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -7,9 +7,9 @@ use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
 use thiserror::Error;
 
+pub mod auth;
 pub mod games;
 pub mod logging;
-pub mod messages;
 pub mod tributes;
 pub mod users;
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,6 +1,7 @@
 extern crate core;
 
 use api::AppState;
+use api::auth::AUTH_ROUTER;
 use api::games::GAMES_ROUTER;
 use api::users::USERS_ROUTER;
 use axum::error_handling::HandleErrorLayer;
@@ -124,13 +125,20 @@ async fn main() {
         .expect("Failed to use database");
     tracing::debug!("Using 'hangry-games' namespace and 'games' database");
 
-    MigrationRunner::new(&*db).up().await.map_err(|e| {
-        eprintln!("Failed to apply migrations: {}", e);
-        std::process::exit(1);
-    })?;
+    MigrationRunner::new(&app_state.db)
+        .up()
+        .await
+        .map_err(|e| {
+            eprintln!("Failed to apply migrations: {}", e);
+            std::process::exit(1);
+        })
+        .unwrap();
     tracing::debug!("Applied migrations");
 
-    let app_state = AppState { db };
+    let allowed_origins = vec![
+        "http://localhost:8080".to_string(),
+        "http://127.0.0.1:8080".to_string(),
+    ];
 
     let cors_layer = CorsLayer::new()
         .allow_methods(vec![
@@ -177,7 +185,8 @@ async fn main() {
                 surreal_jwt,
             )),
         )
-        .nest("/users", USERS_ROUTER.clone());
+        .nest("/users", USERS_ROUTER.clone())
+        .nest("/auth", AUTH_ROUTER.clone());
 
     let router = Router::new()
         .nest("/api", api_routes)

--- a/api/src/users.rs
+++ b/api/src/users.rs
@@ -1,3 +1,4 @@
+use crate::auth::{RefreshToken, TokenResponse, store_refresh_token};
 use crate::{AppError, AppState};
 use axum::extract::State;
 use axum::routing::{get, post};
@@ -5,6 +6,7 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 use surrealdb::opt::auth::Record;
+use surrealdb::sql::Thing;
 
 pub static USERS_ROUTER: LazyLock<Router<AppState>> = LazyLock::new(|| {
     Router::new()
@@ -23,6 +25,29 @@ struct JwtResponse {
     jwt: String,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+struct UserRecord {
+    id: Thing,
+    username: String,
+}
+
+/// Helper function to create both access and refresh tokens
+async fn create_token_pair(
+    state: &AppState,
+    jwt: String,
+    user_id: Thing,
+    username: String,
+) -> Result<TokenResponse, AppError> {
+    // Create and store refresh token
+    let refresh_token = RefreshToken::new(user_id, username);
+    store_refresh_token(state, &refresh_token).await?;
+
+    Ok(TokenResponse {
+        access_token: jwt,
+        refresh_token: refresh_token.token,
+    })
+}
+
 async fn session(state: State<AppState>) -> Result<Json<String>, AppError> {
     let res: Option<String> = state
         .db
@@ -37,7 +62,7 @@ async fn session(state: State<AppState>) -> Result<Json<String>, AppError> {
 async fn user_create(
     state: State<AppState>,
     Json(payload): Json<Params>,
-) -> Result<Json<JwtResponse>, AppError> {
+) -> Result<Json<TokenResponse>, AppError> {
     let username = payload.username;
     let password = payload.password;
 
@@ -54,9 +79,29 @@ async fn user_create(
         })
         .await
     {
-        Ok(token) => Ok(Json(JwtResponse {
-            jwt: token.into_insecure_token(),
-        })),
+        Ok(auth_result) => {
+            let jwt = auth_result.into_insecure_token();
+
+            // Query the user to get their ID
+            let mut result = state
+                .db
+                .query("SELECT id, username FROM user WHERE username = $username LIMIT 1")
+                .bind(("username", username.clone()))
+                .await
+                .map_err(|e| AppError::DbError(format!("Failed to query user: {}", e)))?;
+
+            let users: Vec<UserRecord> = result
+                .take(0)
+                .map_err(|e| AppError::DbError(format!("Failed to parse user: {}", e)))?;
+
+            let user = users
+                .into_iter()
+                .next()
+                .ok_or_else(|| AppError::DbError("User created but not found".to_string()))?;
+
+            let token_pair = create_token_pair(&state, jwt, user.id, user.username).await?;
+            Ok(Json(token_pair))
+        }
         Err(_) => Err(AppError::DbError("Failed to create user".to_string())),
     }
 }
@@ -64,7 +109,7 @@ async fn user_create(
 async fn user_authenticate(
     state: State<AppState>,
     Json(payload): Json<Params>,
-) -> Result<Json<JwtResponse>, AppError> {
+) -> Result<Json<TokenResponse>, AppError> {
     let username = payload.username;
     let password = payload.password;
 
@@ -81,9 +126,29 @@ async fn user_authenticate(
         })
         .await
     {
-        Ok(auth_user) => Ok(Json(JwtResponse {
-            jwt: auth_user.into_insecure_token(),
-        })),
+        Ok(auth_result) => {
+            let jwt = auth_result.into_insecure_token();
+
+            // Query the user to get their ID
+            let mut result = state
+                .db
+                .query("SELECT id, username FROM user WHERE username = $username LIMIT 1")
+                .bind(("username", username.clone()))
+                .await
+                .map_err(|e| AppError::DbError(format!("Failed to query user: {}", e)))?;
+
+            let users: Vec<UserRecord> = result
+                .take(0)
+                .map_err(|e| AppError::DbError(format!("Failed to parse user: {}", e)))?;
+
+            let user = users
+                .into_iter()
+                .next()
+                .ok_or_else(|| AppError::Unauthorized("User not found".to_string()))?;
+
+            let token_pair = create_token_pair(&state, jwt, user.id, user.username).await?;
+            Ok(Json(token_pair))
+        }
         Err(_) => Err(AppError::DbError("Failed to authenticate user".to_string())),
     }
 }

--- a/api/src/users.rs
+++ b/api/src/users.rs
@@ -4,21 +4,17 @@ use axum::extract::State;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
+use shared::RegistrationUser;
 use std::sync::LazyLock;
 use surrealdb::opt::auth::Record;
 use surrealdb::sql::Thing;
+use validator::Validate;
 
 pub static USERS_ROUTER: LazyLock<Router<AppState>> = LazyLock::new(|| {
     Router::new()
         .route("/", get(session).post(user_create))
         .route("/authenticate", post(user_authenticate))
 });
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Params {
-    username: String,
-    password: String,
-}
 
 #[derive(Serialize, Deserialize, Debug)]
 struct JwtResponse {
@@ -61,8 +57,13 @@ async fn session(state: State<AppState>) -> Result<Json<String>, AppError> {
 
 async fn user_create(
     state: State<AppState>,
-    Json(payload): Json<Params>,
+    Json(payload): Json<RegistrationUser>,
 ) -> Result<Json<TokenResponse>, AppError> {
+    // Validate the request
+    payload
+        .validate()
+        .map_err(|e| AppError::ValidationError(e.to_string()))?;
+
     let username = payload.username;
     let password = payload.password;
 
@@ -72,7 +73,7 @@ async fn user_create(
             access: "user",
             namespace: "hangry-games",
             database: "games",
-            params: Params {
+            params: RegistrationUser {
                 username: username.clone(),
                 password: password.clone(),
             },
@@ -108,8 +109,13 @@ async fn user_create(
 
 async fn user_authenticate(
     state: State<AppState>,
-    Json(payload): Json<Params>,
+    Json(payload): Json<RegistrationUser>,
 ) -> Result<Json<TokenResponse>, AppError> {
+    // Validate the request
+    payload
+        .validate()
+        .map_err(|e| AppError::ValidationError(e.to_string()))?;
+
     let username = payload.username;
     let password = payload.password;
 
@@ -119,7 +125,7 @@ async fn user_authenticate(
             access: "user",
             namespace: "hangry-games",
             database: "games",
-            params: Params {
+            params: RegistrationUser {
                 username: username.clone(),
                 password: password.clone(),
             },

--- a/game/src/areas/mod.rs
+++ b/game/src/areas/mod.rs
@@ -64,7 +64,7 @@ impl Area {
             Area::East => vec![Area::Cornucopia, Area::North, Area::South],
             Area::South => vec![Area::Cornucopia, Area::East, Area::West],
             Area::West => vec![Area::Cornucopia, Area::North, Area::South],
-            Area::Cornucopia => vec![Area::North, Area::East, Area::South, Area::West]
+            Area::Cornucopia => vec![Area::North, Area::East, Area::South, Area::West],
         }
     }
 }
@@ -95,7 +95,7 @@ impl OwnsItems for AreaDetails {
 
         if used_item.quantity > 0 {
             Ok(())
-        } else if used_item.quantity == 0  {
+        } else if used_item.quantity == 0 {
             Err(ItemError::ItemNotFound)
         } else {
             Err(ItemError::ItemNotFound)
@@ -103,7 +103,10 @@ impl OwnsItems for AreaDetails {
     }
 
     fn remove_item(&mut self, item: &Item) -> Result<(), ItemError> {
-        let index = self.items.iter().position(|i| i.identifier == item.identifier);
+        let index = self
+            .items
+            .iter()
+            .position(|i| i.identifier == item.identifier);
         if let Some(index) = index {
             self.items.remove(index);
             Ok(())

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -37,7 +37,7 @@ pub struct Game {
     pub areas: Vec<AreaDetails>,
     #[serde(default)]
     pub tributes: Vec<Tribute>,
-    pub private: bool
+    pub private: bool,
 }
 
 impl Default for Game {
@@ -56,7 +56,7 @@ impl Default for Game {
             day: None,
             areas: vec![],
             tributes: vec![],
-            private: true
+            private: true,
         }
     }
 }
@@ -120,23 +120,19 @@ impl Game {
 
     /// Returns a random open area from the game.
     fn random_open_area(&self) -> Option<AreaDetails> {
-        self.open_areas()
-            .choose(&mut rand::rng())
-            .cloned()
+        self.open_areas().choose(&mut rand::rng()).cloned()
     }
 
     /// Returns a vec of open areas.
     fn open_areas(&self) -> Vec<AreaDetails> {
-        self.areas.iter()
-            .filter(|a| a.is_open())
-            .cloned()
-            .collect()
+        self.areas.iter().filter(|a| a.is_open()).cloned().collect()
     }
 
     /// Returns a vec of closed areas.
     #[allow(dead_code)]
     fn closed_areas(&self) -> Vec<AreaDetails> {
-        self.areas.iter()
+        self.areas
+            .iter()
             .filter(|a| !a.is_open())
             .cloned()
             .collect()
@@ -148,14 +144,16 @@ impl Game {
         if let Some(winner) = self.winner() {
             add_game_message(
                 self.identifier.as_str(),
-                format!("{}", GameOutput::TributeWins(winner.name.as_str()))
-            ).expect("Failed to add winner message");
+                format!("{}", GameOutput::TributeWins(winner.name.as_str())),
+            )
+            .expect("Failed to add winner message");
             self.end();
         } else if self.living_tributes().is_empty() {
             add_game_message(
                 self.identifier.as_str(),
-                format!("{}", GameOutput::NoOneWins)
-            ).expect("Failed to add no winner message");
+                format!("{}", GameOutput::NoOneWins),
+            )
+            .expect("Failed to add no winner message");
             self.end();
         }
     }
@@ -186,39 +184,51 @@ impl Game {
                     add_game_message(
                         self.identifier.as_str(),
                         format!("{}", GameOutput::FirstDayStart),
-                    ).expect("Failed to add first day message");
+                    )
+                    .expect("Failed to add first day message");
                 }
                 3 => {
                     add_game_message(
                         self.identifier.as_str(),
                         format!("{}", GameOutput::FeastDayStart),
-                    ).expect("Failed to add feast day message");
-                },
+                    )
+                    .expect("Failed to add feast day message");
+                }
                 _ => {}
             }
             add_game_message(
                 self.identifier.as_str(),
                 format!("{}", GameOutput::GameDayStart(self.clone().day.unwrap())),
-            ).expect("Failed to add day start message");
+            )
+            .expect("Failed to add day start message");
         } else {
             add_game_message(
                 self.identifier.as_str(),
                 format!("{}", GameOutput::GameNightStart(self.day.unwrap())),
-            ).expect("Failed to add night start message");
+            )
+            .expect("Failed to add night start message");
         }
 
         add_game_message(
             self.identifier.as_str(),
-            format!("{}", GameOutput::TributesLeft(self.living_tributes().len() as u32))
-        ).expect("");
+            format!(
+                "{}",
+                GameOutput::TributesLeft(self.living_tributes().len() as u32)
+            ),
+        )
+        .expect("");
     }
 
     /// Announces the end of a cycle
     fn announce_cycle_end(&self, day: bool) {
         add_game_message(
             self.identifier.as_str(),
-            format!("{}", GameOutput::TributesLeft(self.living_tributes().len() as u32)),
-        ).expect("Failed to add tributes left message");
+            format!(
+                "{}",
+                GameOutput::TributesLeft(self.living_tributes().len() as u32)
+            ),
+        )
+        .expect("Failed to add tributes left message");
 
         // Announce tribute deaths
         for tribute in self.recently_dead_tributes() {
@@ -226,19 +236,22 @@ impl Game {
             add_game_message(
                 self.identifier.as_str(),
                 format!("{}", GameOutput::DeathAnnouncement(name)),
-            ).expect("Failed to add tribute death message");
+            )
+            .expect("Failed to add tribute death message");
         }
 
         if day {
             add_game_message(
                 self.identifier.as_str(),
                 format!("{}", GameOutput::GameDayEnd(self.clone().day.unwrap())),
-            ).expect("Failed to add day end message");
+            )
+            .expect("Failed to add day end message");
         } else {
             add_game_message(
                 self.identifier.as_str(),
                 format!("{}", GameOutput::GameNightEnd(self.clone().day.unwrap())),
-            ).expect("Failed to add night end message");
+            )
+            .expect("Failed to add night end message");
         }
     }
 
@@ -272,16 +285,21 @@ impl Game {
                 add_area_message(
                     area_name.as_str(),
                     &self.identifier,
-                    format!("{}", GameOutput::AreaClose(area_name.as_str()))
-                ).expect("Failed to add area close message");
+                    format!("{}", GameOutput::AreaClose(area_name.as_str())),
+                )
+                .expect("Failed to add area close message");
 
                 for event in &area_details.events {
                     let event_name = event.to_string();
                     add_area_message(
                         area_name.as_str(),
                         &self.identifier,
-                        format!("{}", GameOutput::AreaEvent(event_name.as_str(), area_name.as_str()))
-                    ).expect("Failed to add area event message");
+                        format!(
+                            "{}",
+                            GameOutput::AreaEvent(event_name.as_str(), area_name.as_str())
+                        ),
+                    )
+                    .expect("Failed to add area event message");
                 }
             }
         }
@@ -298,7 +316,11 @@ impl Game {
 
     /// Triggers events for the current cycle.
     fn trigger_cycle_events(&mut self, day: bool, rng: &mut SmallRng) {
-        let frequency = if day { DAY_EVENT_FREQUENCY } else { NIGHT_EVENT_FREQUENCY };
+        let frequency = if day {
+            DAY_EVENT_FREQUENCY
+        } else {
+            NIGHT_EVENT_FREQUENCY
+        };
 
         // If it's nighttime, trigger an event
         // If it is daytime and not day #1 or day #3, trigger an event
@@ -312,15 +334,21 @@ impl Game {
                     add_area_message(
                         area_name.as_str(),
                         &self.identifier,
-                        format!("{}", GameOutput::AreaEvent(event_name.as_str(), area_name.as_str()))
-                    ).expect("Failed to add area event message");
+                        format!(
+                            "{}",
+                            GameOutput::AreaEvent(event_name.as_str(), area_name.as_str())
+                        ),
+                    )
+                    .expect("Failed to add area event message");
                 }
             }
         }
 
         // Day 3 is Feast Day, refill the Cornucopia with a random assortment of items
         if day && self.day == Some(3) {
-            let area_details = self.areas.iter_mut()
+            let area_details = self
+                .areas
+                .iter_mut()
                 .filter(|ad| ad.area.is_some())
                 .find(|ad| ad.area.clone().unwrap().to_string() == "Cornucopia")
                 .expect("Cannot find Cornucopia");
@@ -334,7 +362,6 @@ impl Game {
                 area_details.add_item(Item::new_random_consumable());
             }
         }
-
     }
 
     /// If the tribute count is low, constrain them by closing areas.
@@ -377,8 +404,12 @@ impl Game {
                     add_area_message(
                         area_name.as_str(),
                         &self.identifier,
-                        format!("{}", GameOutput::AreaEvent(event_name.as_str(), area_name.as_str()))
-                    ).expect("Failed to add area event message");
+                        format!(
+                            "{}",
+                            GameOutput::AreaEvent(event_name.as_str(), area_name.as_str())
+                        ),
+                    )
+                    .expect("Failed to add area event message");
                 }
             }
 
@@ -394,11 +425,24 @@ impl Game {
     }
 
     /// Runs the tributes' logic for the current cycle.
-    fn run_tribute_cycle(&mut self, day: bool, rng: &mut SmallRng, closed_areas: Vec<Area>, living_tributes: Vec<Tribute>, living_tributes_count: usize) {
+    fn run_tribute_cycle(
+        &mut self,
+        day: bool,
+        rng: &mut SmallRng,
+        closed_areas: Vec<Area>,
+        living_tributes: Vec<Tribute>,
+        living_tributes_count: usize,
+    ) {
         // Pre-compute global action suggestion
         let action_suggestion = match (self.day, day) {
-            (Some(1), true) => Some(ActionSuggestion { action: Action::Move(None), probability: Some(0.5) }),
-            (Some(3), true) => Some(ActionSuggestion { action: Action::Move(Some(Area::Cornucopia)), probability: Some(0.75) }),
+            (Some(1), true) => Some(ActionSuggestion {
+                action: Action::Move(None),
+                probability: Some(0.5),
+            }),
+            (Some(3), true) => Some(ActionSuggestion {
+                action: Action::Move(Some(Area::Cornucopia)),
+                probability: Some(0.75),
+            }),
             (_, _) => None,
         };
 
@@ -413,7 +457,8 @@ impl Game {
         // Group tributes by area for faster lookups
         let mut tributes_by_area: HashMap<Area, Vec<&Tribute>> = HashMap::new();
         for tribute in &living_tributes {
-            tributes_by_area.entry(tribute.area.clone())
+            tributes_by_area
+                .entry(tribute.area.clone())
                 .or_insert_with(Vec::new)
                 .push(tribute);
         }
@@ -446,12 +491,13 @@ impl Game {
             let nearby_tributes = {
                 match tributes_by_area.get(&tribute.area) {
                     Some(tributes) => tributes,
-                    None => &ev
+                    None => &ev,
                 }
             };
             let nearby_tributes_count = nearby_tributes.len() as u32;
 
-            let targets: Vec<Tribute> = nearby_tributes.iter()
+            let targets: Vec<Tribute> = nearby_tributes
+                .iter()
                 .filter(|t| t.is_visible() && t.identifier != tribute.identifier)
                 .cloned()
                 .cloned()
@@ -467,7 +513,7 @@ impl Game {
                 action_suggestion.clone(),
                 &mut environment_details,
                 encounter_context,
-                rng
+                rng,
             );
         }
     }
@@ -496,19 +542,23 @@ impl Game {
         self.constrain_areas(&mut rng);
 
         self.tributes.shuffle(&mut rng);
-        let closed_areas: Vec<Area> = self.closed_areas()
+        let closed_areas: Vec<Area> = self
+            .closed_areas()
             .iter()
             .filter(|ad| ad.area.is_some())
-            .map(|ad| {
-                ad.area.clone().unwrap()
-            })
+            .map(|ad| ad.area.clone().unwrap())
             .clone()
             .collect();
         let living_tributes = self.living_tributes();
         let living_tributes_count: usize = living_tributes.len();
 
-
-        self.run_tribute_cycle(day, &mut rng, closed_areas, living_tributes, living_tributes_count);
+        self.run_tribute_cycle(
+            day,
+            &mut rng,
+            closed_areas,
+            living_tributes,
+            living_tributes_count,
+        );
     }
 
     /// Any tributes who have died in the current cycle will be moved to the "dead" list,
@@ -516,8 +566,11 @@ impl Game {
     fn clean_up_recent_deaths(&mut self) {
         let tribute_count = self.tributes.len();
 
-        for i in 0..tribute_count {  // Using a for loop to avoid mutable borrow issues
-            if self.tributes[i].is_alive() { continue }
+        for i in 0..tribute_count {
+            // Using a for loop to avoid mutable borrow issues
+            if self.tributes[i].is_alive() {
+                continue;
+            }
             let tribute_items: Vec<Item> = self.tributes[i].items.clone();
 
             if self.tributes[i].status == TributeStatus::RecentlyDead {
@@ -537,7 +590,9 @@ impl Game {
 
     /// Get a mutable reference to the area details for a given area.
     fn get_area_details_mut(&mut self, area: Area) -> Option<&mut AreaDetails> {
-        self.areas.iter_mut().find(|ad| ad.area == Some(area.clone()))
+        self.areas
+            .iter_mut()
+            .find(|ad| ad.area == Some(area.clone()))
     }
 }
 
@@ -554,7 +609,7 @@ mod tests {
             day: Some(1),
             areas: vec![],
             tributes,
-            private: true
+            private: true,
         }
     }
 
@@ -654,7 +709,8 @@ mod tests {
     fn test_check_game_state_winner_exists() {
         let winner_tribute = create_tribute("Winner", true);
         let loser_tribute = create_tribute("Loser", false);
-        let mut game = create_test_game_with_tributes(vec![winner_tribute.clone(), loser_tribute.clone()]);
+        let mut game =
+            create_test_game_with_tributes(vec![winner_tribute.clone(), loser_tribute.clone()]);
 
         // Game should have only one living tribute and they should be the winner
         assert_eq!(game.living_tributes().len(), 1);
@@ -670,7 +726,8 @@ mod tests {
     fn test_check_game_state_no_survivors() {
         let loser_tribute = create_tribute("Loser", false);
         let loser2_tribute = create_tribute("Loser 2", false);
-        let mut game = create_test_game_with_tributes(vec![loser_tribute.clone(), loser2_tribute.clone()]);
+        let mut game =
+            create_test_game_with_tributes(vec![loser_tribute.clone(), loser2_tribute.clone()]);
 
         // Game should have only no living tributes and no winner
         assert!(game.living_tributes().is_empty());
@@ -686,7 +743,8 @@ mod tests {
     fn test_check_game_state_continues() {
         let living_tribute1 = create_tribute("Living1", true);
         let living_tribute2 = create_tribute("Living2", true);
-        let mut game = create_test_game_with_tributes(vec![living_tribute1.clone(), living_tribute2.clone()]);
+        let mut game =
+            create_test_game_with_tributes(vec![living_tribute1.clone(), living_tribute2.clone()]);
         let starting_state = game.status.clone();
 
         // Game should have only one living tribute and they should be the winner
@@ -795,7 +853,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trigger_cycle_events() { }
+    fn test_trigger_cycle_events() {}
 
     #[test]
     fn test_constrain_areas() {
@@ -830,11 +888,22 @@ mod tests {
         let mut game = create_test_game_with_tributes(vec![tribute1.clone(), tribute2.clone()]);
         let area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
         game.areas.push(area);
-        let closed_areas = game.areas.iter().filter(|ad| ad.area.is_some() & &!ad.is_open()).map(|ad| ad.area.clone().unwrap()).collect::<Vec<Area>>();
+        let closed_areas = game
+            .areas
+            .iter()
+            .filter(|ad| ad.area.is_some() & &!ad.is_open())
+            .map(|ad| ad.area.clone().unwrap())
+            .collect::<Vec<Area>>();
 
         // Run the tribute cycle
         let mut rng = SmallRng::from_rng(&mut rand::rng());
-        game.run_tribute_cycle(true, &mut rng, closed_areas, vec![tribute1.clone(), tribute2.clone()], 2);
+        game.run_tribute_cycle(
+            true,
+            &mut rng,
+            closed_areas,
+            vec![tribute1.clone(), tribute2.clone()],
+            2,
+        );
 
         // Check if the tributes are updated correctly
         let new_tribute1 = game.tributes[0].clone();

--- a/game/src/items/mod.rs
+++ b/game/src/items/mod.rs
@@ -84,18 +84,14 @@ impl Item {
         match (item_type, name) {
             (ItemType::Consumable, Some(name)) => Self::new_consumable(name),
             (ItemType::Consumable, None) => Self::new_random_consumable(),
-            (ItemType::Weapon, Some(name)) => {
-                match is_shield {
-                    false => Self::new_weapon(name),
-                    true => Self::new_shield(name)
-                }
-            }
-            (ItemType::Weapon, None) => {
-                match is_shield {
-                    false => Self::new_random_weapon(),
-                    true => Self::new_random_shield()
-                }
-            }
+            (ItemType::Weapon, Some(name)) => match is_shield {
+                false => Self::new_weapon(name),
+                true => Self::new_shield(name),
+            },
+            (ItemType::Weapon, None) => match is_shield {
+                false => Self::new_random_weapon(),
+                true => Self::new_random_shield(),
+            },
         }
     }
 
@@ -121,13 +117,7 @@ impl Item {
         let attribute = Attribute::random();
         let effect = rng.random_range(1..=10);
 
-        Item::new(
-            name,
-            ItemType::Consumable,
-            quantity,
-            attribute,
-            effect,
-        )
+        Item::new(name, ItemType::Consumable, quantity, attribute, effect)
     }
 
     pub fn new_random_consumable() -> Item {
@@ -137,13 +127,7 @@ impl Item {
         let quantity = 1;
         let effect = rng.random_range(1..=10);
 
-        Item::new(
-            &name,
-            ItemType::Consumable,
-            quantity,
-            attribute,
-            effect,
-        )
+        Item::new(&name, ItemType::Consumable, quantity, attribute, effect)
     }
 
     pub fn new_shield(name: &str) -> Item {
@@ -238,19 +222,19 @@ impl ConsumableAttribute for Attribute {
     fn consumable_name(&self) -> String {
         match &self {
             // restore health
-            Attribute::Health => { "health kit".to_string() }
+            Attribute::Health => "health kit".to_string(),
             // restore sanity
-            Attribute::Sanity => { "memento".to_string() }
+            Attribute::Sanity => "memento".to_string(),
             // move further
-            Attribute::Movement => { "trail mix".to_string() }
+            Attribute::Movement => "trail mix".to_string(),
             // sure, you can win that fight
-            Attribute::Bravery => { "yayo".to_string() }
+            Attribute::Bravery => "yayo".to_string(),
             // move faster
-            Attribute::Speed => { "go-juice".to_string() }
+            Attribute::Speed => "go-juice".to_string(),
             // hit harder
-            Attribute::Strength => { "adrenaline".to_string() }
+            Attribute::Strength => "adrenaline".to_string(),
             // take hits better
-            Attribute::Defense => { "bear spray".to_string() }
+            Attribute::Defense => "bear spray".to_string(),
         }
     }
 }
@@ -305,13 +289,7 @@ mod tests {
 
     #[test]
     fn new_item() {
-        let item = Item::new(
-            "Test item",
-            ItemType::Weapon,
-            1,
-            Attribute::Defense,
-            10,
-        );
+        let item = Item::new("Test item", ItemType::Weapon, 1, Attribute::Defense, 10);
         assert_eq!(item.name, "Test item");
         assert_eq!(item.item_type, ItemType::Weapon);
         assert_eq!(item.quantity, 1);
@@ -408,7 +386,11 @@ mod tests {
     #[test]
     fn random_attribute() {
         let attribute = Attribute::random();
-        assert!(Attribute::iter().find(|a| *a == attribute.clone()).is_some());
+        assert!(
+            Attribute::iter()
+                .find(|a| *a == attribute.clone())
+                .is_some()
+        );
     }
 
     #[rstest]

--- a/game/src/items/name_generator.rs
+++ b/game/src/items/name_generator.rs
@@ -9,7 +9,7 @@ const SHIELD_ADJECTIVES: &[&str] = &[
 // Weapon nouns
 // <descriptor> _____
 const WEAPON_NOUNS: &[&str] = &[
-    "sword", "spear", "dagger", "knife", "net", "trident", "bow", "mace", "axe"
+    "sword", "spear", "dagger", "knife", "net", "trident", "bow", "mace", "axe",
 ];
 
 // Adjectives to come before a weapon noun

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -2,7 +2,7 @@ pub mod areas;
 pub mod games;
 pub mod items;
 pub mod messages;
+pub mod output;
 pub mod threats;
 pub mod tributes;
-pub mod output;
 mod witty_phrase_generator;

--- a/game/src/messages.rs
+++ b/game/src/messages.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(tag="type", content="value")]
+#[serde(tag = "type", content = "value")]
 pub enum MessageSource {
     #[serde(rename = "Game")]
     Game(String), // Game identifier
@@ -110,10 +110,6 @@ pub fn get_messages_by_day(day: u32) -> Result<Vec<GameMessage>, String> {
 }
 
 pub fn clear_messages() -> Result<(), String> {
-    GLOBAL_MESSAGES
-        .lock()
-        .map_err(|e| e.to_string())?
-        .clear();
+    GLOBAL_MESSAGES.lock().map_err(|e| e.to_string())?.clear();
     Ok(())
 }
-

--- a/game/src/output.rs
+++ b/game/src/output.rs
@@ -78,7 +78,7 @@ pub enum GameOutput<'a> {
     AllAlone(&'a str),
 }
 
-impl <'a> Display for GameOutput<'a> {
+impl<'a> Display for GameOutput<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self {
             GameOutput::GameDayStart(day_number) => {
@@ -118,7 +118,11 @@ impl <'a> Display for GameOutput<'a> {
                 write!(f, "😪 {} rests", tribute)
             }
             GameOutput::TributeLongRest(tribute) => {
-                write!(f, "💤 {} rests and recovers a little health and sanity", tribute)
+                write!(
+                    f,
+                    "💤 {} rests and recovers a little health and sanity",
+                    tribute
+                )
             }
             GameOutput::TributeHide(tribute) => {
                 write!(f, "🫥 {} tries to hide", tribute)
@@ -136,10 +140,18 @@ impl <'a> Display for GameOutput<'a> {
             }
             GameOutput::TributeUseItem(tribute, item) => {
                 let object = indefinite(&item.name);
-                write!(f, "💊 {} uses {}, gains {} {}", tribute, object, item.effect, item.attribute)
+                write!(
+                    f,
+                    "💊 {} uses {}, gains {} {}",
+                    tribute, object, item.effect, item.attribute
+                )
             }
             GameOutput::TributeTravelTooTired(tribute, area) => {
-                write!(f, "😴 {} is too tired to move from {}, rests instead", tribute, area)
+                write!(
+                    f,
+                    "😴 {} is too tired to move from {}, rests instead",
+                    tribute, area
+                )
             }
             GameOutput::TributeTravelAlreadyThere(tribute, area) => {
                 write!(f, "🤔 {} is already in the {}, stays put", tribute, area)
@@ -157,7 +169,11 @@ impl <'a> Display for GameOutput<'a> {
                 write!(f, "🩸 {} bleeds from their wounds.", tribute)
             }
             GameOutput::TributeSick(tribute) => {
-                write!(f, "🤒 {} contracts dysentery, loses strength and speed", tribute)
+                write!(
+                    f,
+                    "🤒 {} contracts dysentery, loses strength and speed",
+                    tribute
+                )
             }
             GameOutput::TributeElectrocuted(tribute) => {
                 write!(f, "🌩️ {} is struck by lightning, loses health", tribute)
@@ -184,20 +200,39 @@ impl <'a> Display for GameOutput<'a> {
                 write!(f, "🦴 {} injures their leg, loses speed.", tribute)
             }
             GameOutput::TributeInfected(tribute) => {
-                write!(f, "🤢 {} gets an infection, loses health and sanity", tribute)
+                write!(
+                    f,
+                    "🤢 {} gets an infection, loses health and sanity",
+                    tribute
+                )
             }
             GameOutput::TributeDrowned(tribute) => {
-                write!(f, "🏊 {} partially drowns, loses health and sanity", tribute)
+                write!(
+                    f,
+                    "🏊 {} partially drowns, loses health and sanity",
+                    tribute
+                )
             }
             GameOutput::TributeMauled(tribute, count, animal, damage) => {
                 let animal = Animal::from_str(animal).unwrap();
-                write!(f, "🐾 {} is attacked by {} {}, takes {} damage!", tribute, count, animal.plural(), damage)
+                write!(
+                    f,
+                    "🐾 {} is attacked by {} {}, takes {} damage!",
+                    tribute,
+                    count,
+                    animal.plural(),
+                    damage
+                )
             }
             GameOutput::TributeBurned(tribute) => {
                 write!(f, "🔥 {} gets burned, loses health", tribute)
             }
             GameOutput::TributeHorrified(tribute, damage) => {
-                write!(f, "😱 {} is horrified by the violence, loses {} sanity.", tribute, damage)
+                write!(
+                    f,
+                    "😱 {} is horrified by the violence, loses {} sanity.",
+                    tribute, damage
+                )
             }
             GameOutput::TributeSuffer(tribute) => {
                 write!(f, "😭 {} suffers from loneliness and terror.", tribute)
@@ -221,7 +256,11 @@ impl <'a> Display for GameOutput<'a> {
                 write!(f, "🤣 {} attacks {}, but loses!", tribute, target)
             }
             GameOutput::TributeAttackLoseExtra(tribute, target) => {
-                write!(f, "🤣 {} attacks {}, but loses decisively!", tribute, target)
+                write!(
+                    f,
+                    "🤣 {} attacks {}, but loses decisively!",
+                    tribute, target
+                )
             }
             GameOutput::TributeAttackMiss(tribute, target) => {
                 write!(f, "😰 {} attacks {}, but misses!", tribute, target)
@@ -258,7 +297,11 @@ impl <'a> Display for GameOutput<'a> {
             }
             GameOutput::SponsorGift(tribute, item) => {
                 let object = indefinite(&item.name);
-                write!(f, "🎁 {} receives {} ({}x {} +{})", tribute, object, item.quantity, item.attribute, item.effect)
+                write!(
+                    f,
+                    "🎁 {} receives {} ({}x {} +{})",
+                    tribute, object, item.quantity, item.attribute, item.effect
+                )
             }
             GameOutput::AreaEvent(area_event, area) => {
                 let area_name = area.replace("The ", "");

--- a/game/src/tributes/actions.rs
+++ b/game/src/tributes/actions.rs
@@ -113,9 +113,12 @@ mod tests {
 
     #[test]
     fn tribute_action_new() {
-        assert_eq!(TributeAction::new(Action::None, None), TributeAction {
-            action: Action::None,
-            target: None
-        });
+        assert_eq!(
+            TributeAction::new(Action::None, None),
+            TributeAction {
+                action: Action::None,
+                target: None
+            }
+        );
     }
 }

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -1,5 +1,5 @@
-use crate::tributes::actions::Action;
 use crate::tributes::Tribute;
+use crate::tributes::actions::Action;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -96,19 +96,19 @@ impl Brain {
         let stats = (
             tribute.attributes.movement,
             tribute.attributes.sanity,
-            tribute.attributes.is_hidden
+            tribute.attributes.is_hidden,
         );
         match stats {
             // low movement, ok sanity, visible
-            (..LOW_MOVEMENT_LIMIT, MID_SANITY_LIMIT.., false) => { Action::Hide },
+            (..LOW_MOVEMENT_LIMIT, MID_SANITY_LIMIT.., false) => Action::Hide,
             // low movement, low sanity, any visibility
-            (..LOW_MOVEMENT_LIMIT, EXTREME_LOW_SANITY_LIMIT..MID_SANITY_LIMIT, _) => { Action::Attack },
+            (..LOW_MOVEMENT_LIMIT, EXTREME_LOW_SANITY_LIMIT..MID_SANITY_LIMIT, _) => Action::Attack,
             // any movement, ok sanity, visible
-            (_, MID_SANITY_LIMIT.., false) => { Action::Move(None) },
+            (_, MID_SANITY_LIMIT.., false) => Action::Move(None),
             // any movement, low sanity, visible
-            (_, ..MID_SANITY_LIMIT, false) => { Action::Attack },
+            (_, ..MID_SANITY_LIMIT, false) => Action::Attack,
             // any movement, any sanity, hidden
-            (_, _, true) => { Action::None },
+            (_, _, true) => Action::None,
         }
     }
 
@@ -127,7 +127,8 @@ impl Brain {
     }
 
     fn decide_action_many_enemies(&self, tribute: &Tribute) -> Action {
-        let recklessness: u32 = 100_u32.saturating_sub(tribute.attributes.intelligence)
+        let recklessness: u32 = 100_u32
+            .saturating_sub(tribute.attributes.intelligence)
             .saturating_sub(tribute.attributes.sanity);
         match recklessness {
             // Smart enough to know better, moves
@@ -143,8 +144,8 @@ impl Brain {
 #[cfg(test)]
 mod tests {
     use crate::items::Item;
-    use crate::tributes::actions::Action;
     use crate::tributes::Tribute;
+    use crate::tributes::actions::Action;
     use rand::prelude::*;
     use rstest::{fixture, rstest};
 
@@ -190,7 +191,10 @@ mod tests {
     }
 
     #[rstest]
-    fn decide_on_action_no_movement_surrounded_low_health(mut tribute: Tribute, mut small_rng: SmallRng) {
+    fn decide_on_action_no_movement_surrounded_low_health(
+        mut tribute: Tribute,
+        mut small_rng: SmallRng,
+    ) {
         // If the tribute has no movement and is not alone, they should hide
         tribute.attributes.movement = 1;
         tribute.attributes.health = 10;
@@ -263,7 +267,10 @@ mod tests {
     }
 
     #[rstest]
-    fn decide_on_action_surrounded_low_health_low_movement_low_sanity(mut tribute: Tribute, mut small_rng: SmallRng) {
+    fn decide_on_action_surrounded_low_health_low_movement_low_sanity(
+        mut tribute: Tribute,
+        mut small_rng: SmallRng,
+    ) {
         tribute.attributes.health = 10;
         tribute.attributes.movement = 0;
         tribute.attributes.sanity = 15;
@@ -272,7 +279,10 @@ mod tests {
     }
 
     #[rstest]
-    fn decide_on_action_surrounded_low_health_low_sanity(mut tribute: Tribute, mut small_rng: SmallRng) {
+    fn decide_on_action_surrounded_low_health_low_sanity(
+        mut tribute: Tribute,
+        mut small_rng: SmallRng,
+    ) {
         tribute.attributes.health = 15;
         tribute.attributes.sanity = 10;
         let action = tribute.brain.act(&tribute.clone(), 3, &mut small_rng);
@@ -280,7 +290,10 @@ mod tests {
     }
 
     #[rstest]
-    fn decide_on_action_surrounded_hidden_low_health(mut tribute: Tribute, mut small_rng: SmallRng) {
+    fn decide_on_action_surrounded_hidden_low_health(
+        mut tribute: Tribute,
+        mut small_rng: SmallRng,
+    ) {
         tribute.attributes.is_hidden = true;
         tribute.attributes.health = 10;
         let action = tribute.brain.act(&tribute.clone(), 3, &mut small_rng);
@@ -288,7 +301,10 @@ mod tests {
     }
 
     #[rstest]
-    fn decide_on_action_surrounded_ok_health_low_sanity(mut tribute: Tribute, mut small_rng: SmallRng) {
+    fn decide_on_action_surrounded_ok_health_low_sanity(
+        mut tribute: Tribute,
+        mut small_rng: SmallRng,
+    ) {
         tribute.attributes.health = 25;
         tribute.attributes.sanity = 15;
         let action = tribute.brain.act(&tribute.clone(), 3, &mut small_rng);
@@ -296,7 +312,10 @@ mod tests {
     }
 
     #[rstest]
-    fn decide_on_action_heavily_surrounded_normal_sanity_and_intelligence(mut tribute: Tribute, mut small_rng: SmallRng) {
+    fn decide_on_action_heavily_surrounded_normal_sanity_and_intelligence(
+        mut tribute: Tribute,
+        mut small_rng: SmallRng,
+    ) {
         tribute.attributes.intelligence = 50;
         tribute.attributes.sanity = 50;
         let action = tribute.brain.act(&tribute.clone(), 6, &mut small_rng);
@@ -304,7 +323,10 @@ mod tests {
     }
 
     #[rstest]
-    fn decide_on_action_heavily_surrounded_low_sanity_and_intelligence(mut tribute: Tribute, mut small_rng: SmallRng) {
+    fn decide_on_action_heavily_surrounded_low_sanity_and_intelligence(
+        mut tribute: Tribute,
+        mut small_rng: SmallRng,
+    ) {
         tribute.attributes.intelligence = 20;
         tribute.attributes.sanity = 20;
         let action = tribute.brain.act(&tribute.clone(), 6, &mut small_rng);
@@ -312,7 +334,10 @@ mod tests {
     }
 
     #[rstest]
-    fn decide_on_action_heavily_surrounded_no_sanity_and_intelligence(mut tribute: Tribute, mut small_rng: SmallRng) {
+    fn decide_on_action_heavily_surrounded_no_sanity_and_intelligence(
+        mut tribute: Tribute,
+        mut small_rng: SmallRng,
+    ) {
         tribute.attributes.intelligence = 10;
         tribute.attributes.sanity = 10;
         let action = tribute.brain.act(&tribute.clone(), 6, &mut small_rng);

--- a/game/src/tributes/events.rs
+++ b/game/src/tributes/events.rs
@@ -1,9 +1,9 @@
 use crate::threats::animals::Animal;
+use rand::prelude::SmallRng;
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::FromStr;
-use rand::prelude::SmallRng;
 
 #[derive(Clone, Debug, PartialOrd, PartialEq, Serialize, Deserialize)]
 pub enum TributeEvent {
@@ -29,8 +29,12 @@ impl FromStr for TributeEvent {
             return if let Some(animal_name) = s.split_once(':').map(|x| x.1) {
                 if let Ok(animal) = Animal::from_str(animal_name.trim()) {
                     Ok(TributeEvent::AnimalAttack(animal))
-                } else { Err(()) }
-            } else { Err(()) }
+                } else {
+                    Err(())
+                }
+            } else {
+                Err(())
+            };
         }
 
         match s {

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -12,9 +12,9 @@ use crate::output::GameOutput;
 use crate::tributes::events::TributeEvent;
 use actions::{Action, AttackOutcome, AttackResult};
 use brains::Brain;
+use fake::Fake;
 use fake::faker::name::raw::*;
 use fake::locales::*;
-use fake::Fake;
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use statuses::TributeStatus;
@@ -131,14 +131,18 @@ impl Default for Tribute {
 }
 
 impl OwnsItems for Tribute {
-    fn add_item(&mut self, item: Item) { self.items.push(item); }
+    fn add_item(&mut self, item: Item) {
+        self.items.push(item);
+    }
 
     fn has_item(&self, item: &Item) -> bool {
         self.items.iter().any(|i| i == item)
     }
 
     fn use_item(&mut self, item: &Item) -> Result<(), ItemError> {
-        let index = self.items.iter()
+        let index = self
+            .items
+            .iter()
             .position(|i| i.identifier == item.identifier)
             .ok_or(ItemError::ItemNotFound)?;
 
@@ -161,7 +165,10 @@ impl OwnsItems for Tribute {
     }
 
     fn remove_item(&mut self, item: &Item) -> Result<(), ItemError> {
-        let index = self.items.iter().position(|i| i.identifier == item.identifier);
+        let index = self
+            .items
+            .iter()
+            .position(|i| i.identifier == item.identifier);
         if let Some(index) = index {
             self.items.remove(index);
             Ok(())
@@ -209,12 +216,7 @@ impl Tribute {
         if self.avatar.is_none() {
             return "https://fallback.pics/api/v1/400x400".to_string();
         }
-        format!(
-            "assets/{}",
-            self.avatar
-                .clone()
-                .unwrap()
-        )
+        format!("assets/{}", self.avatar.clone().unwrap())
     }
 
     /// Reduces health.
@@ -234,7 +236,11 @@ impl Tribute {
 
     /// Increases attack strength.
     fn increase_strength(&mut self, amount: u32) {
-        self.attributes.strength = self.attributes.strength.saturating_add(amount).min(MAX_STRENGTH);
+        self.attributes.strength = self
+            .attributes
+            .strength
+            .saturating_add(amount)
+            .min(MAX_STRENGTH);
     }
 
     /// Reduces movement speed.
@@ -254,13 +260,21 @@ impl Tribute {
 
     /// Increases bravery which affects decision-making.
     fn increase_bravery(&mut self, amount: u32) {
-        self.attributes.bravery = self.attributes.bravery.saturating_add(amount).min(MAX_BRAVERY);
+        self.attributes.bravery = self
+            .attributes
+            .bravery
+            .saturating_add(amount)
+            .min(MAX_BRAVERY);
     }
 
     /// Increases movement which allows more travel
     // TODO: Use movement more effectively.
     fn increase_movement(&mut self, amount: u32) {
-        self.attributes.movement = self.attributes.movement.saturating_add(amount).min(MAX_MOVEMENT);
+        self.attributes.movement = self
+            .attributes
+            .movement
+            .saturating_add(amount)
+            .min(MAX_MOVEMENT);
     }
 
     /// Reduces dexterity which currently affects nothing.
@@ -272,17 +286,27 @@ impl Tribute {
     /// Restores health.
     fn heals(&mut self, health: u32) {
         if self.is_alive() {
-            self.attributes.health = self.attributes.health.saturating_add(health).min(MAX_HEALTH);
+            self.attributes.health = self
+                .attributes
+                .health
+                .saturating_add(health)
+                .min(MAX_HEALTH);
         }
     }
 
     /// Restores mental health.
     fn heals_mental_damage(&mut self, sanity: u32) {
-        self.attributes.sanity = self.attributes.sanity.saturating_add(sanity).min(MAX_SANITY);
+        self.attributes.sanity = self
+            .attributes
+            .sanity
+            .saturating_add(sanity)
+            .min(MAX_SANITY);
     }
 
     /// Restores movement.
-    fn short_rests(&mut self) { self.attributes.movement = MAX_MOVEMENT; }
+    fn short_rests(&mut self) {
+        self.attributes.movement = MAX_MOVEMENT;
+    }
 
     /// Restores movement, some health, and some sanity
     fn long_rests(&mut self) {
@@ -336,10 +360,7 @@ impl Tribute {
     fn attacks(&mut self, target: &mut Tribute, rng: &mut impl Rng) -> AttackOutcome {
         // Is the tribute attempting suicide?
         if self == target {
-            self.try_log_action(
-                GameOutput::TributeSelfHarm(self.name.as_str()),
-                "self-harm"
-            );
+            self.try_log_action(GameOutput::TributeSelfHarm(self.name.as_str()), "self-harm");
 
             // Attack always succeeds
             self.takes_physical_damage(self.attributes.strength);
@@ -347,22 +368,22 @@ impl Tribute {
 
             self.try_log_action(
                 GameOutput::TributeAttackWin(self.name.as_str(), target.name.as_str()),
-                "attack against self"
+                "attack against self",
             );
 
             return if self.attributes.health > 0 {
                 self.try_log_action(
                     GameOutput::TributeAttackWound(self.name.as_str(), target.name.as_str()),
-                    "wounded self"
+                    "wounded self",
                 );
                 AttackOutcome::Wound(self.clone(), target.clone())
             } else {
                 self.try_log_action(
                     GameOutput::TributeSuicide(self.name.as_str()),
-                    "successful suicide"
+                    "successful suicide",
                 );
                 AttackOutcome::Kill(self.clone(), target.clone())
-            }
+            };
         }
 
         let tribute_name = self.name.clone();
@@ -375,7 +396,7 @@ impl Tribute {
                     target,
                     self.attributes.strength,
                     GameOutput::TributeAttackWin(tribute_name.as_str(), target_name.as_str()),
-                    "attack win"
+                    "attack win",
                 );
             }
             AttackResult::AttackerWinsDecisively => {
@@ -384,7 +405,7 @@ impl Tribute {
                     target,
                     self.attributes.strength * 2, // double damage
                     GameOutput::TributeAttackWinExtra(tribute_name.as_str(), target_name.as_str()),
-                    "attack win extra"
+                    "attack win extra",
                 );
             }
             AttackResult::DefenderWins => {
@@ -393,7 +414,7 @@ impl Tribute {
                     self,
                     target.attributes.strength,
                     GameOutput::TributeAttackLose(tribute_name.as_str(), target_name.as_str()),
-                    "attack lose"
+                    "attack lose",
                 );
             }
             AttackResult::DefenderWinsDecisively => {
@@ -402,7 +423,7 @@ impl Tribute {
                     self,
                     target.attributes.strength * 2, // double damage
                     GameOutput::TributeAttackLoseExtra(tribute_name.as_str(), target_name.as_str()),
-                    "attack lose extra"
+                    "attack lose extra",
                 );
             }
             AttackResult::Miss => {
@@ -411,7 +432,7 @@ impl Tribute {
 
                 self.try_log_action(
                     GameOutput::TributeAttackMiss(tribute_name.as_str(), target_name.as_str()),
-                    "missed attack"
+                    "missed attack",
                 );
 
                 return AttackOutcome::Miss(self.clone(), target.clone());
@@ -425,7 +446,7 @@ impl Tribute {
 
             self.try_log_action(
                 GameOutput::TributeAttackDied(tribute_name.as_str(), target_name.as_str()),
-                "attacker died"
+                "attacker died",
             );
 
             AttackOutcome::Kill(target.clone(), self.clone())
@@ -436,14 +457,14 @@ impl Tribute {
 
             self.try_log_action(
                 GameOutput::TributeAttackSuccessKill(tribute_name.as_str(), target_name.as_str()),
-                "killed target"
+                "killed target",
             );
 
             AttackOutcome::Kill(self.clone(), target.clone())
         } else {
             self.try_log_action(
                 GameOutput::TributeAttackWound(tribute_name.as_str(), target_name.as_str()),
-                "wounded target"
+                "wounded target",
             );
             AttackOutcome::Wound(self.clone(), target.clone())
         }
@@ -464,7 +485,7 @@ impl Tribute {
             let current_area = self.area.to_string();
             self.try_log_action(
                 GameOutput::TributeTravelTooTired(self.name.as_str(), current_area.as_str()),
-                "too tired"
+                "too tired",
             );
             return TravelResult::Failure;
         }
@@ -476,8 +497,11 @@ impl Tribute {
                 if suggestion == current_area {
                     let suggestion = suggestion.to_string();
                     self.try_log_action(
-                        GameOutput::TributeTravelAlreadyThere(self.name.as_str(), suggestion.as_str()),
-                        "already there"
+                        GameOutput::TributeTravelAlreadyThere(
+                            self.name.as_str(),
+                            suggestion.as_str(),
+                        ),
+                        "already there",
                     );
                     return TravelResult::Failure;
                 }
@@ -493,15 +517,22 @@ impl Tribute {
                     let current_area = current_area.to_string();
                     let new_area_name = new_area.to_string();
                     self.try_log_action(
-                        GameOutput::TributeTravel(self.name.as_str(), current_area.as_str(), new_area_name.as_str()),
-                        "travel"
+                        GameOutput::TributeTravel(
+                            self.name.as_str(),
+                            current_area.as_str(),
+                            new_area_name.as_str(),
+                        ),
+                        "travel",
                     );
                     TravelResult::Success(new_area)
                 } else {
                     let current_area = current_area.to_string();
                     self.try_log_action(
-                        GameOutput::TributeTravelTooTired(self.name.as_str(), current_area.as_str()),
-                        "too tired"
+                        GameOutput::TributeTravelTooTired(
+                            self.name.as_str(),
+                            current_area.as_str(),
+                        ),
+                        "too tired",
                     );
                     TravelResult::Failure
                 }
@@ -512,10 +543,14 @@ impl Tribute {
                     let current_area = current_area.to_string();
                     let new_area_name = new_area.to_string();
                     self.try_log_action(
-                        GameOutput::TributeTravel(self.name.as_str(), current_area.as_str(), new_area_name.as_str()),
-                        "travel"
+                        GameOutput::TributeTravel(
+                            self.name.as_str(),
+                            current_area.as_str(),
+                            new_area_name.as_str(),
+                        ),
+                        "travel",
                     );
-                    return TravelResult::Success(new_area)
+                    return TravelResult::Success(new_area);
                 }
 
                 let neighbors = current_area.neighbors();
@@ -527,10 +562,13 @@ impl Tribute {
                 if available_neighbors.is_empty() {
                     let current_area_name = current_area.to_string();
                     self.try_log_action(
-                        GameOutput::TributeTravelNoOptions(self.name.as_str(), current_area_name.as_str()),
-                        "no options"
+                        GameOutput::TributeTravelNoOptions(
+                            self.name.as_str(),
+                            current_area_name.as_str(),
+                        ),
+                        "no options",
                     );
-                    return TravelResult::Success(current_area.clone())
+                    return TravelResult::Success(current_area.clone());
                 }
 
                 // TODO: Loyalty bit goes here
@@ -539,8 +577,12 @@ impl Tribute {
                 let current_area_name = current_area.to_string();
                 let chosen_area_name = chosen_neighbor.to_string();
                 self.try_log_action(
-                    GameOutput::TributeTravel(self.name.as_str(), current_area_name.as_str(), chosen_area_name.as_str()),
-                    "travel"
+                    GameOutput::TributeTravel(
+                        self.name.as_str(),
+                        current_area_name.as_str(),
+                        chosen_area_name.as_str(),
+                    ),
+                    "travel",
                 );
                 TravelResult::Success(chosen_neighbor.clone())
             }
@@ -555,17 +597,31 @@ impl Tribute {
 
         match &self.status {
             // TODO: Add more variation to effects.
-            TributeStatus::Wounded => { self.takes_physical_damage(WOUNDED_DAMAGE); }
+            TributeStatus::Wounded => {
+                self.takes_physical_damage(WOUNDED_DAMAGE);
+            }
             TributeStatus::Sick => {
                 self.reduce_strength(SICK_STRENGTH_REDUCTION);
                 self.reduce_speed(SICK_SPEED_REDUCTION);
             }
-            TributeStatus::Electrocuted => { self.takes_physical_damage(ELECTROCUTED_DAMAGE); }
-            TributeStatus::Frozen => { self.reduce_speed(FROZEN_SPEED_REDUCTION); }
-            TributeStatus::Overheated => { self.reduce_speed(OVERHEATED_SPEED_REDUCTION); }
-            TributeStatus::Dehydrated => { self.reduce_strength(DEHYDRATED_STRENGTH_REDUCTION); }
-            TributeStatus::Starving => { self.reduce_strength(STARVING_STRENGTH_REDUCTION); }
-            TributeStatus::Poisoned => { self.takes_mental_damage(POISONED_MENTAL_DAMAGE); }
+            TributeStatus::Electrocuted => {
+                self.takes_physical_damage(ELECTROCUTED_DAMAGE);
+            }
+            TributeStatus::Frozen => {
+                self.reduce_speed(FROZEN_SPEED_REDUCTION);
+            }
+            TributeStatus::Overheated => {
+                self.reduce_speed(OVERHEATED_SPEED_REDUCTION);
+            }
+            TributeStatus::Dehydrated => {
+                self.reduce_strength(DEHYDRATED_STRENGTH_REDUCTION);
+            }
+            TributeStatus::Starving => {
+                self.reduce_strength(STARVING_STRENGTH_REDUCTION);
+            }
+            TributeStatus::Poisoned => {
+                self.takes_mental_damage(POISONED_MENTAL_DAMAGE);
+            }
             TributeStatus::Broken => {
                 // die roll for which bone breaks
                 let bone = rng.random_range(0..4);
@@ -608,7 +664,7 @@ impl Tribute {
             let killer = self.status.clone();
             self.try_log_action(
                 GameOutput::TributeDiesFromStatus(self.name.as_str(), &*killer.to_string()),
-                "dies from status"
+                "dies from status",
             );
             self.statistics.killed_by = Some(killer.to_string());
             self.status = TributeStatus::RecentlyDead;
@@ -660,8 +716,15 @@ impl Tribute {
             add_tribute_message(
                 self.identifier.as_str(),
                 self.statistics.game.as_str(),
-                format!("{}", GameOutput::TributeDiesFromTributeEvent(self.name.as_str(), &*tribute_event.to_string())),
-            ).expect("");
+                format!(
+                    "{}",
+                    GameOutput::TributeDiesFromTributeEvent(
+                        self.name.as_str(),
+                        &*tribute_event.to_string()
+                    )
+                ),
+            )
+            .expect("");
 
             self.statistics.killed_by = Some(self.status.to_string());
             self.status = TributeStatus::RecentlyDead;
@@ -689,7 +752,7 @@ impl Tribute {
         if !self.is_alive() {
             self.try_log_action(
                 GameOutput::TributeAlreadyDead(self.name.as_str()),
-                "already dead"
+                "already dead",
             );
             return;
         }
@@ -703,7 +766,7 @@ impl Tribute {
         if self.status == TributeStatus::RecentlyDead || self.attributes.health == 0 {
             self.try_log_action(
                 GameOutput::TributeDead(self.name.as_str()),
-                "died to events"
+                "died to events",
             );
             return;
         }
@@ -712,20 +775,22 @@ impl Tribute {
         if let Some(gift) = self.receive_patron_gift(&mut *rng) {
             self.try_log_action(
                 GameOutput::SponsorGift(self.name.as_str(), &gift),
-                "received gift"
+                "received gift",
             );
             self.add_item(gift);
         }
 
         // Nighttime terror
         let is_day = environment_details.is_day;
-        if !is_day && self.is_alive() { self.misses_home(); }
+        if !is_day && self.is_alive() {
+            self.misses_home();
+        }
 
         // Set a preferred action if one is suggested
         if let Some(suggestion) = action_suggestion {
             self.brain.set_preferred_action(
                 suggestion.action,
-                suggestion.probability.unwrap_or(1.0) // If no probability is set, perform the preferred action.
+                suggestion.probability.unwrap_or(1.0), // If no probability is set, perform the preferred action.
             );
         }
 
@@ -750,19 +815,16 @@ impl Tribute {
                         self.short_rests();
                     }
                 }
-            },
+            }
             Action::Hide => {
                 self.hides();
-                self.try_log_action(
-                    GameOutput::TributeHide(self.name.as_str()),
-                    "hides"
-                );
+                self.try_log_action(GameOutput::TributeHide(self.name.as_str()), "hides");
             }
             Action::Rest | Action::None => {
                 self.long_rests();
                 self.try_log_action(
                     GameOutput::TributeLongRest(self.name.as_str()),
-                    "long rests"
+                    "long rests",
                 );
             }
             // Try to attack another tribute
@@ -779,7 +841,7 @@ impl Tribute {
                 if let Some(item) = self.take_nearby_item(area_details) {
                     self.try_log_action(
                         GameOutput::TributeTakeItem(self.name.as_str(), item.name.as_str()),
-                        "took item"
+                        "took item",
                     );
                 }
             }
@@ -793,13 +855,16 @@ impl Tribute {
                             Ok(()) => {
                                 self.try_log_action(
                                     GameOutput::TributeUseItem(self.name.as_str(), item),
-                                    "used specific item"
+                                    "used specific item",
                                 );
                             }
                             Err(_) => {
                                 self.try_log_action(
-                                    GameOutput::TributeCannotUseItem(self.name.as_str(), item.name.as_str()),
-                                    "cannot use specific item"
+                                    GameOutput::TributeCannotUseItem(
+                                        self.name.as_str(),
+                                        item.name.as_str(),
+                                    ),
+                                    "cannot use specific item",
                                 );
                                 self.short_rests();
                             }
@@ -812,13 +877,16 @@ impl Tribute {
                                 Ok(()) => {
                                     self.try_log_action(
                                         GameOutput::TributeUseItem(self.name.as_str(), item),
-                                        "used random item"
+                                        "used random item",
                                     );
                                 }
                                 Err(_) => {
                                     self.try_log_action(
-                                        GameOutput::TributeCannotUseItem(self.name.as_str(), item.name.as_str()),
-                                        "cannot use random item"
+                                        GameOutput::TributeCannotUseItem(
+                                            self.name.as_str(),
+                                            item.name.as_str(),
+                                        ),
+                                        "cannot use random item",
                                     );
                                     self.short_rests();
                                 }
@@ -847,7 +915,11 @@ impl Tribute {
             _ => 1.0, // Mainly for testing/debugging purposes
         };
 
-        if rng.random_bool(chance) { Some(Item::new_random_consumable()) } else { None }
+        if rng.random_bool(chance) {
+            Some(Item::new_random_consumable())
+        } else {
+            None
+        }
     }
 
     /// Take an item from the current area
@@ -873,7 +945,10 @@ impl Tribute {
         let item: Item;
 
         // If the tribute has the item...
-        match items.iter().find(|i| i.identifier == chosen_item.identifier) {
+        match items
+            .iter()
+            .find(|i| i.identifier == chosen_item.identifier)
+        {
             Some(selected_item) => {
                 // select it
                 item = selected_item.clone();
@@ -946,16 +1021,17 @@ impl Tribute {
     /// 4. If there are no enemies nearby and no enemies left in the game:
     /// 4a. If loyalty is low, target ally.
     /// 4b. Otherwise, target no one.
-    fn pick_target(&self, mut targets: Vec<Tribute>, living_tributes_count: u32) -> Option<Tribute> {
+    fn pick_target(
+        &self,
+        mut targets: Vec<Tribute>,
+        living_tributes_count: u32,
+    ) -> Option<Tribute> {
         // If there are no targets, check if the tribute is feeling suicidal.
         if targets.is_empty() {
             match self.attributes.sanity {
                 0..=SANITY_BREAK_LEVEL => {
                     // attempt suicide
-                    self.try_log_action(
-                        GameOutput::TributeSuicide(self.name.as_str()),
-                        "suicide"
-                    );
+                    self.try_log_action(GameOutput::TributeSuicide(self.name.as_str()), "suicide");
                     Some(self.clone())
                 }
                 _ => None, // Attack no one
@@ -968,7 +1044,8 @@ impl Tribute {
                 .collect();
 
             match enemies.len() {
-                0 => { // No enemies, check for a "friend"
+                0 => {
+                    // No enemies, check for a "friend"
                     // If there are two of us in the area
                     if targets.len() == 1 {
                         let target = targets.pop().unwrap();
@@ -976,8 +1053,11 @@ impl Tribute {
                         if living_tributes_count == 2 {
                             // Kill the other tribute
                             self.try_log_action(
-                                GameOutput::TributeBetrayal(self.name.as_str(), target.name.as_str()),
-                                "betrayal"
+                                GameOutput::TributeBetrayal(
+                                    self.name.as_str(),
+                                    target.name.as_str(),
+                                ),
+                                "betrayal",
                             );
                             Some(target.clone())
                         } else {
@@ -986,15 +1066,18 @@ impl Tribute {
                             if loyalty < LOYALTY_BREAK_LEVEL {
                                 // Kill the other tribute
                                 self.try_log_action(
-                                    GameOutput::TributeForcedBetrayal(self.name.as_str(), target.name.as_str()),
-                                    "forced betrayal"
+                                    GameOutput::TributeForcedBetrayal(
+                                        self.name.as_str(),
+                                        target.name.as_str(),
+                                    ),
+                                    "forced betrayal",
                                 );
                                 Some(target.clone())
                             } else {
                                 // Otherwise, don't attack
                                 self.try_log_action(
                                     GameOutput::NoOneToAttack(self.name.as_str()),
-                                    "no one to target"
+                                    "no one to target",
                                 );
                                 None
                             }
@@ -1002,11 +1085,11 @@ impl Tribute {
                     } else {
                         self.try_log_action(
                             GameOutput::AllAlone(self.name.as_str()),
-                            "all alone when trying to find a target"
+                            "all alone when trying to find a target",
                         );
                         None
                     }
-                },
+                }
                 1 => Some(enemies.first()?.clone()), // Easy choice
                 _ => {
                     let mut rng = SmallRng::from_rng(&mut rand::rng());
@@ -1017,7 +1100,9 @@ impl Tribute {
         }
     }
 
-    pub fn set_status(&mut self, status: TributeStatus) { self.status = status; }
+    pub fn set_status(&mut self, status: TributeStatus) {
+        self.status = status;
+    }
 
     /// Applies statuses to the tribute based on events in the current area.
     fn apply_area_effects(&mut self, area_details: &AreaDetails) {
@@ -1090,8 +1175,7 @@ fn calculate_violence_stress(kills: u32, wins: u32, current_sanity: u32) -> u32 
 
         // Scale by the tribute's current sanity percentage and apply a final divisor.
         // Lower sanity means less new stress from these types of events.
-        desensitized_stress_per_encounter
-            * (current_sanity as f64 / STRESS_SANITY_NORMALIZATION)
+        desensitized_stress_per_encounter * (current_sanity as f64 / STRESS_SANITY_NORMALIZATION)
             / STRESS_FINAL_DIVISOR
     } else {
         // No wins (and therefore no kills), apply a base stress.
@@ -1113,7 +1197,11 @@ fn calculate_violence_stress(kills: u32, wins: u32, current_sanity: u32) -> u32 
 /// Strength and any weapon are added to the attack roll.
 /// Defense and any shield are added to the defense roll.
 /// If either roll is more than 1.5x the other, that triggers a "decisive" victory.
-fn attack_contest(attacker: &mut Tribute, target: &mut Tribute, rng: &mut impl Rng) -> AttackResult {
+fn attack_contest(
+    attacker: &mut Tribute,
+    target: &mut Tribute,
+    rng: &mut impl Rng,
+) -> AttackResult {
     // Get attack roll and strength modifier
     let mut attack_roll: i32 = rng.random_range(1..=20); // Base roll
     attack_roll += attacker.attributes.strength as i32; // Add strength
@@ -1125,7 +1213,7 @@ fn attack_contest(attacker: &mut Tribute, target: &mut Tribute, rng: &mut impl R
         if weapon.quantity == 0 {
             attacker.try_log_action(
                 GameOutput::WeaponBreak(attacker.name.as_str(), weapon.name.as_str()),
-                "weapon break"
+                "weapon break",
             );
             if let Err(err) = attacker.remove_item(weapon) {
                 eprintln!("Failed to remove weapon: {}", err);
@@ -1144,7 +1232,7 @@ fn attack_contest(attacker: &mut Tribute, target: &mut Tribute, rng: &mut impl R
         if shield.quantity == 0 {
             target.try_log_action(
                 GameOutput::ShieldBreak(target.name.as_str(), shield.name.as_str()),
-                "shield break"
+                "shield break",
             );
             if let Err(err) = target.remove_item(shield) {
                 eprintln!("Failed to remove shield: {}", err);
@@ -1154,7 +1242,8 @@ fn attack_contest(attacker: &mut Tribute, target: &mut Tribute, rng: &mut impl R
 
     // Compare attack vs. defense
     match attack_roll.cmp(&defense_roll) {
-        Ordering::Less => { // If the defender wins
+        Ordering::Less => {
+            // If the defender wins
             let difference = defense_roll as f64 - (attack_roll as f64 * DECISIVE_WIN_MULTIPLIER);
             if difference > 0.0 {
                 // Defender wins significantly
@@ -1164,7 +1253,8 @@ fn attack_contest(attacker: &mut Tribute, target: &mut Tribute, rng: &mut impl R
             }
         }
         Ordering::Equal => AttackResult::Miss, // If they tie
-        Ordering::Greater => { // If the attacker wins
+        Ordering::Greater => {
+            // If the attacker wins
             let difference = attack_roll as f64 - (defense_roll as f64 * DECISIVE_WIN_MULTIPLIER);
 
             if difference > 0.0 {
@@ -1217,11 +1307,11 @@ pub fn update_stats(attacker: &mut Tribute, defender: &mut Tribute, result: Atta
         AttackResult::AttackerWins | AttackResult::AttackerWinsDecisively => {
             defender.statistics.defeats += 1;
             attacker.statistics.wins += 1;
-        },
+        }
         AttackResult::DefenderWins | AttackResult::DefenderWinsDecisively => {
             attacker.statistics.defeats += 1;
             defender.statistics.wins += 1;
-        },
+        }
         AttackResult::Miss => {
             attacker.statistics.draws += 1;
             defender.statistics.draws += 1;
@@ -1305,30 +1395,39 @@ impl Attributes {
 
 #[cfg(test)]
 mod tests {
-    use crate::areas::events::AreaEvent;
     use crate::areas::Area::{Cornucopia, East, North, South, West};
     use crate::areas::AreaDetails;
+    use crate::areas::events::AreaEvent;
     use crate::games::Game;
     use crate::items::{Attribute, Item, ItemType, OwnsItems};
     use crate::threats::animals::Animal;
     use crate::tributes::actions::{AttackOutcome, AttackResult};
     use crate::tributes::statuses::TributeStatus;
-    use crate::tributes::{attack_contest, calculate_violence_stress, EncounterContext, EnvironmentContext, TravelResult, Tribute};
-    use rand::prelude::SmallRng;
+    use crate::tributes::{
+        EncounterContext, EnvironmentContext, TravelResult, Tribute, attack_contest,
+        calculate_violence_stress,
+    };
     use rand::SeedableRng;
+    use rand::prelude::SmallRng;
     use rstest::{fixture, rstest};
 
     #[allow(unused_braces)]
     #[fixture]
-    fn tribute() -> Tribute { Tribute::random() }
+    fn tribute() -> Tribute {
+        Tribute::random()
+    }
 
     #[allow(unused_braces)]
     #[fixture]
-    fn target() -> Tribute { Tribute::random() }
+    fn target() -> Tribute {
+        Tribute::random()
+    }
 
     #[allow(unused_braces)]
     #[fixture]
-    fn small_rng() -> SmallRng { SmallRng::seed_from_u64(0) }
+    fn small_rng() -> SmallRng {
+        SmallRng::seed_from_u64(0)
+    }
 
     #[test]
     fn default() {
@@ -1340,7 +1439,11 @@ mod tests {
 
     #[test]
     fn new() {
-        let tribute = Tribute::new("Katniss".to_string(), Some(12), Some("avatar.png".to_string()));
+        let tribute = Tribute::new(
+            "Katniss".to_string(),
+            Some(12),
+            Some("avatar.png".to_string()),
+        );
         assert_eq!(tribute.name, "Katniss".to_string());
         assert_eq!(tribute.district, 12);
         assert_eq!(tribute.avatar, Some("avatar.png".to_string()));
@@ -1577,9 +1680,14 @@ mod tests {
     #[case(TributeStatus::Burned)]
     #[case(TributeStatus::Drowned)]
     #[case(TributeStatus::Infected)]
-    fn process_status(mut tribute: Tribute, #[case] status: TributeStatus, mut small_rng: SmallRng) {
+    fn process_status(
+        mut tribute: Tribute,
+        #[case] status: TributeStatus,
+        mut small_rng: SmallRng,
+    ) {
         let mut game = Game::default();
-        game.areas.push(AreaDetails::new(Some("Cornucopia".to_string()), Cornucopia));
+        game.areas
+            .push(AreaDetails::new(Some("Cornucopia".to_string()), Cornucopia));
         tribute.status = status;
         let clone = tribute.clone();
 
@@ -1593,7 +1701,8 @@ mod tests {
         let bear = Animal::Bear;
         let hp = tribute.attributes.health;
 
-        game.areas.push(AreaDetails::new(Some("Cornucopia".to_string()), Cornucopia));
+        game.areas
+            .push(AreaDetails::new(Some("Cornucopia".to_string()), Cornucopia));
         tribute.status = TributeStatus::Mauled(bear.clone());
 
         tribute.process_status(&game.areas[0], &mut small_rng);
@@ -1604,9 +1713,14 @@ mod tests {
     #[case(TributeStatus::Healthy)]
     #[case(TributeStatus::RecentlyDead)]
     #[case(TributeStatus::Dead)]
-    fn process_status_no_effect(mut tribute: Tribute, #[case] status: TributeStatus, mut small_rng: SmallRng) {
+    fn process_status_no_effect(
+        mut tribute: Tribute,
+        #[case] status: TributeStatus,
+        mut small_rng: SmallRng,
+    ) {
         let mut game = Game::default();
-        game.areas.push(AreaDetails::new(Some("Cornucopia".to_string()), Cornucopia));
+        game.areas
+            .push(AreaDetails::new(Some("Cornucopia".to_string()), Cornucopia));
         tribute.status = status;
         let clone = tribute.clone();
 
@@ -1617,7 +1731,8 @@ mod tests {
     #[rstest]
     fn process_status_dies(mut tribute: Tribute, mut small_rng: SmallRng) {
         let mut game = Game::default();
-        game.areas.push(AreaDetails::new(Some("Cornucopia".to_string()), Cornucopia));
+        game.areas
+            .push(AreaDetails::new(Some("Cornucopia".to_string()), Cornucopia));
         tribute.status = TributeStatus::Wounded;
         tribute.attributes.health = 1;
 
@@ -1633,7 +1748,11 @@ mod tests {
     #[case(AreaEvent::Blizzard, TributeStatus::Frozen)]
     #[case(AreaEvent::Landslide, TributeStatus::Buried)]
     #[case(AreaEvent::Heatwave, TributeStatus::Overheated)]
-    fn apply_area_effects(mut tribute: Tribute, #[case] event: AreaEvent, #[case] status: TributeStatus) {
+    fn apply_area_effects(
+        mut tribute: Tribute,
+        #[case] event: AreaEvent,
+        #[case] status: TributeStatus,
+    ) {
         let mut game = Game::default();
         let mut area_details = AreaDetails::new(Some("Cornucopia".to_string()), Cornucopia);
         let area = area_details.area.clone().unwrap();
@@ -1687,7 +1806,13 @@ mod tests {
     fn use_consumable(mut tribute: Tribute) {
         tribute.attributes.health = 10;
         let clone = tribute.clone();
-        let health_potion = Item::new("Health Potion", ItemType::Consumable, 1, Attribute::Health, 1);
+        let health_potion = Item::new(
+            "Health Potion",
+            ItemType::Consumable,
+            1,
+            Attribute::Health,
+            1,
+        );
         tribute.items.push(health_potion.clone());
         assert!(tribute.try_use_consumable(&health_potion).is_ok());
         assert_eq!(tribute.items.len(), 0);
@@ -1697,19 +1822,37 @@ mod tests {
 
     #[rstest]
     fn use_consumable_fail_item_not_found(mut tribute: Tribute) {
-        let health_potion = Item::new("Health Potion", ItemType::Consumable, 1, Attribute::Health, 1);
+        let health_potion = Item::new(
+            "Health Potion",
+            ItemType::Consumable,
+            1,
+            Attribute::Health,
+            1,
+        );
         assert!(tribute.try_use_consumable(&health_potion).is_err());
     }
 
     #[rstest]
     fn use_consumable_fail_item_not_available(mut tribute: Tribute) {
-        let health_potion = Item::new("Health Potion", ItemType::Consumable, 0, Attribute::Health, 1);
+        let health_potion = Item::new(
+            "Health Potion",
+            ItemType::Consumable,
+            0,
+            Attribute::Health,
+            1,
+        );
         assert!(tribute.try_use_consumable(&health_potion).is_err());
     }
 
     #[rstest]
     fn available_items(mut tribute: Tribute) {
-        let item1 = Item::new("Health Potion", ItemType::Consumable, 1, Attribute::Health, 1);
+        let item1 = Item::new(
+            "Health Potion",
+            ItemType::Consumable,
+            1,
+            Attribute::Health,
+            1,
+        );
         let item2 = Item::new("Sword", ItemType::Weapon, 0, Attribute::Strength, 5);
         tribute.items.push(item1.clone());
         tribute.items.push(item2.clone());
@@ -1718,7 +1861,13 @@ mod tests {
 
     #[rstest]
     fn weapons(mut tribute: Tribute) {
-        let item1 = Item::new("Health Potion", ItemType::Consumable, 1, Attribute::Health, 1);
+        let item1 = Item::new(
+            "Health Potion",
+            ItemType::Consumable,
+            1,
+            Attribute::Health,
+            1,
+        );
         let item2 = Item::new("Sword", ItemType::Weapon, 1, Attribute::Strength, 5);
         tribute.items.push(item1.clone());
         tribute.items.push(item2.clone());
@@ -1727,7 +1876,13 @@ mod tests {
 
     #[rstest]
     fn shields(mut tribute: Tribute) {
-        let item1 = Item::new("Health Potion", ItemType::Consumable, 1, Attribute::Health, 1);
+        let item1 = Item::new(
+            "Health Potion",
+            ItemType::Consumable,
+            1,
+            Attribute::Health,
+            1,
+        );
         let item2 = Item::new("Shield", ItemType::Weapon, 1, Attribute::Defense, 5);
         tribute.items.push(item1.clone());
         tribute.items.push(item2.clone());
@@ -1736,7 +1891,13 @@ mod tests {
 
     #[rstest]
     fn consumables(mut tribute: Tribute) {
-        let item1 = Item::new("Health Potion", ItemType::Consumable, 1, Attribute::Health, 1);
+        let item1 = Item::new(
+            "Health Potion",
+            ItemType::Consumable,
+            1,
+            Attribute::Health,
+            1,
+        );
         let item2 = Item::new("Sword", ItemType::Weapon, 1, Attribute::Strength, 5);
         tribute.items.push(item1.clone());
         tribute.items.push(item2.clone());
@@ -1746,10 +1907,7 @@ mod tests {
     /// The tributes are from different districts and are in the same area.
     #[rstest]
     #[tokio::test]
-    async fn pick_target(
-        mut tribute: Tribute,
-        mut target: Tribute
-    ) {
+    async fn pick_target(mut tribute: Tribute, mut target: Tribute) {
         let mut game = Game::default();
         let cornucopia = AreaDetails::new(Some("Cornucopia".to_string()), Cornucopia);
         game.areas.push(cornucopia.clone());
@@ -1760,7 +1918,8 @@ mod tests {
         target.district = 10;
         target.area = Cornucopia;
 
-        game.tributes.extend_from_slice([tribute.clone(), target.clone()].as_ref());
+        game.tributes
+            .extend_from_slice([tribute.clone(), target.clone()].as_ref());
 
         let target = tribute.pick_target(vec![target.clone()], 2);
 
@@ -1806,7 +1965,8 @@ mod tests {
         let mut rue = Tribute::new("Rue".to_string(), Some(2), None);
         rue.area = North;
 
-        game.tributes.extend_from_slice([katniss.clone(), peeta.clone(), rue.clone()].as_ref());
+        game.tributes
+            .extend_from_slice([katniss.clone(), peeta.clone(), rue.clone()].as_ref());
 
         let target = katniss.pick_target(vec![peeta], 3);
 
@@ -1833,7 +1993,8 @@ mod tests {
         let mut rue = Tribute::new("Rue".to_string(), Some(2), None);
         rue.area = North;
 
-        game.tributes.extend_from_slice([katniss.clone(), peeta.clone(), rue.clone()].as_ref());
+        game.tributes
+            .extend_from_slice([katniss.clone(), peeta.clone(), rue.clone()].as_ref());
 
         let target = katniss.pick_target(vec![peeta.clone()], 3);
 
@@ -1854,7 +2015,8 @@ mod tests {
         let mut peeta = Tribute::new("Peeta".to_string(), Some(1), None);
         peeta.area = Cornucopia;
 
-        game.tributes.extend_from_slice([katniss.clone(), peeta.clone()].as_ref());
+        game.tributes
+            .extend_from_slice([katniss.clone(), peeta.clone()].as_ref());
 
         let target = katniss.pick_target(vec![peeta.clone()], 2);
 
@@ -1892,7 +2054,6 @@ mod tests {
 
         attacker.attributes.strength = 15;
         target.attributes.defense = 20;
-
 
         let result = attack_contest(&mut attacker, &mut target, &mut small_rng);
         assert_eq!(result, AttackResult::DefenderWins);
@@ -1954,7 +2115,10 @@ mod tests {
         target.attributes.defense = 20;
 
         let result = attacker.attacks(&mut target, &mut small_rng);
-        assert_eq!(result, AttackOutcome::Wound(attacker.clone(), target.clone()));
+        assert_eq!(
+            result,
+            AttackOutcome::Wound(attacker.clone(), target.clone())
+        );
         assert_eq!(attacker.statistics.wins, 1);
         assert_eq!(target.statistics.defeats, 1);
         assert!(attacker.attributes.sanity < sanity);
@@ -1972,7 +2136,10 @@ mod tests {
 
         let result = attacker.attacks(&mut target, &mut small_rng);
 
-        assert_eq!(result, AttackOutcome::Kill(attacker.clone(), target.clone()));
+        assert_eq!(
+            result,
+            AttackOutcome::Kill(attacker.clone(), target.clone())
+        );
         assert_eq!(target.status, TributeStatus::RecentlyDead);
         assert_eq!(target.statistics.killed_by, Some(attacker.name));
         assert_eq!(target.status, TributeStatus::RecentlyDead);
@@ -1994,7 +2161,10 @@ mod tests {
         assert_eq!(target.statistics.wins, 0);
         assert_eq!(attacker.statistics.draws, 1);
         assert_eq!(target.statistics.draws, 1);
-        assert_eq!(result, AttackOutcome::Miss(attacker.clone(), target.clone()));
+        assert_eq!(
+            result,
+            AttackOutcome::Miss(attacker.clone(), target.clone())
+        );
     }
 
     #[tokio::test]
@@ -2026,7 +2196,7 @@ mod tests {
             action_suggestion,
             environment_details,
             encounter_context,
-            &mut rng
+            &mut rng,
         );
 
         assert_ne!(clone, tribute1);
@@ -2060,7 +2230,7 @@ mod tests {
             action_selection,
             environment_details,
             encounter_context,
-            &mut rng
+            &mut rng,
         );
 
         assert_eq!(clone, tribute1);
@@ -2136,7 +2306,6 @@ mod statistics {
         assert_eq!(stats.draws, 0);
         assert_eq!(stats.game, "".to_string());
     }
-
 }
 
 #[cfg(test)]

--- a/game/src/witty_phrase_generator/mod.rs
+++ b/game/src/witty_phrase_generator/mod.rs
@@ -1,5 +1,5 @@
-use rand::prelude::*;
 use rand::Rng;
+use rand::prelude::*;
 use rand::seq::SliceRandom;
 
 use std::cell::RefCell;
@@ -18,18 +18,18 @@ pub struct WPGen {
 impl WPGen {
     pub fn new() -> WPGen {
         let words_intensifiers = include_str!("intensifiers.txt");
-        let words_adjectives   = include_str!("adjectives.txt")  ;
-        let words_nouns        = include_str!("nouns.txt")       ;
+        let words_adjectives = include_str!("adjectives.txt");
+        let words_nouns = include_str!("nouns.txt");
 
         let words_intensifiers = words_intensifiers.lines().collect::<Vec<&'static str>>();
-        let words_adjectives   = words_adjectives  .lines().collect::<Vec<&'static str>>();
-        let words_nouns        = words_nouns       .lines().collect::<Vec<&'static str>>();
+        let words_adjectives = words_adjectives.lines().collect::<Vec<&'static str>>();
+        let words_nouns = words_nouns.lines().collect::<Vec<&'static str>>();
 
         WPGen {
             rng: RefCell::new(ThreadRng::default()),
             words_intensifiers,
-            words_adjectives  ,
-            words_nouns       ,
+            words_adjectives,
+            words_nouns,
         }
     }
 
@@ -37,23 +37,34 @@ impl WPGen {
         // TODO: return Vec<ENUM{ intensifier, adjective, noun }> instead of usize
         // TODO: convert with_words fn to use this also
 
-        let mut ret = vec![0; words+1];
+        let mut ret = vec![0; words + 1];
         let mut n = 1;
 
-        if words > 3 { ret[4] = 3 }
-        if words > 2 { ret[n] = 1; n += 1; }
-        if words > 1 { ret[n] = 2; n += 1; }
-        if words > 0 { ret[n] = 3; }
+        if words > 3 {
+            ret[4] = 3
+        }
+        if words > 2 {
+            ret[n] = 1;
+            n += 1;
+        }
+        if words > 1 {
+            ret[n] = 2;
+            n += 1;
+        }
+        if words > 0 {
+            ret[n] = 3;
+        }
 
         ret
     }
 
-    fn generate_backtracking(&self,
-                             len_min: usize,
-                             len_max: usize,
-                             dep: usize,
-                             dict: &[Vec<&&'static str>; 4],
-                             format: &Vec<usize>,
+    fn generate_backtracking(
+        &self,
+        len_min: usize,
+        len_max: usize,
+        dep: usize,
+        dict: &[Vec<&&'static str>; 4],
+        format: &Vec<usize>,
     ) -> Option<Vec<&'static str>> {
         let pool = &dict[format[dep]];
 
@@ -68,8 +79,9 @@ impl WPGen {
         //};
         // TODO: is binary search even faster on such short wordlists?
         let mut upper_bound = 0;
-        while upper_bound < pool.len() && pool[upper_bound].len() <= len_max { upper_bound += 1; }
-
+        while upper_bound < pool.len() && pool[upper_bound].len() <= len_max {
+            upper_bound += 1;
+        }
 
         let pool = pool[0..upper_bound]
             .choose_multiple(&mut *self.rng.borrow_mut(), upper_bound)
@@ -78,19 +90,25 @@ impl WPGen {
         for selected in pool {
             assert!(selected.len() <= len_max);
 
-            if dep >= format.len()-1 { // last iteration (base case)
-                if selected.len() < len_min { continue } // would wrap all the way around
-                return Some(vec![selected])
+            if dep >= format.len() - 1 {
+                // last iteration (base case)
+                if selected.len() < len_min {
+                    continue;
+                } // would wrap all the way around
+                return Some(vec![selected]);
             }
 
             if let Some(mut suf) = self.generate_backtracking(
                 (len_min as i32 - selected.len() as i32).max(0) as usize,
                 len_max - selected.len(),
-                dep+1, dict, format) {
+                dep + 1,
+                dict,
+                format,
+            ) {
                 suf.push(selected);
                 return Some(suf);
             }
-        };
+        }
         None
     }
 
@@ -107,44 +125,67 @@ impl WPGen {
     /// if it is provided. To allow different phrases to alliterate
     /// with different letters, use with_phrasewise_alliteration
     /// instead.
-    pub fn generic(&self,
-                   words: usize,
-                   count: usize,
-                   len_min: Option<usize>,
-                   len_max: Option<usize>,
-                   word_len_max: Option<usize>,
-                   start_char: Option<char>
+    pub fn generic(
+        &self,
+        words: usize,
+        count: usize,
+        len_min: Option<usize>,
+        len_max: Option<usize>,
+        word_len_max: Option<usize>,
+        start_char: Option<char>,
     ) -> Option<Vec<Vec<&'static str>>> {
-
         let len_min = len_min.unwrap_or(0);
         let len_max = len_max.unwrap_or(usize::MAX);
-        let word_len_max = word_len_max.unwrap_or(len_max / (words-1));
+        let word_len_max = word_len_max.unwrap_or(len_max / (words - 1));
 
-        if len_max < len_min        { return None }
-        if words > 4 || words == 0  { return None }
+        if len_max < len_min {
+            return None;
+        }
+        if words > 4 || words == 0 {
+            return None;
+        }
 
         // convert to references
-        let words_intensifiers = self.words_intensifiers.iter().map(|x| x).collect::<Vec<&&'static str>>();
-        let words_adjectives   = self.words_adjectives  .iter().map(|x| x).collect::<Vec<&&'static str>>();
-        let words_nouns        = self.words_nouns       .iter().map(|x| x).collect::<Vec<&&'static str>>();
+        let words_intensifiers = self
+            .words_intensifiers
+            .iter()
+            .map(|x| x)
+            .collect::<Vec<&&'static str>>();
+        let words_adjectives = self
+            .words_adjectives
+            .iter()
+            .map(|x| x)
+            .collect::<Vec<&&'static str>>();
+        let words_nouns = self
+            .words_nouns
+            .iter()
+            .map(|x| x)
+            .collect::<Vec<&&'static str>>();
 
         // dictionary that we can recurse over
-        let mut dict = [Vec::new(), words_intensifiers, words_adjectives, words_nouns];
+        let mut dict = [
+            Vec::new(),
+            words_intensifiers,
+            words_adjectives,
+            words_nouns,
+        ];
 
         for list in &mut dict {
             // filter words we know we can't use
             if let Some(c) = start_char {
                 list.retain(|s| s.chars().nth(0).expect("empty word found!") == c);
             }
-            list.retain(|s| s.len() <= word_len_max);  // filter out words that are already longer than len_max; TODO: too restrictive sometimes
-            list.shuffle(&mut *self.rng.borrow_mut());      // shuffle all the available words
-            list.sort_by(|a, b: &&&str| a.len().cmp(&b.len()));     // sort by length (stable sort, so still shuffled) for easier length matching
+            list.retain(|s| s.len() <= word_len_max); // filter out words that are already longer than len_max; TODO: too restrictive sometimes
+            list.shuffle(&mut *self.rng.borrow_mut()); // shuffle all the available words
+            list.sort_by(|a, b: &&&str| a.len().cmp(&b.len())); // sort by length (stable sort, so still shuffled) for easier length matching
         }
 
         let mut ret = vec![vec![""; words]; count];
 
         for i in 0..count {
-            if let Some(mut vec) = self.generate_backtracking(len_min, len_max, 1, &dict, &WPGen::create_format(words)) {
+            if let Some(mut vec) =
+                self.generate_backtracking(len_min, len_max, 1, &dict, &WPGen::create_format(words))
+            {
                 vec.reverse();
                 ret[i] = vec;
             } else {
@@ -166,21 +207,22 @@ impl WPGen {
     /// Each phrase will alliterate internally, but different
     /// phrases may start with different letters. To specify
     /// what letter to start with, use generic() instead.
-    pub fn with_phrasewise_alliteration(&self,
-                                        words: usize,
-                                        count: usize,
-                                        len_min: Option<usize>,
-                                        len_max: Option<usize>,
-                                        word_len_max: Option<usize>,
+    pub fn with_phrasewise_alliteration(
+        &self,
+        words: usize,
+        count: usize,
+        len_min: Option<usize>,
+        len_max: Option<usize>,
+        word_len_max: Option<usize>,
     ) -> Option<Vec<Vec<&'static str>>> {
-
         let mut ret = Vec::new();
         ret.reserve_exact(count);
         for _ in 0..count {
             ret.append(&mut loop {
-                let char = (*self.rng.borrow_mut()).random_range(b'a'..b'z'+1) as char;
-                if let Some(p) = self.generic(words, 1, len_min, len_max, word_len_max, Some(char)) {
-                    break p
+                let char = (*self.rng.borrow_mut()).random_range(b'a'..b'z' + 1) as char;
+                if let Some(p) = self.generic(words, 1, len_min, len_max, word_len_max, Some(char))
+                {
+                    break p;
                 }
             });
         }
@@ -194,11 +236,33 @@ impl WPGen {
         let mut ret = vec![""; words];
         let mut n = 0;
 
-        if words > 3 { ret[3] = self.words_nouns       .iter().choose(&mut *self.rng.borrow_mut())?; }
+        if words > 3 {
+            ret[3] = self
+                .words_nouns
+                .iter()
+                .choose(&mut *self.rng.borrow_mut())?;
+        }
 
-        if words > 2 { ret[n] = self.words_intensifiers.iter().choose(&mut *self.rng.borrow_mut())?; n += 1; }
-        if words > 1 { ret[n] = self.words_adjectives  .iter().choose(&mut *self.rng.borrow_mut())?; n += 1; }
-        if words > 0 { ret[n] = self.words_nouns       .iter().choose(&mut *self.rng.borrow_mut())?; }
+        if words > 2 {
+            ret[n] = self
+                .words_intensifiers
+                .iter()
+                .choose(&mut *self.rng.borrow_mut())?;
+            n += 1;
+        }
+        if words > 1 {
+            ret[n] = self
+                .words_adjectives
+                .iter()
+                .choose(&mut *self.rng.borrow_mut())?;
+            n += 1;
+        }
+        if words > 0 {
+            ret[n] = self
+                .words_nouns
+                .iter()
+                .choose(&mut *self.rng.borrow_mut())?;
+        }
 
         Some(ret)
     }

--- a/schemas/refresh_tokens.surql
+++ b/schemas/refresh_tokens.surql
@@ -1,0 +1,16 @@
+-- Refresh tokens for JWT token rotation
+DEFINE TABLE OVERWRITE refresh_token SCHEMAFULL
+    PERMISSIONS
+        -- Only allow authenticated users to query their own tokens
+        FOR select, create WHERE $auth
+        FOR update, delete WHERE user_id = $auth.id;
+
+DEFINE FIELD OVERWRITE token ON refresh_token TYPE string;
+DEFINE FIELD OVERWRITE user_id ON refresh_token TYPE record<user>;
+DEFINE FIELD OVERWRITE username ON refresh_token TYPE string;
+DEFINE FIELD OVERWRITE expires_at ON refresh_token TYPE datetime;
+DEFINE FIELD OVERWRITE revoked ON refresh_token TYPE bool DEFAULT false;
+DEFINE FIELD OVERWRITE created_at ON refresh_token TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX OVERWRITE unique_token ON refresh_token FIELDS token UNIQUE;
+DEFINE INDEX OVERWRITE user_tokens ON refresh_token FIELDS user_id;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -18,22 +18,13 @@ pub type DeleteTribute = String;
 pub struct DeleteGame(pub String, pub String); // Identifier, name
 
 /// Used to edit a tribute. Contains the identifier, name, avatar, and game identifier of the tribute.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
-pub struct EditTribute(
-    #[validate(length(min = 1, message = "Tribute identifier required"))] pub String,
-    #[validate(length(min = 1, max = 50, message = "Name must be 1-50 characters"))] pub String,
-    pub String,
-    pub String,
-);
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct EditTribute(pub String, pub String, pub String, pub String);
 
 /// This struct is used to edit a game
 /// It contains the identifier, name, and a boolean indicating if the game is private
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Validate)]
-pub struct EditGame(
-    #[validate(length(min = 1, message = "Game identifier required"))] pub String,
-    #[validate(length(min = 1, max = 100, message = "Name must be 1-100 characters"))] pub String,
-    pub bool,
-);
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct EditGame(pub String, pub String, pub bool);
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct GameArea {
@@ -48,9 +39,11 @@ pub struct TributeKey {
     pub district: u32,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
 pub struct RegistrationUser {
+    #[validate(length(min = 3, max = 50, message = "Username must be 3-50 characters"))]
     pub username: String,
+    #[validate(length(min = 8, message = "Password must be at least 8 characters"))]
     pub password: String,
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -20,10 +20,8 @@ pub struct DeleteGame(pub String, pub String); // Identifier, name
 /// Used to edit a tribute. Contains the identifier, name, avatar, and game identifier of the tribute.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
 pub struct EditTribute(
-    #[validate(length(min = 1, message = "Tribute identifier required"))]
-    pub String,
-    #[validate(length(min = 1, max = 50, message = "Name must be 1-50 characters"))]
-    pub String,
+    #[validate(length(min = 1, message = "Tribute identifier required"))] pub String,
+    #[validate(length(min = 1, max = 50, message = "Name must be 1-50 characters"))] pub String,
     pub String,
     pub String,
 );
@@ -32,10 +30,8 @@ pub struct EditTribute(
 /// It contains the identifier, name, and a boolean indicating if the game is private
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Validate)]
 pub struct EditGame(
-    #[validate(length(min = 1, message = "Game identifier required"))]
-    pub String,
-    #[validate(length(min = 1, max = 100, message = "Name must be 1-100 characters"))]
-    pub String,
+    #[validate(length(min = 1, message = "Game identifier required"))] pub String,
+    #[validate(length(min = 1, max = 100, message = "Name must be 1-100 characters"))] pub String,
     pub bool,
 );
 


### PR DESCRIPTION
## Summary
Implements comprehensive JWT refresh token mechanism with automatic token rotation for secure authentication.

## Changes
- **Database Schema** (`schemas/refresh_tokens.surql`)
  - New `refresh_token` table with 7-day expiration
  - Row-level permissions (user-scoped access)
  - Unique index on token field

- **Auth Module** (`api/src/auth.rs`)
  - `RefreshToken` struct with lifecycle management
  - Token generation (UUID-based, cryptographically secure)
  - Token validation (expiration + revocation checks)
  - Single-use token rotation (auto-revoke on refresh)
  - JWT signing with HS512 (matches SurrealDB config)

- **API Endpoints**
  - New `/api/auth/refresh` endpoint
  - Updated login/signup to return both access + refresh tokens
  - Token pair creation helper

- **Security Features**
  - Access tokens: 1 hour lifetime
  - Refresh tokens: 7 days lifetime
  - Automatic rotation prevents token theft escalation
  - Revocation tracking in database

## Testing
- Refresh token generation and validation
- Token rotation (old token revoked after use)
- Expiration handling

## Related Issues
Closes hangrier_games-bc1

## Breaking Changes
- Login/signup responses now include `refresh_token` field
- Frontend needs to handle token refresh flow