### PR TITLE
feat: Add seeded threshold variance and psychotic break system

### DIFF
--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -16,6 +16,28 @@ pub enum BrainPersonality {
     Reckless,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum PsychoticBreakType {
+    Berserk,         // Attack anyone nearby
+    Paranoid,        // Flee and hide constantly
+    Catatonic,       // Skip turns (Action::None)
+    SelfDestructive, // Seek danger, ignore health
+}
+
+/// Cached personality thresholds generated at tribute creation with individual variance
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PersonalityThresholds {
+    pub low_health: u32,
+    pub mid_health: u32,
+    pub extreme_low_sanity: u32,
+    pub low_sanity: u32,
+    pub mid_sanity: u32,
+    pub low_movement: u32,
+    pub high_intelligence: u32,
+    pub low_intelligence: u32,
+    pub psychotic_break_threshold: u32, // Sanity level that triggers break
+}
+
 impl BrainPersonality {
     pub fn random(rng: &mut impl Rng) -> Self {
         match rng.gen_range(0..5) {
@@ -27,6 +49,71 @@ impl BrainPersonality {
         }
     }
 
+    /// Generate thresholds with ±20% variance for individual differences
+    pub fn generate_thresholds(&self, rng: &mut impl Rng) -> PersonalityThresholds {
+        fn apply_variance(base: u32, rng: &mut impl Rng) -> u32 {
+            let variance = rng.gen_range(-0.2..=0.2);
+            ((base as f32) * (1.0 + variance)).max(1.0) as u32
+        }
+
+        // Base values per personality
+        let (base_low_health, base_mid_health) = match self {
+            BrainPersonality::Aggressive => (15, 30),
+            BrainPersonality::Defensive => (30, 50),
+            BrainPersonality::Balanced => (20, 40),
+            BrainPersonality::Cautious => (35, 55),
+            BrainPersonality::Reckless => (10, 25),
+        };
+
+        let (base_extreme_low_sanity, base_low_sanity, base_mid_sanity) = match self {
+            BrainPersonality::Aggressive => (8, 15, 25),
+            BrainPersonality::Defensive => (15, 25, 45),
+            BrainPersonality::Balanced => (10, 20, 35),
+            BrainPersonality::Cautious => (18, 30, 50),
+            BrainPersonality::Reckless => (5, 10, 20),
+        };
+
+        let base_low_movement = match self {
+            BrainPersonality::Aggressive => 8,
+            BrainPersonality::Defensive => 15,
+            BrainPersonality::Balanced => 10,
+            BrainPersonality::Cautious => 18,
+            BrainPersonality::Reckless => 5,
+        };
+
+        let (base_high_intelligence, base_low_intelligence) = match self {
+            BrainPersonality::Aggressive => (30, 75),
+            BrainPersonality::Defensive => (40, 85),
+            BrainPersonality::Balanced => (35, 80),
+            BrainPersonality::Cautious => (45, 90),
+            BrainPersonality::Reckless => (25, 70),
+        };
+
+        // Psychotic break threshold varies by personality
+        // Reckless/Aggressive more prone (higher threshold = breaks sooner)
+        // Cautious/Defensive more resilient (lower threshold = breaks later)
+        let base_break_threshold = match self {
+            BrainPersonality::Reckless => 12, // Breaks easily
+            BrainPersonality::Aggressive => 10,
+            BrainPersonality::Balanced => 8,
+            BrainPersonality::Defensive => 6,
+            BrainPersonality::Cautious => 5, // Very resilient
+        };
+
+        PersonalityThresholds {
+            low_health: apply_variance(base_low_health, rng),
+            mid_health: apply_variance(base_mid_health, rng),
+            extreme_low_sanity: apply_variance(base_extreme_low_sanity, rng),
+            low_sanity: apply_variance(base_low_sanity, rng),
+            mid_sanity: apply_variance(base_mid_sanity, rng),
+            low_movement: apply_variance(base_low_movement, rng),
+            high_intelligence: apply_variance(base_high_intelligence, rng),
+            low_intelligence: apply_variance(base_low_intelligence, rng),
+            psychotic_break_threshold: apply_variance(base_break_threshold, rng),
+        }
+    }
+
+    // Keep original methods for backward compatibility/reference
     pub fn low_health_limit(&self) -> u32 {
         match self {
             BrainPersonality::Aggressive => 15,
@@ -111,14 +198,20 @@ impl BrainPersonality {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Brain {
     pub personality: BrainPersonality,
+    pub thresholds: PersonalityThresholds,
+    pub psychotic_break: Option<PsychoticBreakType>,
     pub preferred_action: Option<Action>,
     pub preferred_action_percentage: f64,
 }
 
 impl Default for Brain {
     fn default() -> Self {
+        use rand::SeedableRng;
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(0); // Deterministic default
         Self {
             personality: BrainPersonality::Balanced,
+            thresholds: BrainPersonality::Balanced.generate_thresholds(&mut rng),
+            psychotic_break: None,
             preferred_action: None,
             preferred_action_percentage: 0.0,
         }
@@ -127,10 +220,49 @@ impl Default for Brain {
 
 impl Brain {
     pub fn new_with_random_personality(rng: &mut impl Rng) -> Self {
+        let personality = BrainPersonality::random(rng);
+        let thresholds = personality.generate_thresholds(rng);
         Self {
-            personality: BrainPersonality::random(rng),
+            personality,
+            thresholds,
+            psychotic_break: None,
             preferred_action: None,
             preferred_action_percentage: 0.0,
+        }
+    }
+
+    /// Check if tribute should have a psychotic break
+    ///
+    /// Break type is randomly determined, not tied to personality.
+    /// This allows for emergent behavior - a cautious tribute going berserk
+    /// can be just as dramatic as an aggressive one becoming catatonic.
+    pub fn check_psychotic_break(&mut self, current_sanity: u32, rng: &mut impl Rng) {
+        // Already broken, stay broken
+        if self.psychotic_break.is_some() {
+            return;
+        }
+
+        // Check if sanity dropped below threshold
+        if current_sanity <= self.thresholds.psychotic_break_threshold {
+            // Randomly select break type (equal probability)
+            let break_type = match rng.gen_range(0..4) {
+                0 => PsychoticBreakType::Berserk,
+                1 => PsychoticBreakType::Paranoid,
+                2 => PsychoticBreakType::Catatonic,
+                _ => PsychoticBreakType::SelfDestructive,
+            };
+
+            self.psychotic_break = Some(break_type);
+        }
+    }
+
+    /// Can recover from break if sanity recovers significantly
+    pub fn check_recovery(&mut self, current_sanity: u32) {
+        if self.psychotic_break.is_some() {
+            // Need to recover to 20+ sanity above break threshold to recover
+            if current_sanity >= self.thresholds.psychotic_break_threshold + 20 {
+                self.psychotic_break = None;
+            }
         }
     }
 }
@@ -156,6 +288,41 @@ impl Brain {
     ) -> Action {
         if !tribute.is_alive() {
             return Action::None;
+        }
+
+        // Psychotic break overrides normal behavior
+        if let Some(ref break_type) = self.psychotic_break {
+            return match break_type {
+                PsychoticBreakType::Berserk => {
+                    // Attack if enemies nearby, otherwise move to find enemies
+                    if nearby_tributes > 0 {
+                        Action::Attack
+                    } else {
+                        Action::Move(None)
+                    }
+                }
+                PsychoticBreakType::Paranoid => {
+                    // Always flee and hide
+                    if tribute.attributes.is_hidden {
+                        Action::None // Stay hidden
+                    } else {
+                        Action::Hide
+                    }
+                }
+                PsychoticBreakType::Catatonic => {
+                    // Do nothing
+                    Action::None
+                }
+                PsychoticBreakType::SelfDestructive => {
+                    // Seek danger: attack if enemies present, move otherwise
+                    // Ignore health completely
+                    if nearby_tributes > 0 {
+                        Action::Attack
+                    } else {
+                        Action::Move(None)
+                    }
+                }
+            };
         }
 
         // If there is a preferred action, we should take it, assuming a positive roll
@@ -349,9 +516,9 @@ impl Brain {
         tribute: &Tribute,
         is_concealed: bool,
     ) -> Action {
-        let low_health = self.personality.low_health_limit();
-        let mid_health = self.personality.mid_health_limit();
-        let low_sanity = self.personality.low_sanity_limit();
+        let low_health = self.thresholds.low_health;
+        let mid_health = self.thresholds.mid_health;
+        let low_sanity = self.thresholds.low_sanity;
 
         match tribute.attributes.health {
             h if h < low_health => {
@@ -378,9 +545,9 @@ impl Brain {
         tribute: &Tribute,
         is_concealed: bool,
     ) -> Action {
-        let low_movement = self.personality.low_movement_limit();
-        let mid_sanity = self.personality.mid_sanity_limit();
-        let extreme_low_sanity = self.personality.extreme_low_sanity_limit();
+        let low_movement = self.thresholds.low_movement;
+        let mid_sanity = self.thresholds.mid_sanity;
+        let extreme_low_sanity = self.thresholds.extreme_low_sanity;
 
         let stats = (
             tribute.attributes.movement,
@@ -406,8 +573,8 @@ impl Brain {
         tribute: &Tribute,
         is_concealed: bool,
     ) -> Action {
-        let high_intelligence = self.personality.high_intelligence_limit();
-        let low_intelligence = self.personality.low_intelligence_limit();
+        let high_intelligence = self.thresholds.high_intelligence;
+        let low_intelligence = self.thresholds.low_intelligence;
 
         let recklessness: u32 = 100_u32
             .saturating_sub(tribute.attributes.intelligence)
@@ -422,9 +589,9 @@ impl Brain {
     }
 
     fn decide_action_no_enemies(&self, tribute: &Tribute) -> Action {
-        let low_health = self.personality.low_health_limit();
-        let mid_health = self.personality.mid_health_limit();
-        let low_sanity = self.personality.low_sanity_limit();
+        let low_health = self.thresholds.low_health;
+        let mid_health = self.thresholds.mid_health;
+        let low_sanity = self.thresholds.low_sanity;
 
         match tribute.attributes.health {
             // health is low, rest
@@ -450,9 +617,9 @@ impl Brain {
     }
 
     fn decide_action_few_enemies_low_health(&self, tribute: &Tribute) -> Action {
-        let low_movement = self.personality.low_movement_limit();
-        let mid_sanity = self.personality.mid_sanity_limit();
-        let extreme_low_sanity = self.personality.extreme_low_sanity_limit();
+        let low_movement = self.thresholds.low_movement;
+        let mid_sanity = self.thresholds.mid_sanity;
+        let extreme_low_sanity = self.thresholds.extreme_low_sanity;
 
         let stats = (
             tribute.attributes.movement,
@@ -477,9 +644,9 @@ impl Brain {
     }
 
     fn decide_action_few_enemies(&self, tribute: &Tribute) -> Action {
-        let low_health = self.personality.low_health_limit();
-        let mid_health = self.personality.mid_health_limit();
-        let low_sanity = self.personality.low_sanity_limit();
+        let low_health = self.thresholds.low_health;
+        let mid_health = self.thresholds.mid_health;
+        let low_sanity = self.thresholds.low_sanity;
 
         match tribute.attributes.health {
             h if h < low_health => self.decide_action_few_enemies_low_health(tribute),
@@ -495,8 +662,8 @@ impl Brain {
     }
 
     fn decide_action_many_enemies(&self, tribute: &Tribute) -> Action {
-        let high_intelligence = self.personality.high_intelligence_limit();
-        let low_intelligence = self.personality.low_intelligence_limit();
+        let high_intelligence = self.thresholds.high_intelligence;
+        let low_intelligence = self.thresholds.low_intelligence;
 
         let recklessness: u32 = 100_u32
             .saturating_sub(tribute.attributes.intelligence)
@@ -785,5 +952,131 @@ mod tests {
         let action = tribute.brain.decide_action_few_enemies(&tribute);
         // Defensive should prefer moving/hiding at this health
         assert!(matches!(action, Action::Move(_) | Action::Hide));
+    }
+
+    #[rstest]
+    fn test_threshold_variance_within_range(mut small_rng: SmallRng) {
+        let personality = BrainPersonality::Balanced;
+        let thresholds = personality.generate_thresholds(&mut small_rng);
+
+        // Base value for Balanced is 20, variance is ±20% = 16-24
+        assert!(thresholds.low_health >= 16 && thresholds.low_health <= 24);
+        // Base value for Balanced is 40, variance is ±20% = 32-48
+        assert!(thresholds.mid_health >= 32 && thresholds.mid_health <= 48);
+    }
+
+    #[rstest]
+    fn test_threshold_variance_differs_between_tributes(mut small_rng: SmallRng) {
+        let personality = BrainPersonality::Balanced;
+        let thresholds1 = personality.generate_thresholds(&mut small_rng);
+        let thresholds2 = personality.generate_thresholds(&mut small_rng);
+
+        // With high probability, at least one threshold should differ
+        // (not guaranteed due to randomness, but very likely)
+        let differs = thresholds1.low_health != thresholds2.low_health
+            || thresholds1.mid_health != thresholds2.mid_health
+            || thresholds1.low_sanity != thresholds2.low_sanity;
+
+        // This test may occasionally fail due to random chance, but is very unlikely
+        assert!(differs);
+    }
+
+    #[rstest]
+    fn test_psychotic_break_triggers_at_low_sanity(mut small_rng: SmallRng) {
+        let mut tribute = Tribute::default();
+        tribute.attributes.sanity = 3; // Below typical break threshold
+
+        tribute
+            .brain
+            .check_psychotic_break(tribute.attributes.sanity, &mut small_rng);
+
+        assert!(tribute.brain.psychotic_break.is_some());
+    }
+
+    #[rstest]
+    fn test_psychotic_break_doesnt_trigger_at_normal_sanity(mut small_rng: SmallRng) {
+        let mut tribute = Tribute::default();
+        tribute.attributes.sanity = 50; // Well above break threshold
+
+        tribute
+            .brain
+            .check_psychotic_break(tribute.attributes.sanity, &mut small_rng);
+
+        assert!(tribute.brain.psychotic_break.is_none());
+    }
+
+    #[rstest]
+    fn test_psychotic_break_recovery(mut small_rng: SmallRng) {
+        let mut tribute = Tribute::default();
+        tribute.attributes.sanity = 3;
+
+        // Trigger break
+        tribute
+            .brain
+            .check_psychotic_break(tribute.attributes.sanity, &mut small_rng);
+        assert!(tribute.brain.psychotic_break.is_some());
+
+        // Sanity recovers significantly (needs to be 20+ above threshold)
+        tribute.attributes.sanity = 30;
+        tribute.brain.check_recovery(tribute.attributes.sanity);
+
+        assert!(tribute.brain.psychotic_break.is_none());
+    }
+
+    #[rstest]
+    fn test_psychotic_break_no_recovery_insufficient_sanity(mut small_rng: SmallRng) {
+        let mut tribute = Tribute::default();
+        tribute.attributes.sanity = 3;
+
+        // Trigger break
+        tribute
+            .brain
+            .check_psychotic_break(tribute.attributes.sanity, &mut small_rng);
+        assert!(tribute.brain.psychotic_break.is_some());
+
+        // Sanity recovers but not enough
+        tribute.attributes.sanity = 15;
+        tribute.brain.check_recovery(tribute.attributes.sanity);
+
+        // Should still be broken
+        assert!(tribute.brain.psychotic_break.is_some());
+    }
+
+    #[rstest]
+    fn test_berserk_break_attacks(mut small_rng: SmallRng) {
+        let mut tribute = Tribute::default();
+        tribute.brain.psychotic_break = Some(PsychoticBreakType::Berserk);
+
+        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
+        assert_eq!(action, Action::Attack);
+    }
+
+    #[rstest]
+    fn test_paranoid_break_hides(mut small_rng: SmallRng) {
+        let mut tribute = Tribute::default();
+        tribute.brain.psychotic_break = Some(PsychoticBreakType::Paranoid);
+
+        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
+        assert_eq!(action, Action::Hide);
+    }
+
+    #[rstest]
+    fn test_catatonic_break_does_nothing(mut small_rng: SmallRng) {
+        let mut tribute = Tribute::default();
+        tribute.brain.psychotic_break = Some(PsychoticBreakType::Catatonic);
+
+        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
+        assert_eq!(action, Action::None);
+    }
+
+    #[rstest]
+    fn test_self_destructive_break_attacks(mut small_rng: SmallRng) {
+        let mut tribute = Tribute::default();
+        tribute.brain.psychotic_break = Some(PsychoticBreakType::SelfDestructive);
+        tribute.attributes.health = 5; // Very low health - normally would rest/hide
+
+        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
+        // Self-destructive ignores health and attacks
+        assert_eq!(action, Action::Attack);
     }
 }

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -280,6 +280,11 @@ impl Tribute {
             self.misses_home();
         }
 
+        // Check for psychotic breaks or recovery (sanity-based mental state changes)
+        self.brain
+            .check_psychotic_break(self.attributes.sanity, rng);
+        self.brain.check_recovery(self.attributes.sanity);
+
         // Set a preferred action if one is suggested
         if let Some(suggestion) = action_suggestion {
             self.brain.set_preferred_action(


### PR DESCRIPTION
## Summary

Enhances the personality-based AI system with individual variance and mental health mechanics.

## Changes

### 1. Seeded Threshold Variance (±20%)
- Thresholds generated once at tribute creation with individual variance
- Cached in `PersonalityThresholds` struct (9 fields: 8 decision thresholds + psychotic_break_threshold)
- All decision methods updated to use cached values instead of personality methods
- Provides unique AI behavior per tribute while maintaining personality archetypes

### 2. Psychotic Break System
- New `PsychoticBreakType` enum: Berserk, Paranoid, Catatonic, SelfDestructive
- Triggers when sanity drops below `psychotic_break_threshold`
- Break type randomly selected (NOT personality-dependent) for emergent gameplay
- Overrides normal AI behavior in `act()` method:
  - **Berserk**: Always attacks if enemies nearby, otherwise moves to find them
  - **Paranoid**: Hides constantly, stays hidden if already concealed
  - **Catatonic**: Takes no action (Action::None)
  - **SelfDestructive**: Seeks danger, ignores health warnings
- Recovery possible if sanity rises 20+ above threshold

### 3. Integration
- `check_psychotic_break()` and `check_recovery()` called in `process_turn_phase()`
- Evaluated after sanity-affecting events (nighttime terror, status effects)

### 4. Tests
- 10 new tests covering:
  - Threshold variance ranges and uniqueness between tributes
  - Psychotic break triggering and prevention
  - Recovery mechanics
  - Behavior validation for all 4 break types

## Design Decisions

- **Decoupled break types from personality**: A cautious tribute going berserk is just as dramatic as an aggressive one becoming catatonic - creates emergent storytelling
- **Recovery threshold (20+)**: Prevents rapid cycling between broken/normal states
- **Cached thresholds**: Generated once at creation with seeded RNG for deterministic replay

## Files Changed

- `game/src/tributes/brains.rs`: Core implementation (+333 lines)
- `game/src/tributes/mod.rs`: Game loop integration (+5 lines)

## Related

- Builds on PR #95 (personality thresholds)
- Addresses user requirement for seeded variance (not recalculated per decision)
- Implements psychotic breaks as requested feature