### PR TITLE
fix(game): repair logic-test drift and seed flaky distribution tests

### DIFF
--- a/game/src/areas/events.rs
+++ b/game/src/areas/events.rs
@@ -386,6 +386,8 @@ impl AreaEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
     use rstest::rstest;
 
     #[test]
@@ -436,7 +438,7 @@ mod tests {
     fn test_desert_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Desert, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -451,7 +453,7 @@ mod tests {
     fn test_mountains_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Mountains, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -466,7 +468,7 @@ mod tests {
     fn test_wetlands_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Wetlands, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -481,7 +483,7 @@ mod tests {
     fn test_tundra_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Tundra, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -497,7 +499,9 @@ mod tests {
     fn test_forest_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        // Use a fixed seed so the distribution check is deterministic and
+        // not subject to ~0.5% tail-probability flakes from thread_rng.
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Forest, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -512,7 +516,7 @@ mod tests {
     fn test_grasslands_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Grasslands, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -528,7 +532,7 @@ mod tests {
     fn test_clearing_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Clearing, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -543,7 +547,7 @@ mod tests {
     fn test_badlands_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Badlands, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -559,7 +563,7 @@ mod tests {
     fn test_highlands_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Highlands, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -575,7 +579,7 @@ mod tests {
     fn test_jungle_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Jungle, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -591,7 +595,7 @@ mod tests {
     fn test_urbanruins_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::UrbanRuins, &mut rng);
             *counts.entry(event).or_insert(0) += 1;
@@ -607,7 +611,7 @@ mod tests {
     fn test_geothermal_generates_terrain_appropriate_events() {
         use std::collections::HashMap;
         let mut counts: HashMap<AreaEvent, u32> = HashMap::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..100 {
             let event = AreaEvent::random_for_terrain(&BaseTerrain::Geothermal, &mut rng);
             *counts.entry(event).or_insert(0) += 1;

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -1038,7 +1038,8 @@ mod tests {
         game.tributes.push(tribute2.clone());
 
         // Constrain areas
-        let mut rng = SmallRng::from_rng(&mut rand::rng());
+        // Use a fixed seed so the area-selection branch is deterministic.
+        let mut rng = SmallRng::seed_from_u64(0);
         game.constrain_areas(&mut rng);
 
         // Check if at least one area is closed

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -690,7 +690,16 @@ mod tests {
 
     #[fixture]
     fn tribute() -> Tribute {
-        Tribute::new("Katniss".to_string(), None, None)
+        // Build a fully-deterministic Tribute for AI tests:
+        //   - Brain::default() = Balanced personality with seed=0 thresholds
+        //     (low_health=18, mid_health=38, low_sanity=16, mid_sanity=34,
+        //     low_movement=8, high_intelligence=40, low_intelligence=91)
+        //   - Attributes::default() = maxed-out attributes
+        // Tribute::new() randomizes both, so override after construction.
+        let mut tribute = Tribute::new("Katniss".to_string(), None, None);
+        tribute.brain = Brain::default();
+        tribute.attributes = crate::tributes::Attributes::default();
+        tribute
     }
 
     #[fixture]
@@ -877,8 +886,10 @@ mod tests {
         mut tribute: Tribute,
         mut small_rng: SmallRng,
     ) {
-        tribute.attributes.intelligence = 10;
-        tribute.attributes.sanity = 10;
+        // recklessness = 100 - intelligence - sanity must reach low_intelligence
+        // threshold (~91 for Balanced after variance) for the Attack branch.
+        tribute.attributes.intelligence = 5;
+        tribute.attributes.sanity = 0;
         let action = tribute.brain.act(&tribute.clone(), 6, &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
@@ -947,8 +958,16 @@ mod tests {
     fn test_defensive_retreats_earlier(mut small_rng: SmallRng) {
         let mut tribute = Tribute::default();
         tribute.brain.personality = BrainPersonality::Defensive;
-        tribute.attributes.health = 25; // Above balanced limit but below defensive
-        tribute.attributes.sanity = 40;
+        // Regenerate thresholds for the new personality (otherwise stale
+        // thresholds from random construction are used). Seed=0 gives
+        // Defensive low_health ~28-32, mid_health ~45-55.
+        tribute.brain.thresholds =
+            BrainPersonality::Defensive.generate_thresholds(&mut SmallRng::seed_from_u64(0));
+        tribute.attributes.health = 25; // Below defensive low_health
+        // Sanity must be safely above Defensive mid_sanity (base 45, +20%
+        // variance ceiling = 54) so the visible/ok-sanity arm of
+        // decide_action_few_enemies_low_health returns Move, not Attack.
+        tribute.attributes.sanity = 60;
 
         let action = tribute.brain.decide_action_few_enemies(&tribute);
         // Defensive should prefer moving/hiding at this health
@@ -1009,6 +1028,9 @@ mod tests {
     #[rstest]
     fn test_psychotic_break_recovery(mut small_rng: SmallRng) {
         let mut tribute = Tribute::default();
+        // Use deterministic Brain so psychotic_break_threshold is fixed
+        // (Balanced base = 7) and the +20 recovery margin is predictable.
+        tribute.brain = Brain::default();
         tribute.attributes.sanity = 3;
 
         // Trigger break
@@ -1027,6 +1049,9 @@ mod tests {
     #[rstest]
     fn test_psychotic_break_no_recovery_insufficient_sanity(mut small_rng: SmallRng) {
         let mut tribute = Tribute::default();
+        // Deterministic Brain: Balanced psychotic_break_threshold = 7,
+        // recovery requires sanity >= 27. sanity = 15 is below that.
+        tribute.brain = Brain::default();
         tribute.attributes.sanity = 3;
 
         // Trigger break

--- a/game/src/tributes/combat.rs
+++ b/game/src/tributes/combat.rs
@@ -521,18 +521,19 @@ mod tests {
 
     #[rstest]
     fn test_critical_hit() {
-        // Use a custom RNG that returns 20 for the attack roll
+        // Use a custom RNG that always returns the high bits needed for
+        // `random_range(1..=20)` to produce 20 under rand 0.9's algorithm.
         struct CritRng;
         impl RngCore for CritRng {
             fn next_u32(&mut self) -> u32 {
-                20
+                0xF333_3334
             }
             fn next_u64(&mut self) -> u64 {
-                20
+                ((self.next_u32() as u64) << 32) | self.next_u32() as u64
             }
             fn fill_bytes(&mut self, dest: &mut [u8]) {
                 for byte in dest.iter_mut() {
-                    *byte = 20;
+                    *byte = 0xFF;
                 }
             }
         }
@@ -550,18 +551,18 @@ mod tests {
 
     #[rstest]
     fn test_critical_fumble() {
-        // Use a custom RNG that returns 1 for the attack roll
+        // Use a custom RNG that returns 0 so `random_range(1..=20)` yields 1.
         struct FumbleRng;
         impl RngCore for FumbleRng {
             fn next_u32(&mut self) -> u32 {
-                1
+                0
             }
             fn next_u64(&mut self) -> u64 {
-                1
+                0
             }
             fn fill_bytes(&mut self, dest: &mut [u8]) {
                 for byte in dest.iter_mut() {
-                    *byte = 1;
+                    *byte = 0;
                 }
             }
         }
@@ -576,7 +577,8 @@ mod tests {
 
     #[rstest]
     fn test_perfect_block() {
-        // Use a custom RNG that returns 10 for attack, 20 for defense
+        // First call (attacker roll): 0x7333_3334 → random_range(1..=20) == 10
+        // Second call (defender roll): 0xF333_3334 → random_range(1..=20) == 20
         struct BlockRng {
             call_count: std::cell::Cell<usize>,
         }
@@ -591,7 +593,7 @@ mod tests {
             fn next_u32(&mut self) -> u32 {
                 let count = self.call_count.get();
                 self.call_count.set(count + 1);
-                if count == 0 { 10 } else { 20 } // First call: 10, second: 20
+                if count == 0 { 0x7333_3334 } else { 0xF333_3334 }
             }
             fn next_u64(&mut self) -> u64 {
                 self.next_u32() as u64

--- a/game/src/tributes/inventory.rs
+++ b/game/src/tributes/inventory.rs
@@ -213,7 +213,9 @@ mod tests {
         item.quantity = 2;
         tribute.add_item(item.clone());
         assert!(tribute.use_item(&item).is_ok());
-        assert!(tribute.has_item(&item));
+        // After use, stored item has quantity=1, so equality with the
+        // original `item` (quantity=2) no longer holds. Verify directly.
+        assert_eq!(tribute.items.len(), 1);
         assert_eq!(tribute.items[0].quantity, 1);
     }
 }

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -641,7 +641,12 @@ mod tests {
         let tribute = Tribute::new("Katniss".to_string(), Some(12), None);
         assert_eq!(tribute.name, "Katniss");
         assert_eq!(tribute.district, 12);
-        assert_eq!(tribute.attributes.health, 100);
+        // Attributes::new() randomizes health in 50..=max_health.
+        assert!(
+            (50..=100).contains(&tribute.attributes.health),
+            "health {} out of range",
+            tribute.attributes.health
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

Repairs 8 logic-drift test failures and ~14 RNG-flaky tests in the `game` crate. Combines fixes for `hangrier_games-2ox` (logic drift) and `hangrier_games-krd` (flaky tests) since both stem from related test-isolation issues exposed during recent refactors.

## Root causes

1. **rand 0.9 distribution change** — `random_range(1..=20)` now uses high bits of the underlying u32, not modulo. Mock RNGs returning small ints produced `1` instead of expected values. Required new constants (`0xF333_3334`→20, `0x7333_3334`→10).
2. **Brain threshold drift** — Recent psychotic-break + defensive-retreat tuning shifted decision boundaries; several tests were asserting against the old thresholds.
3. **Unseeded `thread_rng()`** — Distribution-shape tests and `test_constrain_areas` relied on probability without a fixed seed, causing intermittent failures.

## Changes

**Logic-drift fixes (closes 2ox):**
- `tributes/mod.rs` — relax health range assertion in `tests::new`
- `tributes/inventory.rs` — correct length check in `use_item_reusable`
- `tributes/combat.rs` — update mock RNG constants for rand 0.9 high-bit selection
- `tributes/brains.rs` — `tribute()` rstest fixture uses `Brain::default()`; tune `decide_on_action_heavily_surrounded_no_sanity_and_intelligence` and `test_defensive_retreats_earlier`

**Flake fixes (closes krd):**
- `tributes/brains.rs` — `test_psychotic_break_recovery` and `..._no_recovery_insufficient_sanity` inject `Brain::default()` so they don't inherit fixture brain mutations
- `games.rs` — `test_constrain_areas` uses `SmallRng::seed_from_u64(0)`
- `areas/events.rs` — all 10 terrain-distribution tests (desert, mountains, wetlands, tundra, forest, grasslands, clearing, badlands, highlands, jungle, urbanruins, geothermal) use `SmallRng::seed_from_u64(0)`; imports hoisted to test module top

## Verification

```
cargo test --package game --lib   # 368 passed across 8 consecutive runs, 0 flakes
cargo check --workspace --exclude web   # clean
```

## Closes

- hangrier_games-2ox (logic-test drift)
- hangrier_games-krd (RNG-flaky tests)