### PR TITLE
feat(api): Add cleanup job for expired/revoked refresh tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-cron-scheduler",
  "tower",
  "tower-http",
  "tower_governor",
@@ -1143,6 +1144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "croner"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c344b0690c1ad1c7176fe18eb173e0c927008fdaaa256e40dfd43ddd149c0843"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -3641,6 +3651,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6123,6 +6144,21 @@ dependencies = [
  "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-cron-scheduler"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5597b569b4712cf78aa0c9ae29742461b7bda1e49c2a5fdad1d79bf022f8f0"
+dependencies = [
+ "chrono",
+ "croner",
+ "num-derive",
+ "num-traits",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -19,6 +19,7 @@ surrealdb = "2.3.2"
 surrealdb-migrations = "2.2.2"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full"] }
+tokio-cron-scheduler = "0.13.0"
 tower-http = { version = "0.6.4", features = ["trace", "cors"] }
 tower = { version = "0.5.2", features = ["util", "timeout"] }
 tower_governor = "0.8"

--- a/api/src/cleanup.rs
+++ b/api/src/cleanup.rs
@@ -1,0 +1,80 @@
+use crate::{AppError, AppState};
+use tokio_cron_scheduler::{Job, JobScheduler};
+use tracing::{error, info};
+
+/// Delete expired and revoked refresh tokens from the database
+pub async fn cleanup_refresh_tokens(state: &AppState) -> Result<usize, AppError> {
+    let result = state
+        .db
+        .query("DELETE FROM refresh_token WHERE revoked = true OR expires_at < time::now()")
+        .await
+        .map_err(|e| AppError::DbError(format!("Failed to cleanup refresh tokens: {}", e)))?;
+
+    // Extract the number of deleted tokens
+    let deleted: Vec<serde_json::Value> = result
+        .check()
+        .map_err(|e| AppError::DbError(format!("Failed to check cleanup result: {}", e)))?;
+
+    // Count the number of deleted records
+    let count = deleted.len();
+
+    info!(
+        "Cleanup job: deleted {} expired/revoked refresh tokens",
+        count
+    );
+    Ok(count)
+}
+
+/// Initialize the cleanup job scheduler
+pub async fn start_cleanup_scheduler(state: AppState) -> Result<JobScheduler, AppError> {
+    let scheduler = JobScheduler::new()
+        .await
+        .map_err(|e| AppError::InternalServerError(format!("Failed to create scheduler: {}", e)))?;
+
+    // Schedule cleanup job to run daily at 3 AM UTC
+    // Cron format: "sec min hour day_of_month month day_of_week year"
+    let state_clone = state.clone();
+    let job = Job::new_async("0 0 3 * * *", move |_uuid, _lock| {
+        let state = state_clone.clone();
+        Box::pin(async move {
+            match cleanup_refresh_tokens(&state).await {
+                Ok(count) => {
+                    info!("Scheduled cleanup completed: {} tokens deleted", count);
+                }
+                Err(e) => {
+                    error!("Scheduled cleanup failed: {}", e);
+                }
+            }
+        })
+    })
+    .map_err(|e| AppError::InternalServerError(format!("Failed to create cleanup job: {}", e)))?;
+
+    scheduler.add(job).await.map_err(|e| {
+        AppError::InternalServerError(format!("Failed to add job to scheduler: {}", e))
+    })?;
+
+    scheduler
+        .start()
+        .await
+        .map_err(|e| AppError::InternalServerError(format!("Failed to start scheduler: {}", e)))?;
+
+    info!("Cleanup scheduler started: daily at 3 AM UTC");
+
+    Ok(scheduler)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use surrealdb::Surreal;
+    use surrealdb::engine::any::Any;
+
+    #[tokio::test]
+    async fn test_cleanup_scheduler_creation() {
+        // This test verifies the scheduler can be created
+        // Note: We can't easily test the actual cleanup without a real database
+        let result = JobScheduler::new().await;
+        assert!(result.is_ok());
+    }
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -8,6 +8,7 @@ use surrealdb::engine::any::Any;
 use thiserror::Error;
 
 pub mod auth;
+pub mod cleanup;
 pub mod games;
 pub mod logging;
 // pub mod messages; // TODO: Module file missing

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -2,6 +2,7 @@ extern crate core;
 
 use api::AppState;
 use api::auth::AUTH_ROUTER;
+use api::cleanup::start_cleanup_scheduler;
 use api::games::GAMES_ROUTER;
 use api::users::USERS_ROUTER;
 use axum::extract::{Request, State};
@@ -216,6 +217,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let app_state = AppState { db: db.clone() };
+
+    // Start cleanup scheduler for refresh tokens
+    let _cleanup_scheduler = start_cleanup_scheduler(app_state.clone())
+        .await
+        .map_err(|e| format!("Failed to start cleanup scheduler: {}", e))?;
+    tracing::info!("Cleanup scheduler initialized");
 
     let api_routes = Router::new()
         .nest(


### PR DESCRIPTION
Implements automatic cleanup of expired and revoked refresh tokens.

- Added tokio-cron-scheduler dependency
- Created api/src/cleanup.rs with cleanup logic
- Scheduled daily job at 3 AM UTC
- Deletes tokens where revoked = true OR expires_at < NOW()

Closes hangrier_games-96l