### PR TITLE
feat: movement adjacency and stamina validation system

### DIFF
--- a/game/src/areas/mod.rs
+++ b/game/src/areas/mod.rs
@@ -70,6 +70,15 @@ impl Area {
     }
 }
 
+/// Information about a destination area that tributes can use to make movement decisions
+#[derive(Clone, Debug)]
+pub struct DestinationInfo {
+    pub area: Area,
+    pub terrain: TerrainType,
+    pub active_events: Vec<AreaEvent>,
+    pub stamina_cost: u32,
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct AreaDetails {
     pub identifier: String,

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -7,7 +7,9 @@ use crate::output::GameOutput;
 use crate::tributes::actions::Action;
 use crate::tributes::events::TributeEvent;
 use crate::tributes::statuses::TributeStatus;
-use crate::tributes::{ActionSuggestion, EncounterContext, EnvironmentContext, Tribute};
+use crate::tributes::{
+    ActionSuggestion, EncounterContext, EnvironmentContext, Tribute, calculate_stamina_cost,
+};
 use rand::prelude::*;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -478,12 +480,40 @@ impl Game {
                 Some(&idx) => idx,
                 None => continue,
             };
+
+            // Build available destinations BEFORE taking mutable borrow of area_details
+            let available_destinations = tribute
+                .area
+                .neighbors()
+                .into_iter()
+                .filter_map(|neighbor_area| {
+                    // Find the AreaDetails for this neighbor
+                    self.areas
+                        .iter()
+                        .find(|ad| ad.area == Some(neighbor_area.clone()))
+                        .map(|ad| {
+                            // Calculate stamina cost to move to this area
+                            let move_action = Action::Move(Some(neighbor_area.clone()));
+                            let stamina_cost =
+                                calculate_stamina_cost(&move_action, &ad.terrain, &tribute);
+
+                            crate::areas::DestinationInfo {
+                                area: neighbor_area,
+                                terrain: ad.terrain.clone(),
+                                active_events: ad.events.clone(),
+                                stamina_cost,
+                            }
+                        })
+                })
+                .collect();
+
             let area_details = &mut self.areas[area_index];
 
             let mut environment_details = EnvironmentContext {
                 is_day: day,
                 area_details,
                 closed_areas: &closed_areas,
+                available_destinations,
             };
 
             // Get nearby tributes using the pre-computed map

--- a/game/src/output.rs
+++ b/game/src/output.rs
@@ -27,6 +27,7 @@ pub enum GameOutput<'a> {
     TributeCannotUseItem(&'a str, &'a str),
     TributeUseItem(&'a str, &'a Item),
     TributeTravelTooTired(&'a str, &'a str),
+    TributeTravelExhausted(&'a str, &'a str),
     TributeTravelAlreadyThere(&'a str, &'a str),
     TributeTravelFollow(&'a str, &'a str),
     TributeTravelStay(&'a str, &'a str),
@@ -150,6 +151,13 @@ impl<'a> Display for GameOutput<'a> {
                 write!(
                     f,
                     "😴 {} is too tired to move from {}, rests instead",
+                    tribute, area
+                )
+            }
+            GameOutput::TributeTravelExhausted(tribute, area) => {
+                write!(
+                    f,
+                    "🥵 {} is too exhausted to move from {}, lacks stamina",
                     tribute, area
                 )
             }

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -42,7 +42,13 @@ impl Brain {
     }
 
     /// The AI for a tribute. Automatic decisions based on the current state of the tribute.
-    pub fn act(&self, tribute: &Tribute, nearby_tributes: u32, rng: &mut impl Rng) -> Action {
+    pub fn act(
+        &self,
+        tribute: &Tribute,
+        nearby_tributes: u32,
+        available_destinations: &[crate::areas::DestinationInfo],
+        rng: &mut impl Rng,
+    ) -> Action {
         if !tribute.is_alive() {
             return Action::None;
         }
@@ -61,12 +67,49 @@ impl Brain {
             return Action::UseItem(None);
         }
 
-        if nearby_tributes == 0 {
+        let action = if nearby_tributes == 0 {
             self.decide_action_no_enemies(tribute)
         } else if nearby_tributes < LOW_ENEMY_LIMIT {
             self.decide_action_few_enemies(tribute)
         } else {
             self.decide_action_many_enemies(tribute)
+        };
+
+        // If the action is Move(None), choose smart destination based on terrain
+        match action {
+            Action::Move(None) => {
+                // If no destinations available, keep Move(None) for backward compatibility
+                if available_destinations.is_empty() {
+                    return Action::Move(None);
+                }
+
+                // Convert DestinationInfo to AreaDetails for choose_destination
+                let area_details: Vec<AreaDetails> = available_destinations
+                    .iter()
+                    .map(|dest| {
+                        let mut ad = AreaDetails::default();
+                        ad.area = Some(dest.area.clone());
+                        ad.terrain = dest.terrain.clone();
+                        ad.events = dest.active_events.clone();
+                        ad
+                    })
+                    .collect();
+
+                // Choose best destination using terrain scoring
+                if let Some(best_area) = self.choose_destination(&area_details, tribute) {
+                    // Also check if tribute has enough stamina
+                    if let Some(dest_info) =
+                        available_destinations.iter().find(|d| d.area == best_area)
+                    {
+                        if tribute.stamina >= dest_info.stamina_cost {
+                            return Action::Move(Some(best_area));
+                        }
+                    }
+                }
+                // Fall back to rest if no good destination or insufficient stamina
+                Action::Rest
+            }
+            other => other,
         }
     }
 
@@ -353,7 +396,7 @@ mod tests {
     #[rstest]
     fn decide_on_action_default(tribute: Tribute, mut small_rng: SmallRng) {
         // If there are no enemies nearby, the tribute should move
-        let action = tribute.brain.act(&tribute.clone(), 0, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
         assert_eq!(action, Action::Move(None));
     }
 
@@ -361,7 +404,7 @@ mod tests {
     fn decide_on_action_low_health(mut tribute: Tribute, mut small_rng: SmallRng) {
         // If the tribute has low health, they should rest
         tribute.attributes.health = 10;
-        let action = tribute.brain.act(&tribute.clone(), 2, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
         assert_eq!(action, Action::Move(None));
     }
 
@@ -369,7 +412,7 @@ mod tests {
     fn decide_on_action_no_health(mut tribute: Tribute, mut small_rng: SmallRng) {
         // If the tribute has no health, they should do nothing
         tribute.attributes.health = 0;
-        let action = tribute.brain.act(&tribute.clone(), 2, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
         assert_eq!(action, Action::None);
     }
 
@@ -377,7 +420,7 @@ mod tests {
     fn decide_on_action_no_movement_alone(mut tribute: Tribute, mut small_rng: SmallRng) {
         // If the tribute has no movement and is alone, they should rest
         tribute.attributes.movement = 0;
-        let action = tribute.brain.act(&tribute.clone(), 0, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
         assert_eq!(action, Action::Rest);
     }
 
@@ -389,14 +432,14 @@ mod tests {
         // If the tribute has no movement and is not alone, they should hide
         tribute.attributes.movement = 1;
         tribute.attributes.health = 10;
-        let action = tribute.brain.act(&tribute.clone(), 5, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 5, &[], &mut small_rng);
         assert_eq!(action, Action::Hide);
     }
 
     #[rstest]
     fn decide_on_action_enemies(tribute: Tribute, mut small_rng: SmallRng) {
         // If there are enemies nearby, the tribute should attack
-        let action = tribute.brain.act(&tribute.clone(), 2, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 
@@ -405,14 +448,14 @@ mod tests {
         // If there are enemies nearby, but the tribute is low on health
         // the tribute should hide
         tribute.attributes.health = 20;
-        let action = tribute.brain.act(&tribute.clone(), 2, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
         assert_eq!(action, Action::Move(None));
     }
 
     #[rstest]
     fn decide_on_action_preferred_action(mut tribute: Tribute, mut small_rng: SmallRng) {
         tribute.brain.set_preferred_action(Action::Rest, 1.0);
-        let action = tribute.brain.act(&tribute.clone(), 0, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
         assert_eq!(action, Action::Rest);
     }
 
@@ -431,14 +474,14 @@ mod tests {
     fn prefer_to_use_item_if_available(mut tribute: Tribute, mut small_rng: SmallRng) {
         let item = Item::new_random_consumable();
         tribute.items.push(item.clone());
-        let action = tribute.brain.act(&tribute.clone(), 0, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
         assert_eq!(action, Action::UseItem(None));
     }
 
     #[rstest]
     fn prefer_to_hide_at_mid_health_and_visible(mut tribute: Tribute, mut small_rng: SmallRng) {
         tribute.attributes.health = 25;
-        let action = tribute.brain.act(&tribute.clone(), 0, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
         assert_eq!(action, Action::Hide);
     }
 
@@ -446,14 +489,14 @@ mod tests {
     fn prefer_to_move_at_mid_health_and_low_sanity(mut tribute: Tribute, mut small_rng: SmallRng) {
         tribute.attributes.health = 25;
         tribute.attributes.sanity = 15;
-        let action = tribute.brain.act(&tribute.clone(), 0, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
         assert_eq!(action, Action::Move(None));
     }
 
     #[rstest]
     fn decide_on_action_alone_healthy_no_movement(mut tribute: Tribute, mut small_rng: SmallRng) {
         tribute.attributes.movement = 0;
-        let action = tribute.brain.act(&tribute.clone(), 0, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
         assert_eq!(action, Action::Rest);
     }
 
@@ -465,7 +508,7 @@ mod tests {
         tribute.attributes.health = 10;
         tribute.attributes.movement = 0;
         tribute.attributes.sanity = 15;
-        let action = tribute.brain.act(&tribute.clone(), 3, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 3, &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 
@@ -476,7 +519,7 @@ mod tests {
     ) {
         tribute.attributes.health = 15;
         tribute.attributes.sanity = 10;
-        let action = tribute.brain.act(&tribute.clone(), 3, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 3, &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 
@@ -487,7 +530,7 @@ mod tests {
     ) {
         tribute.attributes.is_hidden = true;
         tribute.attributes.health = 10;
-        let action = tribute.brain.act(&tribute.clone(), 3, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 3, &[], &mut small_rng);
         assert_eq!(action, Action::None);
     }
 
@@ -498,7 +541,7 @@ mod tests {
     ) {
         tribute.attributes.health = 25;
         tribute.attributes.sanity = 15;
-        let action = tribute.brain.act(&tribute.clone(), 3, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 3, &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 
@@ -509,7 +552,7 @@ mod tests {
     ) {
         tribute.attributes.intelligence = 50;
         tribute.attributes.sanity = 50;
-        let action = tribute.brain.act(&tribute.clone(), 6, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 6, &[], &mut small_rng);
         assert_eq!(action, Action::Move(None));
     }
 
@@ -520,7 +563,7 @@ mod tests {
     ) {
         tribute.attributes.intelligence = 20;
         tribute.attributes.sanity = 20;
-        let action = tribute.brain.act(&tribute.clone(), 6, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 6, &[], &mut small_rng);
         assert_eq!(action, Action::Hide);
     }
 
@@ -531,7 +574,7 @@ mod tests {
     ) {
         tribute.attributes.intelligence = 10;
         tribute.attributes.sanity = 10;
-        let action = tribute.brain.act(&tribute.clone(), 6, &mut small_rng);
+        let action = tribute.brain.act(&tribute.clone(), 6, &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 }

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -821,7 +821,12 @@ impl Tribute {
 
         // Get tribute action
         let number_of_nearby_tributes = encounter_context.nearby_tributes_count;
-        let action = self.brain.act(&self, number_of_nearby_tributes, rng);
+        let action = self.brain.act(
+            &self,
+            number_of_nearby_tributes,
+            &environment_details.available_destinations,
+            rng,
+        );
 
         let closed_areas = environment_details.closed_areas;
 
@@ -2289,6 +2294,7 @@ mod tests {
             is_day: true,
             area_details: &mut cornucopia,
             closed_areas: &[],
+            available_destinations: vec![],
         };
         let encounter_context = EncounterContext {
             nearby_tributes_count: 1,
@@ -2323,6 +2329,7 @@ mod tests {
             is_day: true,
             area_details: &mut cornucopia,
             closed_areas: &[],
+            available_destinations: vec![],
         };
         let encounter_context = EncounterContext {
             nearby_tributes_count: 1,

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -833,8 +833,38 @@ impl Tribute {
                 };
 
                 match travel_result {
-                    TravelResult::Success(area) => {
-                        self.area = area;
+                    TravelResult::Success(destination) => {
+                        // Find destination info from available_destinations
+                        let dest_info = environment_details
+                            .available_destinations
+                            .iter()
+                            .find(|d| d.area == destination);
+
+                        match dest_info {
+                            Some(info) => {
+                                // Check if tribute has enough stamina
+                                if self.stamina >= info.stamina_cost {
+                                    // Move and deduct stamina
+                                    self.area = destination;
+                                    self.stamina = self.stamina.saturating_sub(info.stamina_cost);
+                                } else {
+                                    // Insufficient stamina - exhausted
+                                    self.short_rests();
+                                    self.try_log_action(
+                                        GameOutput::TributeTravelExhausted(
+                                            self.name.as_str(),
+                                            &self.area.to_string(),
+                                        ),
+                                        "too exhausted to move",
+                                    );
+                                }
+                            }
+                            None => {
+                                // Destination not in available_destinations (shouldn't happen)
+                                // This means travels() returned non-adjacent area or adjacency check failed
+                                self.short_rests();
+                            }
+                        }
                     }
                     TravelResult::Failure => {
                         self.short_rests();

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -81,6 +81,7 @@ pub struct EnvironmentContext<'a> {
     pub is_day: bool,
     pub area_details: &'a mut AreaDetails,
     pub closed_areas: &'a [Area],
+    pub available_destinations: Vec<crate::areas::DestinationInfo>,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary

Implements proper movement validation with:
- Ring topology adjacency enforcement (4 areas + cornucopia center)
- Pre-movement stamina checking (blocks movement if insufficient)
- Terrain-aware AI destination selection
- Tributes receive full destination info (terrain, events, stamina cost) before deciding

## Changes

### Destination Information (`game/src/areas/mod.rs`)
- Add `DestinationInfo` struct with area, terrain, active_events, stamina_cost
- Build available destinations in game loop from `Area::neighbors()`
- Calculate stamina cost per destination using existing `calculate_stamina_cost()`

### Movement Validation (`game/src/tributes/mod.rs`)
- Check stamina BEFORE movement in `Action::Move` handler
- Look up destination in `available_destinations` to get stamina cost
- Block movement and rest instead if stamina < cost
- Deduct stamina immediately on successful movement
- Add `GameOutput::TributeTravelExhausted` for blocked moves

### AI Terrain Awareness (`game/src/tributes/brains.rs`)
- Update `Brain::act()` to accept `available_destinations`
- When AI decides to move, choose destination using terrain scoring
- Score factors: affinity (+20), harshness penalty, visibility, items
- Check stamina before committing to destination
- Fall back to rest if no affordable destination

## Testing
- All existing tests pass (367 tests)
- Tests updated to pass empty destinations list
- Flaky test (process_status::case_06) is pre-existing, passes single-threaded

## Fixes
This PR fixes the limitation noted in #75 where stamina deduction happened AFTER movement. Now tributes check stamina BEFORE moving and are blocked if they lack the stamina to reach their destination.