### PR TITLE
chore(clippy): clean up workspace warnings

### DIFF
--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -28,7 +28,6 @@ pub struct PaginatedTributes {
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::LazyLock;
-use std::sync::RwLock;
 use strum::IntoEnumIterator;
 use surrealdb::engine::any::Any;
 use surrealdb::sql::Thing;
@@ -55,19 +54,6 @@ fn default_limit() -> u32 {
 fn default_offset() -> u32 {
     0
 }
-
-/// Cache entry with TTL tracking
-struct CacheEntry {
-    game: Game,
-    cached_at: std::time::Instant,
-}
-
-/// In-memory game cache with 5-minute TTL using RwLock
-static GAME_CACHE: LazyLock<RwLock<HashMap<String, CacheEntry>>> =
-    LazyLock::new(|| RwLock::new(HashMap::new()));
-
-/// Cache TTL duration (5 minutes)
-const CACHE_TTL_SECS: u64 = 300;
 
 pub static GAMES_ROUTER: LazyLock<Router<AppState>> = LazyLock::new(|| {
     Router::new()
@@ -670,7 +656,7 @@ async fn run_game_cycles(
         .map_err(|e| AppError::InternalServerError(format!("Failed to run day cycle: {}", e)))?;
     game.run_day_night_cycle(false)
         .map_err(|e| AppError::InternalServerError(format!("Failed to run night cycle: {}", e)))?;
-    save_game(game, db, broadcaster).await?;
+    let _ = save_game(game, db, broadcaster).await?;
     Ok(())
 }
 
@@ -739,14 +725,6 @@ async fn get_full_game(identifier: Uuid, db: &Surreal<Any>) -> Result<Json<Game>
         Ok(Json::<Game>(game))
     } else {
         Err(AppError::NotFound("Failed to find game".into()))
-    }
-}
-
-/// Invalidate cache for a game (call on updates)
-fn invalidate_game_cache(identifier: &str) {
-    if let Ok(mut cache) = GAME_CACHE.write() {
-        cache.remove(identifier);
-        tracing::debug!("Cache invalidated for game {}", identifier);
     }
 }
 
@@ -1027,18 +1005,18 @@ async fn save_area_items(
                 "UPDATE item:{} CONTENT {{
                     identifier: '{}',
                     name: '{}',
-                    item_type: '{}',
+                    item_type: '{:?}',
                     effect: {},
                     quantity: {},
-                    attribute: '{}'
+                    attribute: '{:?}'
                 }}",
                 item.identifier,
                 item.identifier,
                 item.name.replace("'", "\\'"),
-                format!("{:?}", item.item_type),
+                item.item_type,
                 item.effect,
                 item.quantity,
-                format!("{:?}", item.attribute)
+                item.attribute
             ));
         }
 
@@ -1143,18 +1121,18 @@ async fn save_tribute_items(
                 "UPDATE item:{} CONTENT {{
                     identifier: '{}',
                     name: '{}',
-                    item_type: '{}',
+                    item_type: '{:?}',
                     effect: {},
                     quantity: {},
-                    attribute: '{}'
+                    attribute: '{:?}'
                 }}",
                 item.identifier,
                 item.identifier,
                 item.name.replace("'", "\\'"),
-                format!("{:?}", item.item_type),
+                item.item_type,
                 item.effect,
                 item.quantity,
-                format!("{:?}", item.attribute)
+                item.attribute
             ));
         }
 

--- a/api/src/tributes.rs
+++ b/api/src/tributes.rs
@@ -47,14 +47,14 @@ struct TributeGameEdge {
 
 pub async fn create_tribute(
     tribute: Option<Tribute>,
-    game_identifier: &String,
+    game_identifier: &str,
     db: &Surreal<Any>,
     district: u32,
 ) -> Result<Tribute, AppError> {
-    let game_id = RecordId::from(("game", game_identifier.clone()));
+    let game_id = RecordId::from(("game", game_identifier.to_owned()));
     let tribute_count = db
         .query("RETURN count(SELECT id FROM playing_in WHERE out.identifier=$game)")
-        .bind(("game", game_identifier.clone()))
+        .bind(("game", game_identifier.to_owned()))
         .await;
     let tribute_count: Option<u32> = tribute_count.unwrap().take(0).unwrap();
     if tribute_count >= Some(24) {
@@ -63,7 +63,7 @@ pub async fn create_tribute(
 
     let mut tribute = tribute.unwrap_or_else(Tribute::random);
     tribute.district = district + 1;
-    tribute.statistics.game = game_identifier.clone();
+    tribute.statistics.game = game_identifier.to_owned();
 
     let id = RecordId::from(("tribute", &tribute.identifier));
 

--- a/api/src/users.rs
+++ b/api/src/users.rs
@@ -18,11 +18,6 @@ pub static USERS_ROUTER: LazyLock<Router<AppState>> = LazyLock::new(|| {
 });
 
 #[derive(Serialize, Deserialize, Debug)]
-struct JwtResponse {
-    jwt: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
 struct JwtClaims {
     id: String,
     #[serde(rename = "sub")]

--- a/game/src/areas/events.rs
+++ b/game/src/areas/events.rs
@@ -283,6 +283,7 @@ impl AreaEvent {
     ///
     /// # Returns
     /// SurvivalResult containing survival status and any rewards
+    #[allow(clippy::too_many_arguments)]
     pub fn survival_check(
         &self,
         terrain: &BaseTerrain,
@@ -392,7 +393,7 @@ mod tests {
 
     #[test]
     fn random_area_event() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let random_event = AreaEvent::random(&mut rng);
         assert!(AreaEvent::iter().any(|a| a == random_event));
     }

--- a/game/src/areas/mod.rs
+++ b/game/src/areas/mod.rs
@@ -127,8 +127,6 @@ impl OwnsItems for AreaDetails {
 
         if used_item.quantity > 0 {
             Ok(())
-        } else if used_item.quantity == 0 {
-            Err(ItemError::ItemNotFound)
         } else {
             Err(ItemError::ItemNotFound)
         }

--- a/game/src/config.rs
+++ b/game/src/config.rs
@@ -137,9 +137,11 @@ mod tests {
 
     #[test]
     fn test_easy_mode_config() {
-        let mut config = GameConfig::default();
-        config.instant_death_enabled = false;
-        config.catastrophic_severity_multiplier = 0.5;
+        let config = GameConfig {
+            instant_death_enabled: false,
+            catastrophic_severity_multiplier: 0.5,
+            ..GameConfig::default()
+        };
 
         assert!(!config.instant_death_enabled);
         assert_eq!(config.catastrophic_severity_multiplier, 0.5);
@@ -147,10 +149,12 @@ mod tests {
 
     #[test]
     fn test_hard_mode_config() {
-        let mut config = GameConfig::default();
-        config.instant_death_enabled = true;
-        config.catastrophic_severity_multiplier = 2.0;
-        config.day_event_frequency = 0.5; // More frequent events
+        let config = GameConfig {
+            instant_death_enabled: true,
+            catastrophic_severity_multiplier: 2.0,
+            day_event_frequency: 0.5,
+            ..GameConfig::default()
+        };
 
         assert_eq!(config.catastrophic_severity_multiplier, 2.0);
         assert_eq!(config.day_event_frequency, 0.5);

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -561,7 +561,7 @@ impl Game {
                 if let Some(area_details) = self.random_open_area() {
                     let event = AreaEvent::random(rng);
                     let area_name = area_details.area.unwrap().to_string();
-                    if area_events.get(&area_name.clone()).is_some() {
+                    if area_events.contains_key(&area_name) {
                         let mut events = area_events[&area_name].1.clone();
                         events.push(event.clone());
                         area_events.insert(area_name, (area_details.clone(), events));
@@ -912,7 +912,7 @@ mod tests {
         assert_eq!(game.living_tributes().len(), 1);
         assert_eq!(game.winner(), Some(winner_tribute.clone()));
 
-        game.check_for_winner();
+        let _ = game.check_for_winner();
 
         // Game should be finished
         assert_eq!(game.status, GameStatus::Finished);
@@ -929,7 +929,7 @@ mod tests {
         assert!(game.living_tributes().is_empty());
         assert!(game.winner().is_none());
 
-        game.check_for_winner();
+        let _ = game.check_for_winner();
 
         // Game should be finished
         assert_eq!(game.status, GameStatus::Finished);
@@ -947,7 +947,7 @@ mod tests {
         assert_eq!(game.living_tributes().len(), 2);
         assert!(game.winner().is_none());
 
-        game.check_for_winner();
+        let _ = game.check_for_winner();
 
         // Game should be finished
         assert_eq!(game.status, starting_state);
@@ -962,12 +962,12 @@ mod tests {
         game.day = Some(1);
         game.areas.push(area);
         game.areas[0].events.push(event.clone());
-        game.prepare_cycle(true);
+        let _ = game.prepare_cycle(true);
         assert_eq!(game.day, Some(2));
         assert_eq!(game.areas[0].events.len(), 0);
 
         game.areas[0].events.push(event.clone());
-        game.prepare_cycle(false);
+        let _ = game.prepare_cycle(false);
         // Night cycle shouldn't advance the game day.
         assert_eq!(game.day, Some(2));
         assert_eq!(game.areas[0].events.len(), 0);
@@ -1012,7 +1012,7 @@ mod tests {
         game.areas.push(area);
 
         assert!(!game.areas[0].is_open());
-        game.announce_area_events();
+        let _ = game.announce_area_events();
         // announce_area_events does not yet emit messages; this test is a placeholder
         // until area-event narration is restored (see hangrier_games-33r).
         assert_eq!(game.messages.len(), 0);
@@ -1059,7 +1059,7 @@ mod tests {
         // Constrain areas
         // Use a fixed seed so the area-selection branch is deterministic.
         let mut rng = SmallRng::seed_from_u64(0);
-        game.constrain_areas(&mut rng);
+        let _ = game.constrain_areas(&mut rng);
 
         // Check if at least one area is closed
         assert!(game.random_open_area().is_some());
@@ -1085,7 +1085,7 @@ mod tests {
 
         // Run the tribute cycle
         let mut rng = SmallRng::from_rng(&mut rand::rng());
-        game.run_tribute_cycle(
+        let _ = game.run_tribute_cycle(
             true,
             &mut rng,
             closed_areas,

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -358,12 +358,11 @@ impl Brain {
                 // Convert DestinationInfo to AreaDetails for choose_destination
                 let area_details: Vec<AreaDetails> = available_destinations
                     .iter()
-                    .map(|dest| {
-                        let mut ad = AreaDetails::default();
-                        ad.area = Some(dest.area);
-                        ad.terrain = dest.terrain.clone();
-                        ad.events = dest.active_events.clone();
-                        ad
+                    .map(|dest| AreaDetails {
+                        area: Some(dest.area),
+                        terrain: dest.terrain.clone(),
+                        events: dest.active_events.clone(),
+                        ..AreaDetails::default()
                     })
                     .collect();
 
@@ -1026,10 +1025,12 @@ mod tests {
 
     #[rstest]
     fn test_psychotic_break_recovery(mut small_rng: SmallRng) {
-        let mut tribute = Tribute::default();
         // Use deterministic Brain so psychotic_break_threshold is fixed
         // (Balanced base = 7) and the +20 recovery margin is predictable.
-        tribute.brain = Brain::default();
+        let mut tribute = Tribute {
+            brain: Brain::default(),
+            ..Tribute::default()
+        };
         tribute.attributes.sanity = 3;
 
         // Trigger break
@@ -1047,10 +1048,12 @@ mod tests {
 
     #[rstest]
     fn test_psychotic_break_no_recovery_insufficient_sanity(mut small_rng: SmallRng) {
-        let mut tribute = Tribute::default();
         // Deterministic Brain: Balanced psychotic_break_threshold = 7,
         // recovery requires sanity >= 27. sanity = 15 is below that.
-        tribute.brain = Brain::default();
+        let mut tribute = Tribute {
+            brain: Brain::default(),
+            ..Tribute::default()
+        };
         tribute.attributes.sanity = 3;
 
         // Trigger break

--- a/game/src/tributes/inventory.rs
+++ b/game/src/tributes/inventory.rs
@@ -102,22 +102,21 @@ impl Tribute {
     /// Use consumable item from inventory
     pub(crate) fn try_use_consumable(&mut self, chosen_item: &Item) -> Result<(), ItemError> {
         let items = self.consumables();
-        let item: Item;
 
         // If the tribute has the item...
-        match items
+        let item = match items
             .iter()
             .find(|i| i.identifier == chosen_item.identifier)
         {
             Some(selected_item) => {
                 // select it
-                item = selected_item.clone();
+                selected_item.clone()
             }
             None => {
                 // otherwise, quit because you can't use an item you don't have
                 return Err(ItemError::ItemNotFound);
             }
-        }
+        };
 
         if self.use_item(&item).is_err() {
             return Err(ItemError::ItemNotUsable);

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -30,20 +30,6 @@ use uuid::Uuid;
 const SANITY_BREAK_LEVEL: u32 = 9;
 const LOYALTY_BREAK_LEVEL: f64 = 0.25;
 
-/// Attribute maximums
-const MAX_HEALTH: u32 = 100;
-const MAX_SANITY: u32 = 100;
-const MAX_MOVEMENT: u32 = 100;
-const MAX_STRENGTH: u32 = 50;
-const MAX_DEFENSE: u32 = 50;
-const MAX_BRAVERY: u32 = 100;
-const MAX_LOYALTY: u32 = 100;
-const MAX_SPEED: u32 = 100;
-const MAX_DEXTERITY: u32 = 100;
-const MAX_INTELLIGENCE: u32 = 100;
-const MAX_PERSUASION: u32 = 100;
-const MAX_LUCK: u32 = 100;
-
 #[derive(Clone, Debug)]
 pub struct ActionSuggestion {
     pub action: Action,
@@ -365,8 +351,8 @@ impl Tribute {
     /// 2. If there are no enemies and the tribute is feeling suicidal, target self.
     /// 3. If there are no enemies nearby, but they exist elsewhere, target no one.
     /// 4. If there are no enemies nearby and no enemies left in the game:
-    /// 4a. If loyalty is low, target ally.
-    /// 4b. Otherwise, target no one.
+    ///    a. If loyalty is low, target ally.
+    ///    b. Otherwise, target no one.
     fn pick_target(
         &self,
         mut targets: Vec<Tribute>,

--- a/game/src/witty_phrase_generator/mod.rs
+++ b/game/src/witty_phrase_generator/mod.rs
@@ -173,12 +173,12 @@ impl WPGen {
 
         let mut ret = vec![vec![""; words]; count];
 
-        for i in 0..count {
+        for slot in ret.iter_mut().take(count) {
             if let Some(mut vec) =
                 self.generate_backtracking(len_min, len_max, 1, &dict, &WPGen::create_format(words))
             {
                 vec.reverse();
-                ret[i] = vec;
+                *slot = vec;
             } else {
                 return None;
             }

--- a/game/tests/event_integration_test.rs
+++ b/game/tests/event_integration_test.rs
@@ -18,11 +18,11 @@ fn test_wildfire_in_forest_kills_tributes() {
     );
     game.areas.push(area_details);
 
-    let area_name = game.areas[0].area.clone().unwrap();
+    let area_name = game.areas[0].area.unwrap();
 
     // Create tribute in forest area with low health
     let mut tribute = Tribute::random();
-    tribute.area = area_name.clone();
+    tribute.area = area_name;
     tribute.attributes.health = 50; // Not desperate but vulnerable
     tribute.terrain_affinity = vec![]; // No affinity bonus
     tribute.statistics.game = game.identifier.clone(); // Set game identifier
@@ -62,7 +62,7 @@ fn test_wildfire_in_desert_minor_impact() {
     );
     game.areas.push(area_details);
 
-    let area_name = game.areas[0].area.clone().unwrap();
+    let area_name = game.areas[0].area.unwrap();
 
     // Create tribute
     let mut tribute = Tribute::random();

--- a/game/tests/event_severity_test.rs
+++ b/game/tests/event_severity_test.rs
@@ -156,9 +156,9 @@ fn test_survival_check_with_affinity() {
         event.survival_check(&terrain, false, false, false, 100, true, 1.0, &mut rng2);
 
     // Both should succeed or fail, but we can't deterministically test randomness
-    // Just verify the function runs without panic
-    assert!(result_with_affinity.survived || !result_with_affinity.survived);
-    assert!(result_without_affinity.survived || !result_without_affinity.survived);
+    // Just verify the function runs without panic and returns accessible fields
+    let _ = result_with_affinity.survived;
+    let _ = result_without_affinity.survived;
 }
 
 // Survival check tests - item bonus
@@ -176,8 +176,8 @@ fn test_survival_check_with_item_bonus() {
         event.survival_check(&terrain, false, false, false, 100, true, 1.0, &mut rng2);
 
     // Just verify the function runs
-    assert!(result_with_item.survived || !result_with_item.survived);
-    assert!(result_without_item.survived || !result_without_item.survived);
+    let _ = result_with_item.survived;
+    let _ = result_without_item.survived;
 }
 
 // Survival check tests - desperation bonus
@@ -195,8 +195,8 @@ fn test_survival_check_with_desperation() {
         event.survival_check(&terrain, false, false, false, 100, true, 1.0, &mut rng2);
 
     // Just verify the function runs
-    assert!(result_desperate.survived || !result_desperate.survived);
-    assert!(result_normal.survived || !result_normal.survived);
+    let _ = result_desperate.survived;
+    let _ = result_normal.survived;
 }
 
 // Test survival result structure
@@ -244,7 +244,7 @@ fn test_catastrophic_instant_death_probability() {
 
     // Should be around 5% (allow 2-10% range for randomness)
     assert!(
-        death_rate >= 0.02 && death_rate <= 0.10,
+        (0.02..=0.10).contains(&death_rate),
         "Instant death rate {} outside expected range",
         death_rate
     );
@@ -288,9 +288,9 @@ fn test_desperation_rewards_distribution() {
         let none_pct = no_rewards as f32 / total;
 
         // Rough validation (allow 25-60% for stamina/sanity, 0-25% for item, 0-15% for none)
-        assert!(stamina_pct >= 0.25 && stamina_pct <= 0.60);
-        assert!(sanity_pct >= 0.25 && sanity_pct <= 0.60);
-        assert!(item_pct >= 0.0 && item_pct <= 0.25);
-        assert!(none_pct >= 0.0 && none_pct <= 0.20);
+        assert!((0.25..=0.60).contains(&stamina_pct));
+        assert!((0.25..=0.60).contains(&sanity_pct));
+        assert!((0.0..=0.25).contains(&item_pct));
+        assert!((0.0..=0.20).contains(&none_pct));
     }
 }

--- a/game/tests/narrative_test.rs
+++ b/game/tests/narrative_test.rs
@@ -228,7 +228,7 @@ fn test_stamina_threshold_differences() {
     assert_ne!(low, critical);
 
     // Critical should be most severe
-    assert!(critical.len() > 0);
+    assert!(!critical.is_empty());
 }
 
 /// Test that harsh terrain stamina narratives are more severe.
@@ -240,8 +240,8 @@ fn test_harsh_terrain_more_severe_stamina() {
     let mild = stamina_narrative(BaseTerrain::Clearing, stamina);
 
     // Both should be non-empty
-    assert!(harsh.len() > 0);
-    assert!(mild.len() > 0);
+    assert!(!harsh.is_empty());
+    assert!(!mild.is_empty());
 
     // Harsh should mention difficulty more prominently
     assert!(harsh.contains("harsh") || harsh.contains("brutal") || harsh.contains("demanding"));

--- a/game/tests/stamina_edge_cases_test.rs
+++ b/game/tests/stamina_edge_cases_test.rs
@@ -169,8 +169,10 @@ fn test_stamina_restoration() {
 #[test]
 fn test_zero_stamina_calculation() {
     let terrain = TerrainType::new(BaseTerrain::Clearing, vec![]).unwrap();
-    let mut tribute = Tribute::default();
-    tribute.stamina = 0; // Depleted stamina
+    let mut tribute = Tribute {
+        stamina: 0, // Depleted stamina
+        ..Tribute::default()
+    };
     tribute.attributes.health = 100;
 
     let action = Action::Rest; // Base cost 0

--- a/game/tests/terrain_specific_events_test.rs
+++ b/game/tests/terrain_specific_events_test.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 #[test]
 fn test_game_loop_generates_terrain_appropriate_events() {
     let mut game = Game::new("test-terrain-events");
-    game.start();
+    let _ = game.start();
     game.day = Some(2); // Day 2 to avoid special day behavior
 
     // Create areas with different terrains


### PR DESCRIPTION
## Summary

Resolves the ~27 remaining clippy warnings across the workspace that were not auto-fixable in PR #104. Also fixes 6 `overly_complex_bool_expr` errors (placeholder tautology asserts) in `event_severity_test.rs` that were blocking `cargo clippy --all-targets` from compiling.

## Changes

**Dead code removal:**
- `game/src/tributes/mod.rs`: removed unused `MAX_*` stat constants (duplicates live in `lifecycle.rs`)
- `api/src/users.rs`: removed unused `JwtResponse` struct
- `api/src/games.rs`: removed unused cache infrastructure (`CacheEntry`, `GAME_CACHE`, `CACHE_TTL_SECS`, `invalidate_game_cache`, and the now-unneeded `RwLock` import)

**Clippy lint fixes:**
- `format_in_format_args`: collapsed `format!(\"{}\", format!(\"{:?}\", x))` into `format!(\"{:?}\", x)` (api/src/games.rs)
- `field_reassign_with_default`: switched to struct-update syntax in config tests, psychotic_break tests, stamina edge case test, and `AreaDetails` construction in brains.rs
- `manual_range_contains`: `>= a && <= b` -> `(a..=b).contains(&x)` in event_severity_test
- `overly_complex_bool_expr`: replaced 6 tautology asserts (`assert!(x || !x)`) with `let _ = x` smoke-access (event_severity_test)
- `len_zero`: `x.len() > 0` -> `!x.is_empty()` (narrative_test)
- `clone_on_copy`: removed unnecessary `.clone()` calls on `Copy` types (event_integration_test)
- `must_use_result`: `let _ = ...` for intentionally unused Results in tests (game/src/games.rs, terrain_specific_events_test)
- `ptr_arg`: `&String` -> `&str` in `api/src/tributes.rs` (with caller updates)
- `deprecated`: `rand::thread_rng()` -> `rand::rng()` (areas/events.rs)
- `needless_late_init`: bound `let item = match ...` directly (tributes/inventory.rs)
- `needless_range_loop`: `for slot in ret.iter_mut().take(count)` (witty_phrase_generator)
- `if_same_then_else`: collapsed identical branches in `areas/use_item`
- `redundant_clone` + `unnecessary_get_then_check`: `.contains_key(&area_name)` instead of `.get(&area_name.clone()).is_some()` (games.rs)
- `doc_list_item_omitted_paragraph_marker`: fixed list indentation in `pick_target`
- `too_many_arguments`: `#[allow]` on `survival_check` (9 args, refactor not in scope)

## Verification

- `cargo clippy --workspace --exclude web --exclude api --all-targets` -> clean (0 warnings)
- `cargo clippy --package api --lib` -> clean
- `cargo test --package game` -> all tests pass except the pre-existing `test_all_terrains_produce_valid_items` failure tracked in `hangrier_games-roa`
- `cargo fmt --check` -> clean

## Out of scope (pre-existing)

- `api/tests/*` has axum-test API drift (`TestServer::new(...).unwrap()` should be `.wrap()`); not touched
- `hangrier_games-roa`: combat gear effect-range assertion failure in `item_distribution_test`

## Follow-ups

- Closes `hangrier_games-9hi`