### PR TITLE
chore: cargo fmt + cargo clippy --fix workspace cleanup

### DIFF
--- a/api/src/cleanup.rs
+++ b/api/src/cleanup.rs
@@ -67,9 +67,6 @@ pub async fn start_cleanup_scheduler(state: AppState) -> Result<JobScheduler, Ap
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
-    use surrealdb::Surreal;
-    use surrealdb::engine::any::Any;
 
     #[tokio::test]
     async fn test_cleanup_scheduler_creation() {

--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -1,4 +1,4 @@
-use crate::tributes::{TRIBUTES_ROUTER, TributeItemEdge, create_tribute};
+use crate::tributes::{TRIBUTES_ROUTER, create_tribute};
 use crate::{AppError, AppState};
 use axum::Json;
 use axum::Router;
@@ -146,7 +146,7 @@ async fn create_game_area_edge(
         WHERE original_name = '$name'
         AND <-areas<-game.identifier = '$game_id'"#,
         )
-        .bind(("name", area.clone()))
+        .bind(("name", area))
         .bind(("game_id", game_identifier_str.clone()))
         .await
         .and_then(|mut resp| resp.take(0))
@@ -156,8 +156,8 @@ async fn create_game_area_edge(
         Uuid::from_str(&identifier.to_string())
             .map_err(|e| AppError::BadRequest(format!("Invalid area UUID: {}", e)))?
     } else {
-        match create_game_area(area, &db).await {
-            Ok(game_area) => Uuid::from_str(&game_area.identifier.as_str())
+        match create_game_area(area, db).await {
+            Ok(game_area) => Uuid::from_str(game_area.identifier.as_str())
                 .map_err(|e| AppError::BadRequest(format!("Invalid game area UUID: {}", e)))?,
             Err(_) => {
                 return Err(AppError::InternalServerError(
@@ -237,14 +237,8 @@ pub async fn create_game(
     let base_item_count = payload.item_quantity.base_item_count();
 
     // Create areas concurrently with customized item count
-    let area_futures = Area::iter().map(|area| {
-        create_area(
-            game_identifier.as_str(),
-            area.clone(),
-            base_item_count,
-            &state.db,
-        )
-    });
+    let area_futures = Area::iter()
+        .map(|area| create_area(game_identifier.as_str(), area, base_item_count, &state.db));
     let area_results = futures::future::join_all(area_futures).await;
 
     if let Some(err) = area_results.into_iter().find_map(Result::err) {
@@ -265,9 +259,9 @@ pub async fn create_area(
 ) -> Result<(), AppError> {
     let game_uuid = Uuid::from_str(game_identifier)
         .map_err(|e| AppError::BadRequest(format!("Invalid game UUID: {}", e)))?;
-    if let Ok(game_area) = create_game_area_edge(area.clone(), game_uuid, &db).await {
+    if let Ok(game_area) = create_game_area_edge(area, game_uuid, db).await {
         // Create initial items for the area (terrain will be assigned by game engine)
-        let item_futures = (0..num_items).map(|_| add_item_to_area(&game_area, None, &db));
+        let item_futures = (0..num_items).map(|_| add_item_to_area(&game_area, None, db));
         let item_results = futures::future::join_all(item_futures).await;
         if let Some(err) = item_results.into_iter().find_map(Result::err) {
             return Err(AppError::InternalServerError(format!(
@@ -498,7 +492,7 @@ pub async fn game_update(
             })?;
             if let Some(game) = game {
                 Ok(Json::<Game>(game))
-            } else if let None = game {
+            } else if game.is_none() {
                 Err(AppError::NotFound("Failed to find game".into()))
             } else {
                 unreachable!()
@@ -705,7 +699,7 @@ pub async fn next_step(
             Ok(Json(Some(game)))
         }
         GameStatus::InProgress => {
-            let dead_tribute_count = get_dead_tribute_count(&state.db, &id_str).await?;
+            let dead_tribute_count = get_dead_tribute_count(&state.db, id_str).await?;
 
             if dead_tribute_count >= 24 {
                 update_game_status(&state.db, &record_id, GameStatus::Finished).await?;
@@ -1056,11 +1050,7 @@ async fn save_area_items(
         // Batch insert relations
         let mut relation_parts = Vec::new();
         for item in &items_to_update {
-            relation_parts.push(format!(
-                "RELATE {}->items->item:{}",
-                owner.to_string(),
-                item.identifier
-            ));
+            relation_parts.push(format!("RELATE {}->items->item:{}", owner, item.identifier));
         }
 
         let bulk_relations = relation_parts.join(";\n");
@@ -1176,11 +1166,7 @@ async fn save_tribute_items(
         // Batch insert relations
         let mut relation_parts = Vec::new();
         for item in &items_to_update {
-            relation_parts.push(format!(
-                "RELATE {}->owns->item:{}",
-                owner.to_string(),
-                item.identifier
-            ));
+            relation_parts.push(format!("RELATE {}->owns->item:{}", owner, item.identifier));
         }
 
         let bulk_relations = relation_parts.join(";\n");

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -194,7 +194,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Initialize storage backend
-    use api::storage::{LocalStorage, StorageBackend};
+    use api::storage::LocalStorage;
     let storage_path = env::var("STORAGE_PATH").unwrap_or_else(|_| "uploads".to_string());
     let storage = Arc::new(LocalStorage::new(&storage_path, "/uploads"));
     storage.init().await?;

--- a/game/src/areas/events.rs
+++ b/game/src/areas/events.rs
@@ -394,7 +394,7 @@ mod tests {
     fn random_area_event() {
         let mut rng = rand::thread_rng();
         let random_event = AreaEvent::random(&mut rng);
-        assert!(AreaEvent::iter().position(|a| a == random_event).is_some());
+        assert!(AreaEvent::iter().any(|a| a == random_event));
     }
 
     #[rstest]

--- a/game/src/areas/mod.rs
+++ b/game/src/areas/mod.rs
@@ -11,9 +11,21 @@ use strum_macros::EnumIter;
 use uuid::Uuid;
 
 #[derive(
-    Copy, Clone, Debug, Eq, PartialEq, EnumIter, Hash, Deserialize, Serialize, Ord, PartialOrd,
+    Copy,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    EnumIter,
+    Hash,
+    Deserialize,
+    Serialize,
+    Ord,
+    PartialOrd,
+    Default,
 )]
 pub enum Area {
+    #[default]
     Cornucopia,
     North,
     East,
@@ -36,12 +48,6 @@ impl Display for Area {
 impl PartialEq<&Area> for Area {
     fn eq(&self, other: &&Area) -> bool {
         *self == **other
-    }
-}
-
-impl Default for Area {
-    fn default() -> Self {
-        Area::Cornucopia
     }
 }
 

--- a/game/src/config.rs
+++ b/game/src/config.rs
@@ -135,7 +135,7 @@ mod tests {
         let config = GameConfig::default();
         assert_eq!(config.day_event_frequency, 0.25);
         assert_eq!(config.night_event_frequency, 0.125);
-        assert_eq!(config.instant_death_enabled, true);
+        assert!(config.instant_death_enabled);
         assert_eq!(config.catastrophic_severity_multiplier, 1.0);
     }
 
@@ -145,7 +145,7 @@ mod tests {
         config.instant_death_enabled = false;
         config.catastrophic_severity_multiplier = 0.5;
 
-        assert_eq!(config.instant_death_enabled, false);
+        assert!(!config.instant_death_enabled);
         assert_eq!(config.catastrophic_severity_multiplier, 0.5);
     }
 

--- a/game/src/districts.rs
+++ b/game/src/districts.rs
@@ -170,7 +170,7 @@ mod tests {
 
         for district in 1..=12 {
             let affinities = assign_terrain_affinity(district, &mut rng);
-            assert!(affinities.len() >= 1 && affinities.len() <= 2);
+            assert!(!affinities.is_empty() && affinities.len() <= 2);
         }
     }
 
@@ -191,7 +191,7 @@ mod tests {
         // With 1000 iterations, expect roughly 350-450 bonuses (40% ± 5%)
         let percentage = (bonus_count as f64 / iterations as f64) * 100.0;
         assert!(
-            percentage >= 35.0 && percentage <= 45.0,
+            (35.0..=45.0).contains(&percentage),
             "Expected ~40% bonus rate, got {:.1}%",
             percentage
         );

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -2,7 +2,6 @@ use crate::areas::events::AreaEvent;
 use crate::areas::{Area, AreaDetails};
 use crate::items::Item;
 use crate::items::OwnsItems;
-use crate::output::GameOutput;
 use crate::tributes::actions::Action;
 use crate::tributes::events::TributeEvent;
 use crate::tributes::statuses::TributeStatus;
@@ -306,10 +305,7 @@ impl Game {
                 .position(|a| a.area.as_ref() == Some(area));
 
             match area_idx {
-                Some(idx) => (
-                    self.areas[idx].terrain.base.clone(),
-                    self.areas[idx].events.clone(),
-                ),
+                Some(idx) => (self.areas[idx].terrain.base, self.areas[idx].events.clone()),
                 None => return Ok(()), // Area not found
             }
         };
@@ -319,7 +315,7 @@ impl Game {
             .tributes
             .iter()
             .enumerate()
-            .filter(|(_, t)| t.is_alive() && &t.area == area)
+            .filter(|(_, t)| t.is_alive() && t.area == area)
             .map(|(idx, _)| idx)
             .collect();
 
@@ -372,7 +368,7 @@ impl Game {
             if !result.survived {
                 tribute.attributes.health = 0;
 
-                let message = if result.instant_death {
+                let _message = if result.instant_death {
                     format!(
                         "{} is instantly killed by the catastrophic {}!",
                         tribute.name, most_severe_event
@@ -384,7 +380,7 @@ impl Game {
                 // Survivor - apply rewards if any
                 if result.stamina_restored > 0 {
                     tribute.stamina = tribute.stamina.saturating_add(result.stamina_restored);
-                    let message = format!(
+                    let _message = format!(
                         "{} survives the {}, recovering {} stamina",
                         tribute.name, most_severe_event, result.stamina_restored
                     );
@@ -395,7 +391,7 @@ impl Game {
                         .attributes
                         .sanity
                         .saturating_add(result.sanity_restored);
-                    let message = format!(
+                    let _message = format!(
                         "{} survives the {}, recovering {} sanity",
                         tribute.name, most_severe_event, result.sanity_restored
                     );
@@ -405,7 +401,7 @@ impl Game {
                     let item = Item::new_random_consumable();
                     let item_name = item.name.clone();
                     tribute.items.push(item);
-                    let message = format!(
+                    let _message = format!(
                         "{} survives the {} and finds a {}",
                         tribute.name, most_severe_event, item_name
                     );
@@ -441,10 +437,10 @@ impl Game {
     /// Announce events in closed areas.
     fn announce_area_events(&self) -> Result<(), GameError> {
         for area_details in &self.areas {
-            let area_name = area_details.area.clone().unwrap().to_string();
+            let _area_name = area_details.area.unwrap().to_string();
             if !area_details.is_open() {
                 for event in &area_details.events {
-                    let event_name = event.to_string();
+                    let _event_name = event.to_string();
                 }
             }
         }
@@ -453,10 +449,10 @@ impl Game {
 
     /// Ensures at least one area is open. If not, opens a random area by clearing its events.
     fn ensure_open_area(&mut self) {
-        if self.random_open_area().is_none() {
-            if let Some(area) = self.random_area() {
-                area.events.clear();
-            }
+        if self.random_open_area().is_none()
+            && let Some(area) = self.random_area()
+        {
+            area.events.clear();
         }
     }
 
@@ -478,14 +474,14 @@ impl Game {
                 if rng.random_bool(frequency) {
                     // Generate terrain-appropriate event
                     let area_event = AreaEvent::random_for_terrain(&area_details.terrain.base, rng);
-                    let area = area_details.area.clone().unwrap();
+                    let area = area_details.area.unwrap();
 
                     // Add event to area
                     area_details.events.push(area_event.clone());
 
                     // Announce event
-                    let event_name = area_event.to_string();
-                    let area_name = area.to_string();
+                    let _event_name = area_event.to_string();
+                    let _area_name = area.to_string();
 
                     // Collect for processing
                     events_to_process.push((area, area_event));
@@ -499,21 +495,21 @@ impl Game {
         }
 
         // Day 3 is Feast Day, refill the Cornucopia with a random assortment of items
-        if day && self.day == Some(3) {
-            if let Some(area_details) = self
+        if day
+            && self.day == Some(3)
+            && let Some(area_details) = self
                 .areas
                 .iter_mut()
                 .find(|ad| ad.area == Some(Area::Cornucopia))
-            {
-                for _ in 0..rng.random_range(1..=FEAST_WEAPON_COUNT) {
-                    area_details.add_item(Item::new_random_weapon());
-                }
-                for _ in 0..rng.random_range(1..=FEAST_SHIELD_COUNT) {
-                    area_details.add_item(Item::new_random_shield());
-                }
-                for _ in 0..rng.random_range(1..=FEAST_CONSUMABLE_COUNT) {
-                    area_details.add_item(Item::new_random_consumable());
-                }
+        {
+            for _ in 0..rng.random_range(1..=FEAST_WEAPON_COUNT) {
+                area_details.add_item(Item::new_random_weapon());
+            }
+            for _ in 0..rng.random_range(1..=FEAST_SHIELD_COUNT) {
+                area_details.add_item(Item::new_random_shield());
+            }
+            for _ in 0..rng.random_range(1..=FEAST_CONSUMABLE_COUNT) {
+                area_details.add_item(Item::new_random_consumable());
             }
         }
         Ok(())
@@ -530,7 +526,7 @@ impl Game {
             // If there is an open area, close it.
             if let Some(area_details) = self.random_open_area() {
                 let event = AreaEvent::random(rng);
-                let area_name = area_details.area.clone().unwrap().to_string();
+                let area_name = area_details.area.unwrap().to_string();
                 area_events.insert(area_name, (area_details.clone(), vec![event.clone()]));
             }
 
@@ -538,7 +534,7 @@ impl Game {
                 // Assuming there's still an open area.
                 if let Some(area_details) = self.random_open_area() {
                     let event = AreaEvent::random(rng);
-                    let area_name = area_details.area.clone().unwrap().to_string();
+                    let area_name = area_details.area.unwrap().to_string();
                     if area_events.get(&area_name.clone()).is_some() {
                         let mut events = area_events[&area_name].1.clone();
                         events.push(event.clone());
@@ -553,13 +549,13 @@ impl Game {
             for (area_name, (mut area_details, events)) in area_events.drain() {
                 for event in events {
                     area_details.events.push(event.clone());
-                    let event_name = event.to_string();
+                    let _event_name = event.to_string();
                     // let area_name = area_details.area.clone().unwrap().to_string();
                 }
 
                 // Update the corresponding area with the new events
                 for area in self.areas.iter_mut() {
-                    let key = area.area.clone().unwrap().to_string();
+                    let key = area.area.unwrap().to_string();
                     if key == area_name {
                         area.events = area_details.events;
                         break;
@@ -596,7 +592,7 @@ impl Game {
         let mut area_details_map = HashMap::with_capacity(self.areas.len());
         for (i, area_detail) in self.areas.iter_mut().enumerate() {
             if let Some(area) = &area_detail.area {
-                area_details_map.insert(area.clone(), i);
+                area_details_map.insert(*area, i);
             }
         }
 
@@ -604,8 +600,8 @@ impl Game {
         let mut tributes_by_area: HashMap<Area, Vec<&Tribute>> = HashMap::new();
         for tribute in &living_tributes {
             tributes_by_area
-                .entry(tribute.area.clone())
-                .or_insert_with(Vec::new)
+                .entry(tribute.area)
+                .or_default()
                 .push(tribute);
         }
 
@@ -634,12 +630,12 @@ impl Game {
                     // Find the AreaDetails for this neighbor
                     self.areas
                         .iter()
-                        .find(|ad| ad.area == Some(neighbor_area.clone()))
+                        .find(|ad| ad.area == Some(neighbor_area))
                         .map(|ad| {
                             // Calculate stamina cost to move to this area
-                            let move_action = Action::Move(Some(neighbor_area.clone()));
+                            let move_action = Action::Move(Some(neighbor_area));
                             let stamina_cost =
-                                calculate_stamina_cost(&move_action, &ad.terrain, &tribute);
+                                calculate_stamina_cost(&move_action, &ad.terrain, tribute);
 
                             crate::areas::DestinationInfo {
                                 area: neighbor_area,
@@ -719,8 +715,7 @@ impl Game {
         let closed_areas: Vec<Area> = self
             .closed_areas()
             .iter()
-            .filter(|ad| ad.area.is_some())
-            .map(|ad| ad.area.clone().unwrap())
+            .filter_map(|ad| ad.area)
             .clone()
             .collect();
         let living_tributes = self.living_tributes();
@@ -750,7 +745,7 @@ impl Game {
 
             if self.tributes[i].status == TributeStatus::RecentlyDead {
                 self.tributes[i].statistics.day_killed = self.day;
-                let tribute_area = self.tributes[i].area.clone();
+                let tribute_area = self.tributes[i].area;
 
                 if let Some(area) = self.get_area_details_mut(tribute_area) {
                     for item in tribute_items {
@@ -765,9 +760,7 @@ impl Game {
 
     /// Get a mutable reference to the area details for a given area.
     fn get_area_details_mut(&mut self, area: Area) -> Option<&mut AreaDetails> {
-        self.areas
-            .iter_mut()
-            .find(|ad| ad.area == Some(area.clone()))
+        self.areas.iter_mut().find(|ad| ad.area == Some(area))
     }
 }
 
@@ -1060,8 +1053,8 @@ mod tests {
         let closed_areas = game
             .areas
             .iter()
-            .filter(|ad| ad.area.is_some() & &!ad.is_open())
-            .map(|ad| ad.area.clone().unwrap())
+            .filter(|ad| ad.area.is_some() & !ad.is_open())
+            .map(|ad| ad.area.unwrap())
             .collect::<Vec<Area>>();
 
         // Run the tribute cycle

--- a/game/src/items/mod.rs
+++ b/game/src/items/mod.rs
@@ -59,7 +59,6 @@ impl Display for ItemRarity {
     }
 }
 
-
 #[derive(Debug, Clone, PartialEq, Error)]
 pub enum ItemError {
     #[error("Item not found")]
@@ -224,7 +223,14 @@ impl Item {
         let (min, max) = rarity.effect_range();
         let effect = rng.random_range(min..=max);
 
-        Item::new(name, ItemType::Consumable, rarity, quantity, attribute, effect)
+        Item::new(
+            name,
+            ItemType::Consumable,
+            rarity,
+            quantity,
+            attribute,
+            effect,
+        )
     }
 
     pub fn new_random_consumable() -> Item {
@@ -236,7 +242,14 @@ impl Item {
         let (min, max) = rarity.effect_range();
         let effect = rng.random_range(min..=max);
 
-        Item::new(&name, ItemType::Consumable, rarity, quantity, attribute, effect)
+        Item::new(
+            &name,
+            ItemType::Consumable,
+            rarity,
+            quantity,
+            attribute,
+            effect,
+        )
     }
 
     pub fn new_shield(name: &str) -> Item {
@@ -395,12 +408,22 @@ mod tests {
     #[test]
     fn item_to_string() {
         let item = Item::default();
-        assert_eq!(item.to_string(), "Useless health potion (Common)".to_string());
+        assert_eq!(
+            item.to_string(),
+            "Useless health potion (Common)".to_string()
+        );
     }
 
     #[test]
     fn new_item() {
-        let item = Item::new("Test item", ItemType::Weapon, ItemRarity::Rare, 1, Attribute::Defense, 10);
+        let item = Item::new(
+            "Test item",
+            ItemType::Weapon,
+            ItemRarity::Rare,
+            1,
+            Attribute::Defense,
+            10,
+        );
         assert_eq!(item.name, "Test item");
         assert_eq!(item.item_type, ItemType::Weapon);
         assert_eq!(item.rarity, ItemRarity::Rare);
@@ -498,11 +521,7 @@ mod tests {
     #[test]
     fn random_attribute() {
         let attribute = Attribute::random();
-        assert!(
-            Attribute::iter()
-                .find(|a| *a == attribute.clone())
-                .is_some()
-        );
+        assert!(Attribute::iter().any(|a| a == attribute.clone()));
     }
 
     #[rstest]
@@ -551,13 +570,15 @@ mod tests {
         // Test that random() returns valid rarities
         for _ in 0..100 {
             let rarity = ItemRarity::random();
-            assert!([
-                ItemRarity::Common,
-                ItemRarity::Uncommon,
-                ItemRarity::Rare,
-                ItemRarity::Legendary
-            ]
-            .contains(&rarity));
+            assert!(
+                [
+                    ItemRarity::Common,
+                    ItemRarity::Uncommon,
+                    ItemRarity::Rare,
+                    ItemRarity::Legendary
+                ]
+                .contains(&rarity)
+            );
         }
     }
 
@@ -583,13 +604,15 @@ mod tests {
     fn weapon_has_rarity() {
         let weapon = Item::new_weapon("Test weapon");
         // Verify rarity is set
-        assert!([
-            ItemRarity::Common,
-            ItemRarity::Uncommon,
-            ItemRarity::Rare,
-            ItemRarity::Legendary
-        ]
-        .contains(&weapon.rarity));
+        assert!(
+            [
+                ItemRarity::Common,
+                ItemRarity::Uncommon,
+                ItemRarity::Rare,
+                ItemRarity::Legendary
+            ]
+            .contains(&weapon.rarity)
+        );
     }
 
     #[test]

--- a/game/src/output.rs
+++ b/game/src/output.rs
@@ -135,11 +135,11 @@ impl<'a> Display for GameOutput<'a> {
                 write!(f, "🚶 {} moves from {} to {}", tribute, area_a, area_b)
             }
             GameOutput::TributeTakeItem(tribute, item) => {
-                let object = indefinite(&item);
+                let object = indefinite(item);
                 write!(f, "🔨 {} takes {}", tribute, object)
             }
             GameOutput::TributeCannotUseItem(tribute, item) => {
-                let object = indefinite(&item);
+                let object = indefinite(item);
                 write!(f, "❌ {} cannot use {}", tribute, object)
             }
             GameOutput::TributeUseItem(tribute, item) => {
@@ -333,7 +333,7 @@ impl<'a> Display for GameOutput<'a> {
             }
             GameOutput::AreaEvent(area_event, area) => {
                 let area_name = area.replace("The ", "");
-                let event = indefinite_capitalized(&area_event);
+                let event = indefinite_capitalized(area_event);
                 write!(f, "=== ⚠️ {} has occurred in the {} ===", event, area_name)
             }
             GameOutput::AreaClose(area) => {

--- a/game/src/terrain/assignment.rs
+++ b/game/src/terrain/assignment.rs
@@ -31,7 +31,7 @@ impl TerrainType {
 
     /// Generate random Moderate harshness terrain
     pub fn random_moderate(rng: &mut impl Rng) -> Self {
-        let moderate_terrains = vec![
+        let moderate_terrains = [
             BaseTerrain::Forest,
             BaseTerrain::Jungle,
             BaseTerrain::UrbanRuins,

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -326,10 +326,10 @@ impl Brain {
         }
 
         // If there is a preferred action, we should take it, assuming a positive roll
-        if let Some(ref preferred_action) = self.preferred_action {
-            if rng.random_bool(self.preferred_action_percentage) {
-                return preferred_action.clone();
-            }
+        if let Some(ref preferred_action) = self.preferred_action
+            && rng.random_bool(self.preferred_action_percentage)
+        {
+            return preferred_action.clone();
         }
 
         // Does the tribute have items?
@@ -360,7 +360,7 @@ impl Brain {
                     .iter()
                     .map(|dest| {
                         let mut ad = AreaDetails::default();
-                        ad.area = Some(dest.area.clone());
+                        ad.area = Some(dest.area);
                         ad.terrain = dest.terrain.clone();
                         ad.events = dest.active_events.clone();
                         ad
@@ -372,10 +372,9 @@ impl Brain {
                     // Also check if tribute has enough stamina
                     if let Some(dest_info) =
                         available_destinations.iter().find(|d| d.area == best_area)
+                        && tribute.stamina >= dest_info.stamina_cost
                     {
-                        if tribute.stamina >= dest_info.stamina_cost {
-                            return Action::Move(Some(best_area));
-                        }
+                        return Action::Move(Some(best_area));
                     }
                 }
                 // Fall back to rest if no good destination or insufficient stamina
@@ -443,7 +442,7 @@ impl Brain {
 
             if score > best_score {
                 best_score = score;
-                best_area = area_details.area.clone();
+                best_area = area_details.area;
             }
         }
 
@@ -467,10 +466,10 @@ impl Brain {
         }
 
         // Check for preferred action first
-        if let Some(ref preferred_action) = self.preferred_action {
-            if rng.random_bool(self.preferred_action_percentage) {
-                return preferred_action.clone();
-            }
+        if let Some(ref preferred_action) = self.preferred_action
+            && rng.random_bool(self.preferred_action_percentage)
+        {
+            return preferred_action.clone();
         }
 
         // Check if we have consumables
@@ -955,7 +954,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_defensive_retreats_earlier(mut small_rng: SmallRng) {
+    fn test_defensive_retreats_earlier(_small_rng: SmallRng) {
         let mut tribute = Tribute::default();
         tribute.brain.personality = BrainPersonality::Defensive;
         // Regenerate thresholds for the new personality (otherwise stale

--- a/game/src/tributes/combat.rs
+++ b/game/src/tributes/combat.rs
@@ -614,7 +614,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_critical_hit_triple_damage(mut small_rng: SmallRng) {
+    fn test_critical_hit_triple_damage(_small_rng: SmallRng) {
         let mut attacker = Tribute::new("Katniss".to_string(), None, None);
         let mut target = Tribute::new("Peeta".to_string(), None, None);
 
@@ -637,7 +637,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_fumble_self_damage(mut small_rng: SmallRng) {
+    fn test_fumble_self_damage(_small_rng: SmallRng) {
         let mut attacker = Tribute::new("Katniss".to_string(), None, None);
         attacker.attributes.health = 100;
         let initial_health = attacker.attributes.health;

--- a/game/src/tributes/lifecycle.rs
+++ b/game/src/tributes/lifecycle.rs
@@ -288,7 +288,7 @@ impl Tribute {
         if self.attributes.health == 0 {
             let killer = self.status.clone();
             self.try_log_action(
-                GameOutput::TributeDiesFromStatus(self.name.as_str(), &*killer.to_string()),
+                GameOutput::TributeDiesFromStatus(self.name.as_str(), &killer.to_string()),
                 "dies from status",
             );
             self.statistics.killed_by = Some(killer.to_string());
@@ -300,7 +300,7 @@ impl Tribute {
     /// The success of this function does not affect the outcome of the calling method.
     pub(crate) fn try_log_action(
         &self,
-        game_event_output: impl std::fmt::Display,
+        _game_event_output: impl std::fmt::Display,
         action_description: &str,
     ) {
         // Message logging removed - now handled at API level
@@ -400,7 +400,7 @@ mod tests {
         tribute.dies();
         assert_eq!(tribute.attributes.health, 0);
         assert_eq!(tribute.status, TributeStatus::Dead);
-        assert_eq!(tribute.attributes.is_hidden, false);
+        assert!(!tribute.attributes.is_hidden);
         assert_eq!(tribute.items.len(), 0);
     }
 

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -124,7 +124,7 @@ impl Tribute {
         // Assign terrain affinity and personality based on district
         let mut rng = SmallRng::from_rng(&mut rand::rng());
         let brain = Brain::new_with_random_personality(&mut rng);
-        let terrain_affinity = if district >= 1 && district <= 12 {
+        let terrain_affinity = if (1..=12).contains(&district) {
             crate::districts::assign_terrain_affinity(district as u8, &mut rng)
         } else {
             vec![]
@@ -241,7 +241,7 @@ impl Tribute {
         let area_details = &mut environment_details.area_details;
 
         // Update the tribute based on the period's events.
-        self.process_status(&area_details, rng);
+        self.process_status(area_details, rng);
 
         // Tribute died to the period's events.
         if self.status == TributeStatus::RecentlyDead || self.attributes.health == 0 {
@@ -283,7 +283,7 @@ impl Tribute {
         // Get tribute action
         let number_of_nearby_tributes = encounter_context.nearby_tributes_count;
         let action = self.brain.act(
-            &self,
+            self,
             number_of_nearby_tributes,
             &environment_details.available_destinations,
             rng,
@@ -294,7 +294,7 @@ impl Tribute {
         match &action {
             Action::Move(area) => {
                 let travel_result = match area {
-                    Some(specific_area) => self.travels(closed_areas, Some(specific_area.clone())),
+                    Some(specific_area) => self.travels(closed_areas, Some(*specific_area)),
                     None => self.travels(closed_areas, None),
                 };
 
@@ -608,8 +608,7 @@ impl Attributes {
 
 #[cfg(test)]
 mod tests {
-    use crate::areas::Area::{Cornucopia, East, North, South, West};
-    use crate::areas::AreaDetails;
+
     use crate::tributes::Tribute;
     use rand::SeedableRng;
     use rand::rngs::SmallRng;

--- a/game/src/tributes/movement.rs
+++ b/game/src/tributes/movement.rs
@@ -30,7 +30,7 @@ impl Tribute {
     ) -> TravelResult {
         let mut rng = SmallRng::from_rng(&mut rand::rng());
         // Where is the tribute?
-        let current_area = self.area.clone();
+        let current_area = self.area;
 
         // 1. Can the tribute move at all?
         if self.attributes.movement == 0 {
@@ -44,21 +44,18 @@ impl Tribute {
 
         // 2. Determine the target area based on suggestion and validity.
         let mut target_area: Option<Area> = None;
-        if let Some(suggestion) = suggested_area {
-            if !closed_areas.contains(&suggestion) {
-                if suggestion == current_area {
-                    let suggestion = suggestion.to_string();
-                    self.try_log_action(
-                        GameOutput::TributeTravelAlreadyThere(
-                            self.name.as_str(),
-                            suggestion.as_str(),
-                        ),
-                        "already there",
-                    );
-                    return TravelResult::Failure;
-                }
-                target_area = Some(suggestion);
+        if let Some(suggestion) = suggested_area
+            && !closed_areas.contains(&suggestion)
+        {
+            if suggestion == current_area {
+                let suggestion = suggestion.to_string();
+                self.try_log_action(
+                    GameOutput::TributeTravelAlreadyThere(self.name.as_str(), suggestion.as_str()),
+                    "already there",
+                );
+                return TravelResult::Failure;
             }
+            target_area = Some(suggestion);
         }
 
         // 3. Handle movement based on tribute's movement attribute.
@@ -120,7 +117,7 @@ impl Tribute {
                         ),
                         "no options",
                     );
-                    return TravelResult::Success(current_area.clone());
+                    return TravelResult::Success(current_area);
                 }
 
                 // TODO: Loyalty bit goes here
@@ -136,7 +133,7 @@ impl Tribute {
                     ),
                     "travel",
                 );
-                TravelResult::Success(chosen_neighbor.clone())
+                TravelResult::Success(*chosen_neighbor)
             }
         }
     }

--- a/game/src/witty_phrase_generator/mod.rs
+++ b/game/src/witty_phrase_generator/mod.rs
@@ -149,18 +149,9 @@ impl WPGen {
         let words_intensifiers = self
             .words_intensifiers
             .iter()
-            .map(|x| x)
             .collect::<Vec<&&'static str>>();
-        let words_adjectives = self
-            .words_adjectives
-            .iter()
-            .map(|x| x)
-            .collect::<Vec<&&'static str>>();
-        let words_nouns = self
-            .words_nouns
-            .iter()
-            .map(|x| x)
-            .collect::<Vec<&&'static str>>();
+        let words_adjectives = self.words_adjectives.iter().collect::<Vec<&&'static str>>();
+        let words_nouns = self.words_nouns.iter().collect::<Vec<&&'static str>>();
 
         // dictionary that we can recurse over
         let mut dict = [
@@ -177,7 +168,7 @@ impl WPGen {
             }
             list.retain(|s| s.len() <= word_len_max); // filter out words that are already longer than len_max; TODO: too restrictive sometimes
             list.shuffle(&mut *self.rng.borrow_mut()); // shuffle all the available words
-            list.sort_by(|a, b: &&&str| a.len().cmp(&b.len())); // sort by length (stable sort, so still shuffled) for easier length matching
+            list.sort_by_key(|a| a.len()); // sort by length (stable sort, so still shuffled) for easier length matching
         }
 
         let mut ret = vec![vec![""; words]; count];

--- a/game/tests/district_affinity_test.rs
+++ b/game/tests/district_affinity_test.rs
@@ -68,7 +68,7 @@ fn test_affinity_count() {
 
         let affinity_count = tribute.terrain_affinity.len();
         assert!(
-            affinity_count >= 1 && affinity_count <= 2,
+            (1..=2).contains(&affinity_count),
             "District {} should have 1-2 terrain affinities, got {}",
             district,
             affinity_count
@@ -96,7 +96,7 @@ fn test_bonus_affinity_probability() {
 
     // With 100 iterations, expect roughly 30-50 bonuses (40% ± 10%)
     assert!(
-        bonus_count >= 30 && bonus_count <= 50,
+        (30..=50).contains(&bonus_count),
         "Expected ~40 bonuses in 100 iterations, got {}",
         bonus_count
     );

--- a/game/tests/event_severity_test.rs
+++ b/game/tests/event_severity_test.rs
@@ -149,7 +149,8 @@ fn test_survival_check_with_affinity() {
     let mut rng = SmallRng::seed_from_u64(42);
 
     // With affinity, survival should be easier
-    let result_with_affinity = event.survival_check(&terrain, true, false, false, 100, true, 1.0, &mut rng);
+    let result_with_affinity =
+        event.survival_check(&terrain, true, false, false, 100, true, 1.0, &mut rng);
     let mut rng2 = SmallRng::seed_from_u64(42);
     let result_without_affinity =
         event.survival_check(&terrain, false, false, false, 100, true, 1.0, &mut rng2);
@@ -168,9 +169,11 @@ fn test_survival_check_with_item_bonus() {
     let mut rng = SmallRng::seed_from_u64(42);
 
     // With item bonus, survival should be easier
-    let result_with_item = event.survival_check(&terrain, false, true, false, 100, true, 1.0, &mut rng);
+    let result_with_item =
+        event.survival_check(&terrain, false, true, false, 100, true, 1.0, &mut rng);
     let mut rng2 = SmallRng::seed_from_u64(42);
-    let result_without_item = event.survival_check(&terrain, false, false, false, 100, true, 1.0, &mut rng2);
+    let result_without_item =
+        event.survival_check(&terrain, false, false, false, 100, true, 1.0, &mut rng2);
 
     // Just verify the function runs
     assert!(result_with_item.survived || !result_with_item.survived);
@@ -185,9 +188,11 @@ fn test_survival_check_with_desperation() {
     let mut rng = SmallRng::seed_from_u64(42);
 
     // With desperation, survival should be easier
-    let result_desperate = event.survival_check(&terrain, false, false, true, 10, true, 1.0, &mut rng);
+    let result_desperate =
+        event.survival_check(&terrain, false, false, true, 10, true, 1.0, &mut rng);
     let mut rng2 = SmallRng::seed_from_u64(42);
-    let result_normal = event.survival_check(&terrain, false, false, false, 100, true, 1.0, &mut rng2);
+    let result_normal =
+        event.survival_check(&terrain, false, false, false, 100, true, 1.0, &mut rng2);
 
     // Just verify the function runs
     assert!(result_desperate.survived || !result_desperate.survived);

--- a/game/tests/terrain_config_test.rs
+++ b/game/tests/terrain_config_test.rs
@@ -6,7 +6,7 @@ fn test_movement_costs_within_range() {
     for terrain in BaseTerrain::iter() {
         let cost = terrain.movement_cost();
         assert!(
-            cost >= 0.5 && cost <= 3.0,
+            (0.5..=3.0).contains(&cost),
             "Movement cost out of range for {:?}",
             terrain
         );
@@ -52,7 +52,7 @@ fn test_item_spawn_modifiers_reasonable() {
     for terrain in BaseTerrain::iter() {
         let modifier = terrain.item_spawn_modifier();
         assert!(
-            modifier >= 0.5 && modifier <= 1.5,
+            (0.5..=1.5).contains(&modifier),
             "Item modifier out of range for {:?}",
             terrain
         );

--- a/game/tests/terrain_specific_events_test.rs
+++ b/game/tests/terrain_specific_events_test.rs
@@ -23,7 +23,7 @@ fn test_game_loop_generates_terrain_appropriate_events() {
     for (area, terrain, name) in terrains {
         let area_details = AreaDetails::new_with_terrain(
             Some(name.to_string()),
-            area.clone(),
+            area,
             TerrainType::new(terrain, vec![]).unwrap(),
         );
         game.areas.push(area_details);


### PR DESCRIPTION
## Summary

Mechanical cleanup applying rustfmt and clippy --fix across the workspace. No behavior changes.

## Commands run

```
cargo fmt --all
cargo clippy --fix --workspace --exclude web --all-targets
```

## Verification

- \`cargo test --package game --lib\` — 368 passed, 0 failed
- \`cargo check --workspace --exclude web\` — clean

## Follow-up

~27 warnings remain that require manual review (unused \`Result\` values from \`check_for_winner\`, \`prepare_cycle\`, etc., and unused imports). Tracked in **hangrier_games-9hi**.

## Notes

- \`api/tests/*\` has pre-existing compile errors (axum-test \`TestServer\` API drift) that are unrelated to this PR.
- \`rustfmt.toml\` sets \`fn_single_line = true\` which is nightly-only; warnings on stable rustfmt are harmless.