### PR TITLE
feat(game): unify area-event survival narration into Game.messages (33r PR3)

### DIFF
--- a/game/src/areas/events.rs
+++ b/game/src/areas/events.rs
@@ -34,6 +34,12 @@ pub struct SurvivalResult {
     pub stamina_restored: u32,
     pub sanity_restored: u32,
     pub reward_item: Option<String>,
+    /// d20 roll value (1..=20) used for the survival check.
+    pub roll: i32,
+    /// Total modifier applied to the roll (affinity + items + desperation).
+    pub modifier: i32,
+    /// Severity of the event in this terrain at check time.
+    pub severity: EventSeverity,
 }
 
 impl FromStr for AreaEvent {
@@ -336,6 +342,9 @@ impl AreaEvent {
                 stamina_restored: 0,
                 sanity_restored: 0,
                 reward_item: None,
+                roll,
+                modifier,
+                severity: severity.clone(),
             };
         }
 
@@ -349,6 +358,9 @@ impl AreaEvent {
                 stamina_restored: 0,
                 sanity_restored: 0,
                 reward_item: None,
+                roll,
+                modifier,
+                severity: severity.clone(),
             };
         }
 
@@ -380,6 +392,9 @@ impl AreaEvent {
             stamina_restored,
             sanity_restored,
             reward_item,
+            roll,
+            modifier,
+            severity,
         }
     }
 }

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -349,6 +349,16 @@ impl Game {
             event.clone()
         };
 
+        // Announce the event itself in the area channel so the broader narrative
+        // captures *what happened* even when no tributes are present to react.
+        let area_name = area.to_string();
+        let area_subject = format!("area:{}", area_name);
+        self.log_output(
+            crate::messages::MessageSource::Area(area_name.clone()),
+            area_subject.clone(),
+            crate::output::GameOutput::AreaEvent(&most_severe_event.to_string(), &area_name),
+        );
+
         // Process each tribute's survival check
         for tribute_idx in tribute_indices {
             // Outcome messages we'll log after the tribute borrow is released.
@@ -386,6 +396,18 @@ impl Game {
 
                 let source = crate::messages::MessageSource::Tribute(tribute.identifier.clone());
                 let subject = format!("tribute:{}", tribute.identifier);
+                let roll_detail = format!(
+                    "[{:?} severity, rolled {}{}]",
+                    result.severity,
+                    result.roll,
+                    if result.modifier == 0 {
+                        String::new()
+                    } else if result.modifier > 0 {
+                        format!(" +{}", result.modifier)
+                    } else {
+                        format!(" {}", result.modifier)
+                    }
+                );
 
                 // Apply results
                 if !result.survived {
@@ -393,14 +415,28 @@ impl Game {
 
                     let content = if result.instant_death {
                         format!(
-                            "{} is instantly killed by the catastrophic {}!",
-                            tribute.name, most_severe_event
+                            "{} is instantly killed by the catastrophic {}! {}",
+                            tribute.name, most_severe_event, roll_detail
                         )
                     } else {
-                        format!("{} dies from the {}", tribute.name, most_severe_event)
+                        format!(
+                            "{} dies from the {} {}",
+                            tribute.name, most_severe_event, roll_detail
+                        )
                     };
                     pending_messages.push((source, subject, content));
                 } else {
+                    // Always announce the survival itself so the narrative captures
+                    // who weathered the event, even when no rewards land.
+                    pending_messages.push((
+                        source.clone(),
+                        subject.clone(),
+                        format!(
+                            "{} survives the {} {}",
+                            tribute.name, most_severe_event, roll_detail
+                        ),
+                    ));
+
                     // Survivor - apply rewards if any
                     if result.stamina_restored > 0 {
                         tribute.stamina = tribute.stamina.saturating_add(result.stamina_restored);
@@ -408,8 +444,8 @@ impl Game {
                             source.clone(),
                             subject.clone(),
                             format!(
-                                "{} survives the {}, recovering {} stamina",
-                                tribute.name, most_severe_event, result.stamina_restored
+                                "{} recovers {} stamina from the {}",
+                                tribute.name, result.stamina_restored, most_severe_event
                             ),
                         ));
                     }
@@ -423,8 +459,8 @@ impl Game {
                             source.clone(),
                             subject.clone(),
                             format!(
-                                "{} survives the {}, recovering {} sanity",
-                                tribute.name, most_severe_event, result.sanity_restored
+                                "{} recovers {} sanity from the {}",
+                                tribute.name, result.sanity_restored, most_severe_event
                             ),
                         ));
                     }
@@ -437,8 +473,8 @@ impl Game {
                             source,
                             subject,
                             format!(
-                                "{} survives the {} and finds a {}",
-                                tribute.name, most_severe_event, item_name
+                                "{} finds a {} after surviving the {}",
+                                tribute.name, item_name, most_severe_event
                             ),
                         ));
                     }
@@ -476,14 +512,40 @@ impl Game {
     }
 
     /// Announce events in closed areas.
-    fn announce_area_events(&self) -> Result<(), GameError> {
-        for area_details in &self.areas {
-            let _area_name = area_details.area.unwrap().to_string();
-            if !area_details.is_open() {
-                for event in &area_details.events {
-                    let _event_name = event.to_string();
-                }
+    ///
+    /// Emits one `MessageSource::Area` line per active event (using
+    /// `GameOutput::AreaEvent`) plus a closing `GameOutput::AreaClose`
+    /// summary so consumers know the area is currently uninhabitable.
+    fn announce_area_events(&mut self) -> Result<(), GameError> {
+        // Snapshot to avoid borrow conflicts with self.log_output below.
+        let snapshots: Vec<(String, Vec<String>)> = self
+            .areas
+            .iter()
+            .filter(|a| !a.is_open())
+            .filter_map(|a| {
+                a.area.map(|area| {
+                    (
+                        area.to_string(),
+                        a.events.iter().map(|e| e.to_string()).collect(),
+                    )
+                })
+            })
+            .collect();
+
+        for (area_name, event_names) in snapshots {
+            let subject = format!("area:{}", area_name);
+            for event_name in &event_names {
+                self.log_output(
+                    crate::messages::MessageSource::Area(area_name.clone()),
+                    subject.clone(),
+                    crate::output::GameOutput::AreaEvent(event_name, &area_name),
+                );
             }
+            self.log_output(
+                crate::messages::MessageSource::Area(area_name.clone()),
+                subject,
+                crate::output::GameOutput::AreaClose(&area_name),
+            );
         }
         Ok(())
     }
@@ -1035,8 +1097,6 @@ mod tests {
 
     #[test]
     fn test_announce_area_events() {
-        // Clear any messages from other tests running in parallel
-
         let mut game = Game::new("Test Game");
         let mut area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
         let mut rng = rand::rng();
@@ -1046,9 +1106,18 @@ mod tests {
 
         assert!(!game.areas[0].is_open());
         let _ = game.announce_area_events();
-        // announce_area_events does not yet emit messages; this test is a placeholder
-        // until area-event narration is restored (see hangrier_games-33r).
-        assert_eq!(game.messages.len(), 0);
+
+        // 2 AreaEvent lines + 1 AreaClose summary
+        assert_eq!(game.messages.len(), 3);
+        // All emitted under the Area channel for the affected area.
+        let area_name = Area::Cornucopia.to_string();
+        for msg in &game.messages {
+            assert_eq!(
+                msg.source,
+                crate::messages::MessageSource::Area(area_name.clone())
+            );
+            assert_eq!(msg.subject, format!("area:{}", area_name));
+        }
     }
 
     #[test]

--- a/game/tests/event_unification_area_events_test.rs
+++ b/game/tests/event_unification_area_events_test.rs
@@ -1,0 +1,109 @@
+//! Round-trip test for hangrier_games-33r (PR3: area-event survival slice).
+//!
+//! Verifies that area-event narration emitted by `process_event_for_area`
+//! and `announce_area_events` reaches `Game.messages` with the correct
+//! `MessageSource::Area(_)` tagging, and that per-tribute survival
+//! outcomes still surface as `MessageSource::Tribute(_)` entries. Together
+//! these confirm the full event slice is unified through `Game.messages`.
+
+use game::areas::events::AreaEvent;
+use game::areas::{Area, AreaDetails};
+use game::games::Game;
+use game::messages::{GameMessage, MessageSource};
+use game::terrain::{BaseTerrain, TerrainType};
+use game::tributes::Tribute;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+/// Drop two tributes into a single area, fire an `AreaEvent` directly via
+/// `process_event_for_area`, and assert that:
+/// - one `MessageSource::Area(_)` line announces the event itself
+/// - per-tribute survival narration appears as `MessageSource::Tribute(_)`
+///   carrying the matching tribute identifier
+#[test]
+fn area_event_survival_narration_reaches_game_messages() {
+    let mut game = Game::new("event-unification-area-events-test");
+
+    let area_details = AreaDetails::new_with_terrain(
+        Some("Cornucopia".to_string()),
+        Area::Cornucopia,
+        TerrainType::new(BaseTerrain::Clearing, vec![]).unwrap(),
+    );
+    game.areas.push(area_details);
+    let area = game.areas[0].area.unwrap();
+
+    let mut alpha = Tribute::random();
+    alpha.name = "Alpha".to_string();
+    alpha.area = area;
+    alpha.attributes.health = 100;
+    alpha.statistics.game = game.identifier.clone();
+    let alpha_id = alpha.identifier.clone();
+
+    let mut bravo = Tribute::random();
+    bravo.name = "Bravo".to_string();
+    bravo.area = area;
+    bravo.attributes.health = 100;
+    bravo.statistics.game = game.identifier.clone();
+    bravo.district = (alpha.district % 12) + 1;
+    let bravo_id = bravo.identifier.clone();
+
+    game.tributes.push(alpha);
+    game.tributes.push(bravo);
+
+    let mut rng = SmallRng::seed_from_u64(0xC0FFEE);
+    let event = AreaEvent::Wildfire;
+
+    let messages_before = game.messages.len();
+
+    game.process_event_for_area(&area, &event, &mut rng)
+        .expect("process_event_for_area succeeded");
+
+    let new_messages: Vec<&GameMessage> = game.messages.iter().skip(messages_before).collect();
+
+    assert!(
+        !new_messages.is_empty(),
+        "expected at least one game message after processing area event"
+    );
+
+    // Exactly one MessageSource::Area(_) opening announcement, tagged to
+    // our area name and using the canonical area:{name} subject.
+    let area_sourced: Vec<&&GameMessage> = new_messages
+        .iter()
+        .filter(|m| matches!(m.source, MessageSource::Area(_)))
+        .collect();
+    assert_eq!(
+        area_sourced.len(),
+        1,
+        "expected exactly one MessageSource::Area(_) announcement, got: {:?}",
+        new_messages.iter().map(|m| &m.source).collect::<Vec<_>>()
+    );
+    match &area_sourced[0].source {
+        MessageSource::Area(name) => assert_eq!(name, "Cornucopia"),
+        other => panic!("expected MessageSource::Area, got {other:?}"),
+    }
+    assert_eq!(area_sourced[0].subject, "area:Cornucopia");
+
+    // Per-tribute survival narration: at least one MessageSource::Tribute(_)
+    // entry per tribute, identifiers must match our two tributes.
+    let tribute_sourced: Vec<&&GameMessage> = new_messages
+        .iter()
+        .filter(|m| matches!(m.source, MessageSource::Tribute(_)))
+        .collect();
+    assert!(
+        !tribute_sourced.is_empty(),
+        "expected at least one MessageSource::Tribute(_) survival outcome, \
+         got sources: {:?}",
+        new_messages.iter().map(|m| &m.source).collect::<Vec<_>>()
+    );
+    for msg in &tribute_sourced {
+        match &msg.source {
+            MessageSource::Tribute(id) => {
+                assert!(
+                    id == &alpha_id || id == &bravo_id,
+                    "unexpected tribute identifier in message source: {id}"
+                );
+            }
+            other => panic!("filter let through non-Tribute source: {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Final slice of `hangrier_games-33r`. Routes area-event narration through `Game.messages` with proper `MessageSource` tagging, completing the unification PR1 (#109, combat) and PR2 (#110, movement/turn-phase) began.

## Changes

- **`SurvivalResult` enriched** with `roll: i32`, `modifier: i32`, `severity: EventSeverity` so callers can surface the underlying d20 mechanics. Populated at all three `survival_check` return sites.
- **`process_event_for_area`** now emits a per-event opening line under `MessageSource::Area(area_name)` (subject `area:{name}`), and per-tribute outcomes carry an enriched `[{Severity:?} severity, rolled {roll}{±modifier}]` detail. Survivors now always get a baseline survival message — previously silent when no rewards landed.
- **`announce_area_events`** implemented (was a `&self` stub). For each closed area: one `GameOutput::AreaEvent` line per active event plus one `GameOutput::AreaClose` summary, all tagged `MessageSource::Area`. Signature promoted to `&mut self`; sole caller (`run_day_night_cycle`) is already mutable.
- **Tests**: replaced the placeholder `test_announce_area_events` with a real assertion (message count, source tagging, subject formatting). Added `event_unification_area_events_test.rs` round-tripping `process_event_for_area` and asserting both `MessageSource::Area(_)` and `MessageSource::Tribute(_)` entries reach `Game.messages` with the expected identifiers.

## Verification

- `cargo check --package game` — clean
- `cargo check --package api` — clean
- `cargo clippy --package game --tests` — clean
- `cargo fmt --all` — clean
- `cargo test --package game --lib --tests` — 550+ tests pass

Note: `test_mountains_favors_combat_gear` is a pre-existing flaky RNG-based distribution test unrelated to this slice; passes in isolation.

## Follow-ups

- `hangrier_games-33r` — close after this PR merges.
- `hangrier_games-mqi` (P3) — open: replace `GameOutput` with a serializable `GameEvent`.