### PR TITLE
Fix RNG determinism - pass RNG to survival_check

### DIFF
--- a/game/src/areas/events.rs
+++ b/game/src/areas/events.rs
@@ -277,6 +277,7 @@ impl AreaEvent {
     /// * `has_item_bonus` - Whether tribute has relevant protective item (+2 bonus)
     /// * `is_desperate` - Whether tribute is in desperate state (health < 30%, +5 bonus)
     /// * `current_health` - Tribute's current health for desperation rewards
+    /// * `rng` - Random number generator for deterministic simulation
     ///
     /// # Returns
     /// SurvivalResult containing survival status and any rewards
@@ -287,8 +288,8 @@ impl AreaEvent {
         has_item_bonus: bool,
         is_desperate: bool,
         current_health: u32,
+        rng: &mut impl Rng,
     ) -> SurvivalResult {
-        let mut rng = SmallRng::from_rng(&mut rand::rng());
         let severity = self.severity_in_terrain(terrain);
 
         // Base survival DC by severity

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -263,7 +263,7 @@ impl Game {
     }
 
     /// Process survival checks for all tributes in an area when an event occurs
-    pub fn process_event_for_area(&mut self, area: &Area, event: &AreaEvent) {
+    pub fn process_event_for_area(&mut self, area: &Area, event: &AreaEvent, rng: &mut impl Rng) {
         // Get area terrain and events
         let (terrain, area_events) = {
             let area_idx = self
@@ -329,6 +329,7 @@ impl Game {
                 has_item_bonus,
                 is_desperate,
                 current_health,
+                rng,
             );
 
             // Apply results
@@ -489,7 +490,7 @@ impl Game {
 
         // Process survival checks for all triggered events
         for (area, event) in events_to_process {
-            self.process_event_for_area(&area, &event);
+            self.process_event_for_area(&area, &event, rng);
         }
 
         // Day 3 is Feast Day, refill the Cornucopia with a random assortment of items

--- a/game/tests/event_severity_test.rs
+++ b/game/tests/event_severity_test.rs
@@ -1,5 +1,7 @@
 use game::areas::events::{AreaEvent, EventSeverity};
 use game::terrain::BaseTerrain;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
 use rstest::rstest;
 
 // Test EventSeverity ordering
@@ -144,10 +146,13 @@ fn test_rockslide_severity(#[case] terrain: BaseTerrain, #[case] expected: Event
 fn test_survival_check_with_affinity() {
     let event = AreaEvent::Wildfire;
     let terrain = BaseTerrain::Forest;
+    let mut rng = SmallRng::seed_from_u64(42);
 
     // With affinity, survival should be easier
-    let result_with_affinity = event.survival_check(&terrain, true, false, false, 100);
-    let result_without_affinity = event.survival_check(&terrain, false, false, false, 100);
+    let result_with_affinity = event.survival_check(&terrain, true, false, false, 100, &mut rng);
+    let mut rng2 = SmallRng::seed_from_u64(42);
+    let result_without_affinity =
+        event.survival_check(&terrain, false, false, false, 100, &mut rng2);
 
     // Both should succeed or fail, but we can't deterministically test randomness
     // Just verify the function runs without panic
@@ -160,10 +165,12 @@ fn test_survival_check_with_affinity() {
 fn test_survival_check_with_item_bonus() {
     let event = AreaEvent::Blizzard;
     let terrain = BaseTerrain::Tundra;
+    let mut rng = SmallRng::seed_from_u64(42);
 
     // With item bonus, survival should be easier
-    let result_with_item = event.survival_check(&terrain, false, true, false, 100);
-    let result_without_item = event.survival_check(&terrain, false, false, false, 100);
+    let result_with_item = event.survival_check(&terrain, false, true, false, 100, &mut rng);
+    let mut rng2 = SmallRng::seed_from_u64(42);
+    let result_without_item = event.survival_check(&terrain, false, false, false, 100, &mut rng2);
 
     // Just verify the function runs
     assert!(result_with_item.survived || !result_with_item.survived);
@@ -175,10 +182,12 @@ fn test_survival_check_with_item_bonus() {
 fn test_survival_check_with_desperation() {
     let event = AreaEvent::Earthquake;
     let terrain = BaseTerrain::Mountains;
+    let mut rng = SmallRng::seed_from_u64(42);
 
     // With desperation, survival should be easier
-    let result_desperate = event.survival_check(&terrain, false, false, true, 10);
-    let result_normal = event.survival_check(&terrain, false, false, false, 100);
+    let result_desperate = event.survival_check(&terrain, false, false, true, 10, &mut rng);
+    let mut rng2 = SmallRng::seed_from_u64(42);
+    let result_normal = event.survival_check(&terrain, false, false, false, 100, &mut rng2);
 
     // Just verify the function runs
     assert!(result_desperate.survived || !result_desperate.survived);
@@ -190,8 +199,9 @@ fn test_survival_check_with_desperation() {
 fn test_survival_result_structure() {
     let event = AreaEvent::Wildfire;
     let terrain = BaseTerrain::Forest;
+    let mut rng = SmallRng::seed_from_u64(42);
 
-    let result = event.survival_check(&terrain, false, false, false, 100);
+    let result = event.survival_check(&terrain, false, false, false, 100, &mut rng);
 
     // Verify result has expected fields
     if result.survived {
@@ -217,8 +227,9 @@ fn test_catastrophic_instant_death_probability() {
     let mut instant_deaths = 0;
     let trials = 1000;
 
-    for _ in 0..trials {
-        let result = event.survival_check(&terrain, false, false, false, 100);
+    for i in 0..trials {
+        let mut rng = SmallRng::seed_from_u64(i);
+        let result = event.survival_check(&terrain, false, false, false, 100, &mut rng);
         if !result.survived && result.instant_death {
             instant_deaths += 1;
         }
@@ -226,7 +237,7 @@ fn test_catastrophic_instant_death_probability() {
 
     let death_rate = instant_deaths as f32 / trials as f32;
 
-    // Should be around 5% (allow 2-8% range for randomness)
+    // Should be around 5% (allow 2-10% range for randomness)
     assert!(
         death_rate >= 0.02 && death_rate <= 0.10,
         "Instant death rate {} outside expected range",
@@ -246,8 +257,9 @@ fn test_desperation_rewards_distribution() {
     let mut no_rewards = 0;
     let trials = 1000;
 
-    for _ in 0..trials {
-        let result = event.survival_check(&terrain, false, false, true, 10);
+    for i in 0..trials {
+        let mut rng = SmallRng::seed_from_u64(i);
+        let result = event.survival_check(&terrain, false, false, true, 10, &mut rng);
         if result.survived {
             if result.stamina_restored > 0 {
                 stamina_rewards += 1;
@@ -270,7 +282,7 @@ fn test_desperation_rewards_distribution() {
         let item_pct = item_rewards as f32 / total;
         let none_pct = no_rewards as f32 / total;
 
-        // Rough validation (allow 25-60% for stamina/sanity, 0-20% for item, 0-15% for none)
+        // Rough validation (allow 25-60% for stamina/sanity, 0-25% for item, 0-15% for none)
         assert!(stamina_pct >= 0.25 && stamina_pct <= 0.60);
         assert!(sanity_pct >= 0.25 && sanity_pct <= 0.60);
         assert!(item_pct >= 0.0 && item_pct <= 0.25);


### PR DESCRIPTION
Fixes regression where survival_check() created new RNG internally, breaking deterministic replay.

## Changes
- Updated survival_check() signature to accept rng: &mut impl Rng parameter
- Removed internal SmallRng::from_rng creation
- Updated all callers in games.rs and test files

## Impact
- Enables deterministic replay with seeded RNGs
- Aligns with existing RNG threading pattern
- Fixes P0 architectural guarantee

Closes hangrier_games-c39