### PR TITLE
Refactor GLOBAL_MESSAGES to per-game message queues

### DIFF
--- a/game/src/messages.rs
+++ b/game/src/messages.rs
@@ -1,8 +1,5 @@
 use chrono::{DateTime, Utc};
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::collections::VecDeque;
-use std::sync::Mutex;
 use uuid::Uuid;
 
 use crate::terrain::{BaseTerrain, Harshness, Visibility};
@@ -29,91 +26,18 @@ pub struct GameMessage {
     pub content: String,
 }
 
-pub static GLOBAL_MESSAGES: Lazy<Mutex<VecDeque<GameMessage>>> =
-    Lazy::new(|| Mutex::new(VecDeque::new()));
-
-pub fn add_message(
-    source: MessageSource,
-    game_day: u32,
-    subject: String,
-    content: String,
-) -> Result<(), String> {
-    let message = GameMessage {
-        identifier: Uuid::new_v4().to_string(),
-        source,
-        game_day,
-        subject,
-        timestamp: Utc::now(),
-        content,
-    };
-
-    GLOBAL_MESSAGES
-        .lock()
-        .map_err(|e| e.to_string())?
-        .push_back(message);
-
-    Ok(())
-}
-
-pub fn add_game_message(game_id: &str, content: String) -> Result<(), String> {
-    add_message(
-        MessageSource::Game(game_id.to_string()),
-        0,
-        game_id.to_string(),
-        content,
-    )
-}
-
-pub fn add_area_message(area_name: &str, game_id: &str, content: String) -> Result<(), String> {
-    add_message(
-        MessageSource::Area(area_name.to_string()),
-        0,
-        format!("{game_id}:{area_name}"),
-        content,
-    )
-}
-
-pub fn add_tribute_message(tribute_id: &str, game_id: &str, content: String) -> Result<(), String> {
-    add_message(
-        MessageSource::Tribute(tribute_id.to_string()),
-        0,
-        format!("{game_id}:{tribute_id}"),
-        content,
-    )
-}
-
-pub fn get_all_messages() -> Result<Vec<GameMessage>, String> {
-    Ok(GLOBAL_MESSAGES
-        .lock()
-        .map_err(|e| e.to_string())?
-        .iter()
-        .cloned()
-        .collect())
-}
-
-pub fn get_messages_by_source(source: &MessageSource) -> Result<Vec<GameMessage>, String> {
-    Ok(GLOBAL_MESSAGES
-        .lock()
-        .map_err(|e| e.to_string())?
-        .iter()
-        .filter(|msg| msg.source == *source)
-        .cloned()
-        .collect())
-}
-
-pub fn get_messages_by_day(day: u32) -> Result<Vec<GameMessage>, String> {
-    Ok(GLOBAL_MESSAGES
-        .lock()
-        .map_err(|e| e.to_string())?
-        .iter()
-        .filter(|msg| msg.game_day == day)
-        .cloned()
-        .collect())
-}
-
-pub fn clear_messages() -> Result<(), String> {
-    GLOBAL_MESSAGES.lock().map_err(|e| e.to_string())?.clear();
-    Ok(())
+impl GameMessage {
+    /// Create a new game message
+    pub fn new(source: MessageSource, game_day: u32, subject: String, content: String) -> Self {
+        GameMessage {
+            identifier: Uuid::new_v4().to_string(),
+            source,
+            game_day,
+            subject,
+            timestamp: Utc::now(),
+            content,
+        }
+    }
 }
 
 /// Generate terrain-aware movement narrative.


### PR DESCRIPTION
Eliminates global mutable state for true functional purity.

## Changes
- Replaced GLOBAL_MESSAGES with CycleResult return type
- run_day_night_cycle() now returns messages instead of posting globally
- All cycle functions collect and return messages
- Removed 8 global message functions from messages.rs
- Updated API to use returned messages

## Benefits
- Enables parallel game execution
- True stateless game engine
- Simplified testing (no global state cleanup)
- Thread-safe (no mutex contention)
- Clear data flow: game → messages → API → database

## Impact
- Architecture: Global state → Pure functional
- Concurrency: Sequential only → Parallel capable
- Testing: Requires cleanup → Isolated by default

Closes hangrier_games-744