### PR TITLE
fix(game): correct item effect range assertion in item_distribution_test

### DIFF
--- a/game/tests/item_distribution_test.rs
+++ b/game/tests/item_distribution_test.rs
@@ -202,18 +202,13 @@ fn test_all_terrains_produce_valid_items() {
             assert!(!item.name.is_empty(), "Item should have name");
             assert!(item.quantity > 0, "Item should have positive quantity");
 
-            // Effect should be reasonable
-            if item.is_weapon() || item.is_defensive() {
-                assert!(
-                    item.effect > 0 && item.effect <= 7,
-                    "Combat gear should have 1-7 effect"
-                );
-            } else {
-                assert!(
-                    item.effect > 0 && item.effect <= 10,
-                    "Consumables should have 1-10 effect"
-                );
-            }
+            // Effect should be within the rarity tier ranges (max Legendary = 12).
+            assert!(
+                item.effect > 0 && item.effect <= 12,
+                "Item effect {} out of range 1-12 (rarity {:?})",
+                item.effect,
+                item.rarity
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

`test_all_terrains_produce_valid_items` was asserting `combat gear effect <= 7` and `consumables effect <= 10`, but `ItemRarity::effect_range()` in `game/src/items/mod.rs` actually produces values up to 12 for Legendary items, and the same rarity table applies to every item type. The assertion was just stale.

## Changes

- `game/tests/item_distribution_test.rs`: replaced the split combat-gear / consumables assertion with a single `1..=12` range check that includes the rarity in the panic message.

## Verification

- `cargo test --package game --test item_distribution_test` -> 8/8 pass

## Follow-ups

- Closes `hangrier_games-roa`