### PR TITLE
feat: Tribute avatar file upload system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ name = "api"
 version = "0.1.15"
 dependencies = [
  "announcers",
+ "async-trait",
  "axum",
  "axum-test",
  "base64-url",
@@ -450,6 +451,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -2724,6 +2726,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -6416,9 +6424,18 @@ checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2024"
 
 [dependencies]
 announcers = { path = "../announcers" }
-axum = { version = "0.8.4", features = ["macros"] }
+async-trait = "0.1"
+axum = { version = "0.8.4", features = ["macros", "multipart"] }
 base64-url = "3.0.0"
 chrono = { version = "0.4.41", features = ["serde"] }
 futures = "0.3.31"
@@ -20,7 +21,7 @@ surrealdb-migrations = "2.2.2"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full"] }
 tokio-cron-scheduler = "0.13.0"
-tower-http = { version = "0.6.4", features = ["trace", "cors"] }
+tower-http = { version = "0.6.4", features = ["trace", "cors", "fs"] }
 tower = { version = "0.5.2", features = ["util", "timeout"] }
 tower_governor = "0.8"
 tracing = "0.1.41"

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -11,12 +11,14 @@ pub mod auth;
 pub mod cleanup;
 pub mod games;
 // pub mod messages; // TODO: Module file missing
+pub mod storage;
 pub mod tributes;
 pub mod users;
 
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<Surreal<Any>>,
+    pub storage: Arc<dyn storage::StorageBackend>,
 }
 
 #[derive(Debug, Error)]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -193,7 +193,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .ok_or("Failed to build GovernorConfig")?,
     );
 
-    let app_state = AppState { db: db.clone() };
+    // Initialize storage backend
+    use api::storage::{LocalStorage, StorageBackend};
+    let storage_path = env::var("STORAGE_PATH").unwrap_or_else(|_| "uploads".to_string());
+    let storage = Arc::new(LocalStorage::new(&storage_path, "/uploads"));
+    storage.init().await?;
+    tracing::info!("Storage initialized at: {}", storage_path);
+
+    let app_state = AppState {
+        db: db.clone(),
+        storage,
+    };
 
     // Start cleanup scheduler for refresh tokens
     let _cleanup_scheduler = start_cleanup_scheduler(app_state.clone())
@@ -214,6 +224,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let router = Router::new()
         .nest("/api", api_routes)
+        .nest_service(
+            "/uploads",
+            tower_http::services::ServeDir::new(&storage_path),
+        )
         .route(
             "/",
             axum::routing::get(move || async { Json(env!("CARGO_PKG_VERSION")) }),

--- a/api/src/storage.rs
+++ b/api/src/storage.rs
@@ -1,0 +1,224 @@
+use crate::AppError;
+use std::path::{Path, PathBuf};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+/// File validation constraints
+pub struct UploadConstraints {
+    pub max_size_bytes: usize,
+    pub allowed_extensions: Vec<String>,
+    pub max_width: Option<u32>,
+    pub max_height: Option<u32>,
+}
+
+impl Default for UploadConstraints {
+    fn default() -> Self {
+        Self {
+            max_size_bytes: 5 * 1024 * 1024, // 5MB
+            allowed_extensions: vec![
+                "jpg".to_string(),
+                "jpeg".to_string(),
+                "png".to_string(),
+                "webp".to_string(),
+            ],
+            max_width: Some(1024),
+            max_height: Some(1024),
+        }
+    }
+}
+
+/// Storage backend trait - allows swapping between local filesystem and S3/MinIO
+#[async_trait::async_trait]
+pub trait StorageBackend: Send + Sync {
+    /// Save a file and return its public URL path
+    async fn save(&self, path: &str, data: &[u8]) -> Result<String, AppError>;
+
+    /// Delete a file
+    async fn delete(&self, path: &str) -> Result<(), AppError>;
+
+    /// Check if a file exists
+    async fn exists(&self, path: &str) -> Result<bool, AppError>;
+
+    /// Get the public URL for accessing the file
+    fn public_url(&self, path: &str) -> String;
+}
+
+/// Local filesystem storage implementation
+pub struct LocalStorage {
+    base_path: PathBuf,
+    public_prefix: String,
+}
+
+impl LocalStorage {
+    pub fn new(base_path: impl AsRef<Path>, public_prefix: impl Into<String>) -> Self {
+        Self {
+            base_path: base_path.as_ref().to_path_buf(),
+            public_prefix: public_prefix.into(),
+        }
+    }
+
+    /// Ensure the storage directory exists
+    pub async fn init(&self) -> Result<(), AppError> {
+        fs::create_dir_all(&self.base_path).await.map_err(|e| {
+            AppError::InternalServerError(format!("Failed to create storage directory: {}", e))
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageBackend for LocalStorage {
+    async fn save(&self, path: &str, data: &[u8]) -> Result<String, AppError> {
+        let file_path = self.base_path.join(path);
+
+        // Ensure parent directory exists
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent).await.map_err(|e| {
+                AppError::InternalServerError(format!("Failed to create directory: {}", e))
+            })?;
+        }
+
+        // Write file
+        let mut file = fs::File::create(&file_path)
+            .await
+            .map_err(|e| AppError::InternalServerError(format!("Failed to create file: {}", e)))?;
+
+        file.write_all(data)
+            .await
+            .map_err(|e| AppError::InternalServerError(format!("Failed to write file: {}", e)))?;
+
+        Ok(path.to_string())
+    }
+
+    async fn delete(&self, path: &str) -> Result<(), AppError> {
+        let file_path = self.base_path.join(path);
+
+        if file_path.exists() {
+            fs::remove_file(&file_path).await.map_err(|e| {
+                AppError::InternalServerError(format!("Failed to delete file: {}", e))
+            })?;
+        }
+
+        Ok(())
+    }
+
+    async fn exists(&self, path: &str) -> Result<bool, AppError> {
+        let file_path = self.base_path.join(path);
+        Ok(file_path.exists())
+    }
+
+    fn public_url(&self, path: &str) -> String {
+        format!("{}/{}", self.public_prefix, path)
+    }
+}
+
+/// Validate uploaded file data
+pub fn validate_upload(
+    data: &[u8],
+    filename: &str,
+    constraints: &UploadConstraints,
+) -> Result<(), AppError> {
+    // Check size
+    if data.len() > constraints.max_size_bytes {
+        return Err(AppError::ValidationError(format!(
+            "File size {} bytes exceeds maximum {} bytes",
+            data.len(),
+            constraints.max_size_bytes
+        )));
+    }
+
+    // Check extension
+    let ext = Path::new(filename)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .ok_or_else(|| AppError::ValidationError("File has no extension".to_string()))?;
+
+    if !constraints.allowed_extensions.contains(&ext) {
+        return Err(AppError::ValidationError(format!(
+            "File extension '{}' not allowed. Allowed: {}",
+            ext,
+            constraints.allowed_extensions.join(", ")
+        )));
+    }
+
+    // Basic image format validation (magic bytes)
+    validate_image_format(data, &ext)?;
+
+    Ok(())
+}
+
+/// Validate image file format by checking magic bytes
+fn validate_image_format(data: &[u8], expected_ext: &str) -> Result<(), AppError> {
+    if data.len() < 12 {
+        return Err(AppError::ValidationError(
+            "File too small to be valid image".to_string(),
+        ));
+    }
+
+    let is_valid = match expected_ext {
+        "jpg" | "jpeg" => data.starts_with(&[0xFF, 0xD8, 0xFF]),
+        "png" => data.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
+        "webp" => data.starts_with(b"RIFF") && data[8..12] == *b"WEBP",
+        _ => {
+            return Err(AppError::ValidationError(format!(
+                "Unknown image format: {}",
+                expected_ext
+            )));
+        }
+    };
+
+    if !is_valid {
+        return Err(AppError::ValidationError(format!(
+            "File content does not match {} format",
+            expected_ext
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_jpeg_magic_bytes() {
+        let jpeg_data = vec![
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+        ];
+        assert!(validate_image_format(&jpeg_data, "jpg").is_ok());
+    }
+
+    #[test]
+    fn test_validate_png_magic_bytes() {
+        let png_data = vec![
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+        ];
+        assert!(validate_image_format(&png_data, "png").is_ok());
+    }
+
+    #[test]
+    fn test_reject_invalid_magic_bytes() {
+        let invalid_data = vec![
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        assert!(validate_image_format(&invalid_data, "jpg").is_err());
+    }
+
+    #[test]
+    fn test_validate_upload_size() {
+        let constraints = UploadConstraints {
+            max_size_bytes: 100,
+            ..Default::default()
+        };
+        let large_data = vec![0xFF; 200];
+        assert!(validate_upload(&large_data, "test.jpg", &constraints).is_err());
+    }
+
+    #[test]
+    fn test_validate_upload_extension() {
+        let constraints = UploadConstraints::default();
+        let data = vec![0xFF; 50];
+        assert!(validate_upload(&data, "test.exe", &constraints).is_err());
+    }
+}

--- a/api/src/tributes.rs
+++ b/api/src/tributes.rs
@@ -1,8 +1,9 @@
 use crate::games::game_tributes;
+use crate::storage::{UploadConstraints, validate_upload};
 use crate::{AppError, AppState};
-use axum::extract::{Path, State};
+use axum::extract::{Multipart, Path, State};
 use axum::http::StatusCode;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use game::items::Item;
 use game::messages::GameMessage;
@@ -24,6 +25,7 @@ pub static TRIBUTES_ROUTER: LazyLock<Router<AppState>> = LazyLock::new(|| {
                 .delete(tribute_delete)
                 .put(tribute_update),
         )
+        .route("/{identifier}/avatar", post(upload_avatar))
         .route("/{identifier}/log", get(tribute_log))
 });
 
@@ -137,9 +139,10 @@ pub async fn tribute_update(
 
     let response = state
         .db
-        .query("UPDATE tribute SET name = $name WHERE identifier = $identifier;")
+        .query("UPDATE tribute SET name = $name, avatar = $avatar WHERE identifier = $identifier;")
         .bind(("identifier", payload.identifier.clone()))
         .bind(("name", payload.name.clone()))
+        .bind(("avatar", Some(payload.avatar.clone())))
         .await;
 
     match response {
@@ -194,4 +197,85 @@ pub async fn tribute_log(
         .take(0)
         .map_err(|e| AppError::InternalServerError(format!("Failed to take logs: {}", e)))?;
     Ok(Json(logs))
+}
+
+/// Upload avatar for a tribute
+/// Accepts multipart/form-data with a file field named "avatar"
+pub async fn upload_avatar(
+    Path((_, tribute_identifier)): Path<(Uuid, Uuid)>,
+    State(state): State<AppState>,
+    mut multipart: Multipart,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let tribute_identifier = tribute_identifier.to_string();
+
+    // Find the file field
+    let mut file_data: Option<Vec<u8>> = None;
+    let mut filename: Option<String> = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| AppError::BadRequest(format!("Failed to read multipart field: {}", e)))?
+    {
+        let field_name = field.name().unwrap_or("").to_string();
+
+        if field_name == "avatar" {
+            filename = field.file_name().map(|s| s.to_string());
+            file_data = Some(
+                field
+                    .bytes()
+                    .await
+                    .map_err(|e| AppError::BadRequest(format!("Failed to read file data: {}", e)))?
+                    .to_vec(),
+            );
+            break;
+        }
+    }
+
+    let file_data = file_data.ok_or_else(|| {
+        AppError::BadRequest("No file uploaded. Field 'avatar' required.".to_string())
+    })?;
+
+    let filename =
+        filename.ok_or_else(|| AppError::BadRequest("No filename provided".to_string()))?;
+
+    // Validate upload
+    let constraints = UploadConstraints::default();
+    validate_upload(&file_data, &filename, &constraints)?;
+
+    // Generate storage path: avatars/{tribute_id}.{extension}
+    let extension = std::path::Path::new(&filename)
+        .extension()
+        .and_then(|e| e.to_str())
+        .ok_or_else(|| AppError::ValidationError("Invalid filename".to_string()))?;
+
+    let storage_path = format!("avatars/{}.{}", tribute_identifier, extension);
+
+    // Save file
+    let saved_path = state.storage.save(&storage_path, &file_data).await?;
+    let public_url = state.storage.public_url(&saved_path);
+
+    // Update tribute avatar field in database
+    let response = state
+        .db
+        .query("UPDATE tribute SET avatar = $avatar WHERE identifier = $identifier;")
+        .bind(("identifier", tribute_identifier.clone()))
+        .bind(("avatar", Some(saved_path.clone())))
+        .await;
+
+    match response {
+        Ok(mut response) => match response.take::<Option<Tribute>>(0).unwrap() {
+            Some(_) => Ok(Json(serde_json::json!({
+                "url": public_url,
+                "path": saved_path
+            }))),
+            None => Err(AppError::InternalServerError(
+                "Failed to update tribute avatar".into(),
+            )),
+        },
+        Err(e) => Err(AppError::InternalServerError(format!(
+            "Failed to update tribute: {}",
+            e
+        ))),
+    }
 }

--- a/web/src/components/tribute_edit.rs
+++ b/web/src/components/tribute_edit.rs
@@ -113,6 +113,10 @@ pub fn EditTributeForm() -> Element {
     let name = tribute_details.1.clone();
     let avatar = tribute_details.2.clone();
     let game_identifier = tribute_details.3.clone();
+    let identifier = tribute_details.0.clone();
+
+    let mut avatar_preview = use_signal(|| avatar.clone());
+    let mut upload_status = use_signal(|| String::new());
 
     let mutate = use_mutation(edit_tribute);
 
@@ -130,7 +134,7 @@ pub fn EditTributeForm() -> Element {
             .clone()
             .expect("No details provided");
         let identifier = tribute_details.0.clone();
-        let avatar = tribute_details.2.clone();
+        let current_avatar = avatar_preview.read().clone();
 
         let data = e.data().values();
         let name = data.get("name").expect("No name value").0[0].clone();
@@ -139,7 +143,7 @@ pub fn EditTributeForm() -> Element {
             let edit_tribute = EditTribute(
                 identifier.clone(),
                 name.clone(),
-                avatar.clone(),
+                current_avatar,
                 game_identifier.clone(),
             );
             spawn(async move {
@@ -159,6 +163,60 @@ pub fn EditTributeForm() -> Element {
                 }
             });
         }
+    };
+
+    let upload_avatar = move |e: Event<FormData>| {
+        let token = storage.get().jwt.expect("No JWT found");
+        let game_id = game_identifier.clone();
+        let tribute_id = identifier.clone();
+
+        upload_status.set("Uploading...".to_string());
+
+        spawn(async move {
+            let files = e.files();
+
+            if let Some(file_engine) = files {
+                if let Some(file_name) = file_engine.files().into_iter().next() {
+                    if let Some(file_data) = file_engine.read_file(&file_name).await {
+                        // Upload file using multipart/form-data
+                        let client = reqwest::Client::new();
+                        let url = format!(
+                            "{}/api/games/{}/tributes/{}/avatar",
+                            APP_API_HOST, game_id, tribute_id
+                        );
+
+                        let part =
+                            reqwest::multipart::Part::bytes(file_data).file_name(file_name.clone());
+
+                        let form = reqwest::multipart::Form::new().part("avatar", part);
+
+                        let response = client
+                            .post(&url)
+                            .bearer_auth(token)
+                            .multipart(form)
+                            .send()
+                            .await;
+
+                        match response {
+                            Ok(resp) if resp.status().is_success() => {
+                                if let Ok(json) = resp.json::<serde_json::Value>().await {
+                                    if let Some(url) = json.get("url").and_then(|v| v.as_str()) {
+                                        avatar_preview.set(url.to_string());
+                                        upload_status.set("Upload successful!".to_string());
+                                    }
+                                }
+                            }
+                            Ok(resp) => {
+                                upload_status.set(format!("Upload failed: {}", resp.status()));
+                            }
+                            Err(e) => {
+                                upload_status.set(format!("Upload error: {}", e));
+                            }
+                        }
+                    }
+                }
+            }
+        });
     };
 
     rsx! {
@@ -191,17 +249,45 @@ pub fn EditTributeForm() -> Element {
                         value: name,
                     }
                 }
-                label {
-                    "Avatar",
+            }
 
-                    Input {
-                        class: "border ml-2 px-2 py-1",
-                        r#type: "url",
+            div {
+                label {
+                    class: "block mb-2",
+                    "Avatar"
+                }
+
+                // Show current avatar if exists
+                if !avatar_preview.read().is_empty() {
+                    img {
+                        class: "w-32 h-32 object-cover rounded mb-2",
+                        src: "{avatar_preview}",
+                        alt: "Tribute avatar"
+                    }
+                }
+
+                // File upload form
+                form {
+                    class: "mb-2",
+                    onchange: upload_avatar,
+                    prevent_default: "onsubmit",
+
+                    input {
+                        r#type: "file",
                         name: "avatar",
-                        value: avatar.clone(),
+                        accept: "image/jpeg,image/png,image/webp",
+                        class: "border px-2 py-1"
+                    }
+                }
+
+                if !upload_status.read().is_empty() {
+                    p {
+                        class: "text-sm italic",
+                        "{upload_status}"
                     }
                 }
             }
+
             div {
                 class: "flex justify-end gap-2",
                 Button {


### PR DESCRIPTION
## Summary

Implements complete file upload infrastructure for tribute avatars with:
- **Backend**: Storage abstraction, local filesystem implementation, multipart upload endpoint
- **Frontend**: File upload UI with image preview and status feedback
- **Validation**: File size (5MB), format (JPEG/PNG/WebP), magic byte verification

## Changes

### Backend (API)

**New Storage Module** (`api/src/storage.rs`):
- `StorageBackend` trait for pluggable storage (local filesystem today, S3/MinIO tomorrow)
- `LocalStorage` implementation with async file operations
- `UploadConstraints` with configurable limits
- Magic byte validation for image formats
- **Future-proof**: Easy to add MinIO/S3 backend by implementing the trait

**File Upload Endpoint** (`api/src/tributes.rs`):
- `POST /api/games/{game}/tributes/{id}/avatar` - multipart/form-data upload
- Validates file format, size, and content
- Stores to `uploads/avatars/{tribute_id}.{ext}`
- Updates database with avatar path
- Returns public URL for immediate use

**Static File Serving** (`api/src/main.rs`):
- Added `/uploads/*` route serving files from `STORAGE_PATH` env var
- CORS-enabled for cross-origin image loading

**Bug Fix**:
- `tribute_update` now actually saves the `avatar` field (was previously ignored)

### Frontend (Web)

**Enhanced Edit Form** (`web/src/components/tribute_edit.rs`):
- Replaced URL input with file upload
- Accept only image/* MIME types (JPEG, PNG, WebP)
- Real-time avatar preview (shows current or newly uploaded image)
- Upload on file selection with progress status
- Multipart/form-data upload using reqwest

**User Experience**:
- Immediate visual feedback on upload success/failure
- Preview updates without page refresh
- Upload status messages (Uploading... → Success/Error)

## Configuration

**Environment Variables**:
STORAGE_PATH=uploads  # Where to store uploaded files (default: "uploads")

## Migration Path to MinIO

When ready to add MinIO:
1. Implement MinioStorage struct implementing StorageBackend trait
2. Add s3 dependency to api/Cargo.toml
3. Update main.rs to instantiate MinioStorage based on env var
4. No changes needed to upload endpoint or frontend!

Closes hangrier_games-606