### PR TITLE
feat(game): unify movement and turn-phase events into Game.messages (33r PR2)

### DIFF
--- a/game/src/tributes/lifecycle.rs
+++ b/game/src/tributes/lifecycle.rs
@@ -287,23 +287,6 @@ impl Tribute {
             self.status = TributeStatus::RecentlyDead;
         }
     }
-
-    /// Helper to attempt to add a tribute message, logging a warning on failure.
-    /// The success of this function does not affect the outcome of the calling method.
-    pub(crate) fn try_log_action(
-        &self,
-        _game_event_output: impl std::fmt::Display,
-        action_description: &str,
-    ) {
-        // Message logging removed - now handled at API level
-        // The game engine is now pure (no I/O side effects)
-        tracing::debug!(
-            target: "game::tribute",
-            "Tribute {} action: {}",
-            self.name,
-            action_description
-        );
-    }
 }
 
 #[cfg(test)]

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -187,10 +187,7 @@ impl Tribute {
 
         // Any generous patrons this round?
         if let Some(gift) = self.receive_patron_gift(&mut *rng) {
-            self.try_log_action(
-                GameOutput::SponsorGift(self.name.as_str(), &gift),
-                "received gift",
-            );
+            events.push(GameOutput::SponsorGift(self.name.as_str(), &gift).to_string());
             self.add_item(gift);
         }
 
@@ -227,8 +224,8 @@ impl Tribute {
         match &action {
             Action::Move(area) => {
                 let travel_result = match area {
-                    Some(specific_area) => self.travels(closed_areas, Some(*specific_area)),
-                    None => self.travels(closed_areas, None),
+                    Some(specific_area) => self.travels(closed_areas, Some(*specific_area), events),
+                    None => self.travels(closed_areas, None, events),
                 };
 
                 match travel_result {
@@ -249,12 +246,12 @@ impl Tribute {
                                 } else {
                                     // Insufficient stamina - exhausted
                                     self.short_rests();
-                                    self.try_log_action(
+                                    events.push(
                                         GameOutput::TributeTravelExhausted(
                                             self.name.as_str(),
                                             &self.area.to_string(),
-                                        ),
-                                        "too exhausted to move",
+                                        )
+                                        .to_string(),
                                     );
                                 }
                             }
@@ -270,28 +267,23 @@ impl Tribute {
                 }
             }
             Action::Rest => {
-                self.try_log_action(GameOutput::TributeRest(self.name.as_str()), "resting");
+                events.push(GameOutput::TributeRest(self.name.as_str()).to_string());
                 self.long_rests();
             }
             Action::Hide => {
                 let hidden = self.hides();
                 if hidden {
-                    self.try_log_action(
-                        GameOutput::TributeHide(self.name.as_str()),
-                        "hid successfully",
-                    );
+                    events.push(GameOutput::TributeHide(self.name.as_str()).to_string());
                 } else {
                     // Just log as regular hide, game doesn't distinguish failure in output
-                    self.try_log_action(
-                        GameOutput::TributeHide(self.name.as_str()),
-                        "failed to hide",
-                    );
+                    events.push(GameOutput::TributeHide(self.name.as_str()).to_string());
                 }
             }
             Action::Attack => {
                 let target = self.pick_target(
                     encounter_context.potential_targets,
                     encounter_context.total_living_tributes,
+                    events,
                 );
                 if let Some(mut target) = target {
                     let outcome = self.attacks(&mut target, rng, events);
@@ -308,9 +300,8 @@ impl Tribute {
             }
             Action::TakeItem => {
                 if let Some(item) = self.take_nearby_item(area_details) {
-                    self.try_log_action(
-                        GameOutput::TributeTakeItem(self.name.as_str(), &item.name),
-                        "took item",
+                    events.push(
+                        GameOutput::TributeTakeItem(self.name.as_str(), &item.name).to_string(),
                     );
                 }
                 // If no items available, no output
@@ -318,18 +309,16 @@ impl Tribute {
             Action::UseItem(maybe_item) => {
                 if let Some(item) = maybe_item {
                     if let Err(error) = self.try_use_consumable(item) {
-                        self.try_log_action(
+                        events.push(
                             GameOutput::TributeCannotUseItem(
                                 self.name.as_str(),
                                 &error.to_string(),
-                            ),
-                            "item error",
+                            )
+                            .to_string(),
                         );
                     } else {
-                        self.try_log_action(
-                            GameOutput::TributeUseItem(self.name.as_str(), item),
-                            "used item",
-                        );
+                        events
+                            .push(GameOutput::TributeUseItem(self.name.as_str(), item).to_string());
                     }
                 }
             }
@@ -352,13 +341,14 @@ impl Tribute {
         &self,
         mut targets: Vec<Tribute>,
         living_tributes_count: u32,
+        events: &mut Vec<String>,
     ) -> Option<Tribute> {
         // If there are no targets, check if the tribute is feeling suicidal.
         if targets.is_empty() {
             match self.attributes.sanity {
                 0..=SANITY_BREAK_LEVEL => {
                     // attempt suicide
-                    self.try_log_action(GameOutput::TributeSuicide(self.name.as_str()), "suicide");
+                    events.push(GameOutput::TributeSuicide(self.name.as_str()).to_string());
                     Some(self.clone())
                 }
                 _ => None, // Attack no one

--- a/game/src/tributes/movement.rs
+++ b/game/src/tributes/movement.rs
@@ -27,6 +27,7 @@ impl Tribute {
         &self,
         closed_areas: &[Area],
         suggested_area: Option<Area>,
+        events: &mut Vec<String>,
     ) -> TravelResult {
         let mut rng = SmallRng::from_rng(&mut rand::rng());
         // Where is the tribute?
@@ -35,9 +36,9 @@ impl Tribute {
         // 1. Can the tribute move at all?
         if self.attributes.movement == 0 {
             let current_area = self.area.to_string();
-            self.try_log_action(
-                GameOutput::TributeTravelTooTired(self.name.as_str(), current_area.as_str()),
-                "too tired",
+            events.push(
+                GameOutput::TributeTravelTooTired(self.name.as_str(), current_area.as_str())
+                    .to_string(),
             );
             return TravelResult::Failure;
         }
@@ -49,9 +50,9 @@ impl Tribute {
         {
             if suggestion == current_area {
                 let suggestion = suggestion.to_string();
-                self.try_log_action(
-                    GameOutput::TributeTravelAlreadyThere(self.name.as_str(), suggestion.as_str()),
-                    "already there",
+                events.push(
+                    GameOutput::TributeTravelAlreadyThere(self.name.as_str(), suggestion.as_str())
+                        .to_string(),
                 );
                 return TravelResult::Failure;
             }
@@ -65,23 +66,23 @@ impl Tribute {
                 if let Some(new_area) = target_area {
                     let current_area = current_area.to_string();
                     let new_area_name = new_area.to_string();
-                    self.try_log_action(
+                    events.push(
                         GameOutput::TributeTravel(
                             self.name.as_str(),
                             current_area.as_str(),
                             new_area_name.as_str(),
-                        ),
-                        "travel",
+                        )
+                        .to_string(),
                     );
                     TravelResult::Success(new_area)
                 } else {
                     let current_area = current_area.to_string();
-                    self.try_log_action(
+                    events.push(
                         GameOutput::TributeTravelTooTired(
                             self.name.as_str(),
                             current_area.as_str(),
-                        ),
-                        "too tired",
+                        )
+                        .to_string(),
                     );
                     TravelResult::Failure
                 }
@@ -91,13 +92,13 @@ impl Tribute {
                 if let Some(new_area) = target_area {
                     let current_area = current_area.to_string();
                     let new_area_name = new_area.to_string();
-                    self.try_log_action(
+                    events.push(
                         GameOutput::TributeTravel(
                             self.name.as_str(),
                             current_area.as_str(),
                             new_area_name.as_str(),
-                        ),
-                        "travel",
+                        )
+                        .to_string(),
                     );
                     return TravelResult::Success(new_area);
                 }
@@ -110,12 +111,12 @@ impl Tribute {
 
                 if available_neighbors.is_empty() {
                     let current_area_name = current_area.to_string();
-                    self.try_log_action(
+                    events.push(
                         GameOutput::TributeTravelNoOptions(
                             self.name.as_str(),
                             current_area_name.as_str(),
-                        ),
-                        "no options",
+                        )
+                        .to_string(),
                     );
                     return TravelResult::Success(current_area);
                 }
@@ -125,13 +126,13 @@ impl Tribute {
                 let chosen_neighbor = available_neighbors.choose(&mut rng).unwrap();
                 let current_area_name = current_area.to_string();
                 let chosen_area_name = chosen_neighbor.to_string();
-                self.try_log_action(
+                events.push(
                     GameOutput::TributeTravel(
                         self.name.as_str(),
                         current_area_name.as_str(),
                         chosen_area_name.as_str(),
-                    ),
-                    "travel",
+                    )
+                    .to_string(),
                 );
                 TravelResult::Success(*chosen_neighbor)
             }
@@ -156,7 +157,7 @@ mod tests {
     #[tokio::test]
     async fn travels_success(tribute: Tribute) {
         let open_area = AreaDetails::new(Some("Forest".to_string()), Cornucopia);
-        let result = tribute.travels(&[East, South, North, West], None);
+        let result = tribute.travels(&[East, South, North, West], None, &mut Vec::new());
         assert_eq!(result, TravelResult::Success(open_area.area.unwrap()));
     }
 
@@ -164,7 +165,7 @@ mod tests {
     #[tokio::test]
     async fn travels_fail_no_movement(mut tribute: Tribute) {
         tribute.attributes.movement = 0;
-        let result = tribute.travels(&[], None);
+        let result = tribute.travels(&[], None, &mut Vec::new());
         assert_eq!(result, TravelResult::Failure);
     }
 
@@ -172,7 +173,11 @@ mod tests {
     #[tokio::test]
     async fn travels_fail_already_there(mut tribute: Tribute) {
         tribute.area = North;
-        let result = tribute.travels(&[Cornucopia, East, West, South], Some(North));
+        let result = tribute.travels(
+            &[Cornucopia, East, West, South],
+            Some(North),
+            &mut Vec::new(),
+        );
         assert_eq!(result, TravelResult::Failure);
     }
 
@@ -180,7 +185,7 @@ mod tests {
     #[tokio::test]
     async fn travels_fail_low_movement_no_suggestion(mut tribute: Tribute) {
         tribute.attributes.movement = 5;
-        let result = tribute.travels(&[Cornucopia, East, West, North], None);
+        let result = tribute.travels(&[Cornucopia, East, West, North], None, &mut Vec::new());
         assert_eq!(result, TravelResult::Failure);
     }
 
@@ -188,7 +193,11 @@ mod tests {
     #[tokio::test]
     async fn travels_fail_low_movement_suggestion(mut tribute: Tribute) {
         tribute.attributes.movement = 5;
-        let result = tribute.travels(&[Cornucopia, East, West, North], Some(North));
+        let result = tribute.travels(
+            &[Cornucopia, East, West, North],
+            Some(North),
+            &mut Vec::new(),
+        );
         assert_eq!(result, TravelResult::Failure);
     }
 
@@ -198,7 +207,7 @@ mod tests {
         tribute.area = North;
         tribute.attributes.movement = 5;
         let open_area = AreaDetails::new(Some("Forest".to_string()), Cornucopia);
-        let result = tribute.travels(&[East, South], Some(Cornucopia));
+        let result = tribute.travels(&[East, South], Some(Cornucopia), &mut Vec::new());
         assert_eq!(result, TravelResult::Success(open_area.area.unwrap()));
     }
 }

--- a/game/tests/event_unification_movement_test.rs
+++ b/game/tests/event_unification_movement_test.rs
@@ -1,0 +1,83 @@
+//! Round-trip test for hangrier_games-33r (PR2: movement + turn-phase slice).
+//!
+//! Verifies that movement and turn-phase narration emitted by
+//! `Tribute::travels`, `process_turn_phase` (rest/hide/take-item/sponsor-gift,
+//! exhausted-travel, suicide), now reach `Game.messages` rather than being
+//! silently dropped by the old `try_log_action` no-op.
+
+use game::areas::{Area, AreaDetails};
+use game::games::Game;
+use game::messages::{GameMessage, MessageSource};
+use game::terrain::{BaseTerrain, TerrainType};
+use game::tributes::Tribute;
+
+/// Drop a single tribute alone in an arena (no possible combat) and run
+/// several day cycles. The tribute will rest, hide, move, etc. Each of
+/// these used to vanish via `try_log_action`; they should now surface as
+/// `MessageSource::Tribute(_)` entries in `game.messages`.
+#[test]
+fn movement_and_turn_phase_events_reach_game_messages() {
+    let mut game = Game::new("event-unification-movement-test");
+
+    // Two areas so movement is actually possible.
+    for (name, area) in [
+        ("Cornucopia", Area::Cornucopia),
+        ("North Field", Area::North),
+    ] {
+        let details = AreaDetails::new_with_terrain(
+            Some(name.to_string()),
+            area,
+            TerrainType::new(BaseTerrain::Clearing, vec![]).unwrap(),
+        );
+        game.areas.push(details);
+    }
+
+    // Single tribute: no targets means combat code paths can't fire and
+    // any tribute-sourced messages must come from movement / rest / hide /
+    // take-item / use-item / sponsor-gift / exhausted-travel paths.
+    let mut lone = Tribute::random();
+    lone.name = "Lone".to_string();
+    lone.area = Area::Cornucopia;
+    lone.attributes.health = 100;
+    lone.attributes.movement = 80; // high movement → travel branch
+    lone.attributes.sanity = 80;
+    lone.statistics.game = game.identifier.clone();
+
+    let lone_id = lone.identifier.clone();
+    game.tributes.push(lone);
+
+    let messages_before = game.messages.len();
+
+    // Run several cycles to give the brain plenty of opportunities to
+    // pick non-attack actions.
+    for _ in 0..8 {
+        game.run_day_night_cycle(true).expect("day cycle ran");
+    }
+
+    let new_messages: Vec<&GameMessage> = game.messages.iter().skip(messages_before).collect();
+
+    let tribute_sourced: Vec<&&GameMessage> = new_messages
+        .iter()
+        .filter(|m| matches!(m.source, MessageSource::Tribute(_)))
+        .collect();
+
+    assert!(
+        !tribute_sourced.is_empty(),
+        "expected at least one MessageSource::Tribute(_) entry from \
+         movement/turn-phase narration; sources observed: {:?}",
+        new_messages.iter().map(|m| &m.source).collect::<Vec<_>>()
+    );
+
+    // Every tribute-sourced message must carry our lone tribute's identifier.
+    for msg in &tribute_sourced {
+        match &msg.source {
+            MessageSource::Tribute(id) => {
+                assert_eq!(
+                    id, &lone_id,
+                    "unexpected tribute identifier in message source: {id}"
+                );
+            }
+            other => panic!("filter let through non-Tribute source: {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Second of three PRs resolving `hangrier_games-33r` (P1). Builds on #109.

This PR finishes routing all per-tribute narration through the `events: &mut Vec<String>` sink that PR1 introduced, so movement, rest/hide/take-item/use-item, sponsor gifts, exhausted travel, and suicide all reach `Game.messages`. With the last `try_log_action` call sites gone, the dead helper itself is deleted.

PR3 will tackle survival result enrichment and area-event narration.

## Changes

- **`Tribute::travels`** (`game/src/tributes/movement.rs`) — takes `events: &mut Vec<String>`; all 7 narration sites converted (`TributeTravelTooTired` x2, `TributeTravelAlreadyThere`, `TributeTravel` x2, `TributeTravelNoOptions`).
- **`Tribute::process_turn_phase`** (`game/src/tributes/mod.rs`) — remaining 9 sites converted: `SponsorGift`, `TributeTravelExhausted`, `TributeRest`, `TributeHide` (success/fail), `TributeTakeItem`, `TributeCannotUseItem` / `TributeUseItem`. Both `self.travels(...)` calls now pass `events`.
- **`Tribute::pick_target`** — takes `events: &mut Vec<String>` for the `TributeSuicide` branch.
- **`Tribute::try_log_action`** (`game/src/tributes/lifecycle.rs`) — deleted; no callers remain.
- **Test callers** of `travels` updated (6 sites) to pass `&mut Vec::new()`.
- **New integration test** `game/tests/event_unification_movement_test.rs` runs day cycles with a single tribute (no combat possible) and asserts non-combat narration surfaces in `game.messages` tagged with `MessageSource::Tribute(_)`.

## Verification

```
cargo fmt --all                                       # clean
cargo clippy --package game --tests                   # clean (no warnings)
cargo check --package api                             # clean
cargo test --package game --lib --tests               # 550 passed
cargo test --package game --test event_unification_movement_test
                                                      # 1 passed
```

## Follow-ups

- `hangrier_games-33r` PR3 — enrich `SurvivalResult` (non-desperate survival, 5%-nothing branch, roll/modifier/severity); wire `process_event_for_area` and `announce_area_events` to emit `MessageSource::Area(_)`; close out the bead.
- `hangrier_games-mqi` (P3) — replace string-based `GameOutput` with serializable `GameEvent` enum.
- Pre-existing: 4 doctests in `game/src/messages.rs` and `game/src/items/mod.rs` reference a non-existent `hangrier_games` crate; unrelated to this PR.