### PR TITLE
fix(game): persist event survival outcome messages and stabilize affinity test

### DIFF
--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -336,76 +336,102 @@ impl Game {
 
         // Process each tribute's survival check
         for tribute_idx in tribute_indices {
-            let tribute = &mut self.tributes[tribute_idx];
+            // Outcome messages we'll log after the tribute borrow is released.
+            let mut pending_messages: Vec<(crate::messages::MessageSource, String, String)> =
+                Vec::new();
 
-            // Check modifiers
-            let has_affinity = tribute.terrain_affinity.contains(&terrain);
+            {
+                let tribute = &mut self.tributes[tribute_idx];
 
-            // Check for protective items (shields only for physical events)
-            let is_physical_event = matches!(
-                most_severe_event,
-                AreaEvent::Avalanche | AreaEvent::Rockslide | AreaEvent::Earthquake
-            );
-            let has_item_bonus =
-                is_physical_event && tribute.items.iter().any(|item| item.is_defensive());
+                // Check modifiers
+                let has_affinity = tribute.terrain_affinity.contains(&terrain);
 
-            let is_desperate = tribute.attributes.health < 30;
-            let current_health = tribute.attributes.health;
+                // Check for protective items (shields only for physical events)
+                let is_physical_event = matches!(
+                    most_severe_event,
+                    AreaEvent::Avalanche | AreaEvent::Rockslide | AreaEvent::Earthquake
+                );
+                let has_item_bonus =
+                    is_physical_event && tribute.items.iter().any(|item| item.is_defensive());
 
-            // Run survival check with config parameters
-            let result = most_severe_event.survival_check(
-                &terrain,
-                has_affinity,
-                has_item_bonus,
-                is_desperate,
-                current_health,
-                self.config.instant_death_enabled,
-                self.config.catastrophic_severity_multiplier,
-                rng,
-            );
+                let is_desperate = tribute.attributes.health < 30;
+                let current_health = tribute.attributes.health;
 
-            // Apply results
-            if !result.survived {
-                tribute.attributes.health = 0;
+                // Run survival check with config parameters
+                let result = most_severe_event.survival_check(
+                    &terrain,
+                    has_affinity,
+                    has_item_bonus,
+                    is_desperate,
+                    current_health,
+                    self.config.instant_death_enabled,
+                    self.config.catastrophic_severity_multiplier,
+                    rng,
+                );
 
-                let _message = if result.instant_death {
-                    format!(
-                        "{} is instantly killed by the catastrophic {}!",
-                        tribute.name, most_severe_event
-                    )
+                let source = crate::messages::MessageSource::Tribute(tribute.identifier.clone());
+                let subject = format!("tribute:{}", tribute.identifier);
+
+                // Apply results
+                if !result.survived {
+                    tribute.attributes.health = 0;
+
+                    let content = if result.instant_death {
+                        format!(
+                            "{} is instantly killed by the catastrophic {}!",
+                            tribute.name, most_severe_event
+                        )
+                    } else {
+                        format!("{} dies from the {}", tribute.name, most_severe_event)
+                    };
+                    pending_messages.push((source, subject, content));
                 } else {
-                    format!("{} dies from the {}", tribute.name, most_severe_event)
-                };
-            } else {
-                // Survivor - apply rewards if any
-                if result.stamina_restored > 0 {
-                    tribute.stamina = tribute.stamina.saturating_add(result.stamina_restored);
-                    let _message = format!(
-                        "{} survives the {}, recovering {} stamina",
-                        tribute.name, most_severe_event, result.stamina_restored
-                    );
-                }
+                    // Survivor - apply rewards if any
+                    if result.stamina_restored > 0 {
+                        tribute.stamina = tribute.stamina.saturating_add(result.stamina_restored);
+                        pending_messages.push((
+                            source.clone(),
+                            subject.clone(),
+                            format!(
+                                "{} survives the {}, recovering {} stamina",
+                                tribute.name, most_severe_event, result.stamina_restored
+                            ),
+                        ));
+                    }
 
-                if result.sanity_restored > 0 {
-                    tribute.attributes.sanity = tribute
-                        .attributes
-                        .sanity
-                        .saturating_add(result.sanity_restored);
-                    let _message = format!(
-                        "{} survives the {}, recovering {} sanity",
-                        tribute.name, most_severe_event, result.sanity_restored
-                    );
-                }
+                    if result.sanity_restored > 0 {
+                        tribute.attributes.sanity = tribute
+                            .attributes
+                            .sanity
+                            .saturating_add(result.sanity_restored);
+                        pending_messages.push((
+                            source.clone(),
+                            subject.clone(),
+                            format!(
+                                "{} survives the {}, recovering {} sanity",
+                                tribute.name, most_severe_event, result.sanity_restored
+                            ),
+                        ));
+                    }
 
-                if result.reward_item.is_some() {
-                    let item = Item::new_random_consumable();
-                    let item_name = item.name.clone();
-                    tribute.items.push(item);
-                    let _message = format!(
-                        "{} survives the {} and finds a {}",
-                        tribute.name, most_severe_event, item_name
-                    );
+                    if result.reward_item.is_some() {
+                        let item = Item::new_random_consumable();
+                        let item_name = item.name.clone();
+                        tribute.items.push(item);
+                        pending_messages.push((
+                            source,
+                            subject,
+                            format!(
+                                "{} survives the {} and finds a {}",
+                                tribute.name, most_severe_event, item_name
+                            ),
+                        ));
+                    }
                 }
+            }
+
+            for (source, subject, content) in pending_messages {
+                self.log(source, subject, content);
             }
         }
         Ok(())

--- a/game/tests/event_game_loop_test.rs
+++ b/game/tests/event_game_loop_test.rs
@@ -10,7 +10,7 @@ use rand::rngs::SmallRng;
 #[test]
 fn test_event_survival_integration_with_game_loop() {
     let mut game = Game::new("test-game");
-    game.start();
+    let _ = game.start();
 
     // Create area with Forest terrain (catastrophic for wildfire)
     let mut area_details = AreaDetails::new_with_terrain(
@@ -77,7 +77,7 @@ fn test_event_survival_integration_with_game_loop() {
 #[test]
 fn test_trigger_cycle_events_calls_process_event() {
     let mut game = Game::new("test-game");
-    game.start();
+    let _ = game.start();
     game.day = Some(2); // Day 2 to avoid special day #1 behavior
 
     // Create multiple areas with different terrains
@@ -142,23 +142,28 @@ fn test_trigger_cycle_events_calls_process_event() {
 /// Test that tributes with terrain affinity have better survival
 #[test]
 fn test_terrain_affinity_improves_survival() {
-    // Run multiple trials to get statistical significance
+    // Use a Major-severity event (Flood in Forest = DC 15) so the +3 affinity
+    // bonus makes a measurable statistical difference. Catastrophic events
+    // (DC 20) are too lethal in this regime to show separation reliably.
+    //
+    // Each arm gets its own deterministic RNG so the comparison is independent.
+    let trials = 50;
     let mut with_affinity_deaths = 0;
     let mut without_affinity_deaths = 0;
-    let trials = 20;
-    let mut rng = SmallRng::seed_from_u64(2024);
+    let mut rng_with = SmallRng::seed_from_u64(2024);
+    let mut rng_without = SmallRng::seed_from_u64(4048);
 
     for _ in 0..trials {
         // Test WITH affinity
         let mut game_with = Game::new("test-affinity");
-        game_with.start();
+        let _ = game_with.start();
 
         let mut area = AreaDetails::new_with_terrain(
             Some("Forest".to_string()),
             Area::North,
             TerrainType::new(BaseTerrain::Forest, vec![]).unwrap(),
         );
-        area.events.push(AreaEvent::Wildfire);
+        area.events.push(AreaEvent::Flood);
         game_with.areas.push(area);
 
         let mut tribute = Tribute::new("Affinity Tribute".to_string(), Some(1), None);
@@ -169,7 +174,7 @@ fn test_terrain_affinity_improves_survival() {
         game_with.tributes.push(tribute);
 
         game_with
-            .process_event_for_area(&Area::North, &AreaEvent::Wildfire, &mut rng)
+            .process_event_for_area(&Area::North, &AreaEvent::Flood, &mut rng_with)
             .unwrap();
 
         if game_with.tributes[0].attributes.health == 0 {
@@ -178,14 +183,14 @@ fn test_terrain_affinity_improves_survival() {
 
         // Test WITHOUT affinity
         let mut game_without = Game::new("test-no-affinity");
-        game_without.start();
+        let _ = game_without.start();
 
         let mut area2 = AreaDetails::new_with_terrain(
             Some("Forest".to_string()),
             Area::North,
             TerrainType::new(BaseTerrain::Forest, vec![]).unwrap(),
         );
-        area2.events.push(AreaEvent::Wildfire);
+        area2.events.push(AreaEvent::Flood);
         game_without.areas.push(area2);
 
         let mut tribute2 = Tribute::new("No Affinity Tribute".to_string(), Some(1), None);
@@ -196,7 +201,7 @@ fn test_terrain_affinity_improves_survival() {
         game_without.tributes.push(tribute2);
 
         game_without
-            .process_event_for_area(&Area::North, &AreaEvent::Wildfire, &mut rng)
+            .process_event_for_area(&Area::North, &AreaEvent::Flood, &mut rng_without)
             .unwrap();
 
         if game_without.tributes[0].attributes.health == 0 {
@@ -204,10 +209,10 @@ fn test_terrain_affinity_improves_survival() {
         }
     }
 
-    // Tributes with affinity should die less often
-    // This is probabilistic, but over 20 trials should show a difference
+    // Tributes with affinity should die strictly less often than tributes
+    // without it. With these seeds and 50 trials this is deterministic.
     assert!(
-        with_affinity_deaths <= without_affinity_deaths,
+        with_affinity_deaths < without_affinity_deaths,
         "Expected tributes WITH affinity to die less often (with: {}, without: {})",
         with_affinity_deaths,
         without_affinity_deaths


### PR DESCRIPTION
## Summary

Closes `hangrier_games-x65` — repairs the 3 pre-existing failures in `game/tests/event_game_loop_test.rs`.

## Root causes

1. **`process_event_for_area` never logged outcomes.** Death, stamina-recovery, sanity-recovery, and item-find strings were built into `let _message = ...` bindings and immediately discarded. The two integration tests asserting on `game.messages` had no chance of passing.

2. **`test_terrain_affinity_improves_survival` used a regime where affinity barely matters.** Wildfire-on-Forest is Catastrophic (DC 20). With `health=50` (not desperate), tributes without affinity have a 0% survival rate (rolls 1..=20 < 20); with affinity only natural 17+ survives (~20%). Both arms hover near 100% lethality, so RNG noise dominated and the assertion bounced between 18–20 deaths with no stable order.

## Changes

- **`game/src/games.rs`** — emit four real `log()` calls (death, stamina recovery, sanity recovery, item-find reward) sourced as `MessageSource::Tribute`. Resolved the inevitable borrow conflict (per-tribute mutable borrow vs `&mut self` log) by collecting messages into a small `Vec` first, then logging after the borrow is released.
- **`game/tests/event_game_loop_test.rs`** — switch the affinity test to Flood-in-Forest (Major, DC 15) where the +3 affinity bonus produces measurable separation, give each arm its own `SmallRng` seed for independent determinism, bump trials to 50, and tighten the assertion to strict `<`. Also clear the warned 'unused Result' on `game.start()` in the other two tests.

## Verification

```
cargo test --package game --test event_game_loop_test  → 3/3 pass
cargo test --package game (lib)                        → 368/368 pass
cargo check --workspace --exclude web                  → clean
```

## Follow-ups

- `hangrier_games-roa` (P2) — pre-existing `test_all_terrains_produce_valid_items` failure in `item_distribution_test`. Reproduces on clean main; not in scope here.
- `hangrier_games-9hi` (P3) — remaining manual clippy warnings, queued next.