### PR TITLE
test(game): fix doctest module paths and stabilize item-distribution tests

### DIFF
--- a/game/src/items/mod.rs
+++ b/game/src/items/mod.rs
@@ -160,8 +160,8 @@ impl Item {
     ///
     /// # Example
     /// ```
-    /// use hangrier_games::items::Item;
-    /// use hangrier_games::terrain::BaseTerrain;
+    /// use game::items::Item;
+    /// use game::terrain::BaseTerrain;
     ///
     /// // Desert terrain favors consumables (0.6 weight)
     /// let item = Item::new_random_with_terrain(BaseTerrain::Desert, None);

--- a/game/src/messages.rs
+++ b/game/src/messages.rs
@@ -45,8 +45,8 @@ impl GameMessage {
 ///
 /// # Examples
 /// ```
-/// use hangrier_games::messages::movement_narrative;
-/// use hangrier_games::terrain::BaseTerrain;
+/// use game::messages::movement_narrative;
+/// use game::terrain::BaseTerrain;
 ///
 /// let desc = movement_narrative(BaseTerrain::Desert, "Alice");
 /// // Returns: "Alice struggles through the scorching desert sands"
@@ -133,8 +133,8 @@ pub fn movement_narrative(terrain: BaseTerrain, tribute_name: &str) -> String {
 ///
 /// # Examples
 /// ```
-/// use hangrier_games::messages::hiding_spot_narrative;
-/// use hangrier_games::terrain::BaseTerrain;
+/// use game::messages::hiding_spot_narrative;
+/// use game::terrain::BaseTerrain;
 ///
 /// let desc = hiding_spot_narrative(BaseTerrain::Forest, "Bob");
 /// // Returns: "Bob conceals themselves behind dense foliage, nearly invisible"
@@ -236,8 +236,8 @@ pub fn hiding_spot_narrative(terrain: BaseTerrain, tribute_name: &str) -> String
 ///
 /// # Examples
 /// ```
-/// use hangrier_games::messages::stamina_narrative;
-/// use hangrier_games::terrain::BaseTerrain;
+/// use game::messages::stamina_narrative;
+/// use game::terrain::BaseTerrain;
 ///
 /// let desc = stamina_narrative(BaseTerrain::Mountains, 30);
 /// // Returns: "The harsh mountain terrain is taking a severe toll..."

--- a/game/tests/item_distribution_test.rs
+++ b/game/tests/item_distribution_test.rs
@@ -10,8 +10,9 @@ fn test_desert_favors_consumables() {
     let mut weapon_count = 0;
     let mut shield_count = 0;
 
-    // Generate 100 items and count distribution
-    for _ in 0..100 {
+    // Generate 1000 items so the distribution assertions below are
+    // stable across RNG tails (n=100 was tail-flaky).
+    for _ in 0..1000 {
         let item = Item::new_random_with_terrain(terrain, None);
         if item.is_weapon() {
             weapon_count += 1;
@@ -22,10 +23,10 @@ fn test_desert_favors_consumables() {
         }
     }
 
-    // Consumables should be the majority (expect ~60% = 60 items)
-    // Allow variance but should be clearly dominant
+    // Consumables should be the majority (expect ~60% = 600 items).
+    // Allow variance but should be clearly dominant.
     assert!(
-        consumable_count > 40,
+        consumable_count > 400,
         "Desert should favor consumables: got {} consumables, {} weapons, {} shields",
         consumable_count,
         weapon_count,
@@ -46,7 +47,7 @@ fn test_urban_ruins_favors_weapons() {
     let mut shield_count = 0;
     let mut consumable_count = 0;
 
-    for _ in 0..100 {
+    for _ in 0..1000 {
         let item = Item::new_random_with_terrain(terrain, None);
         if item.is_weapon() {
             weapon_count += 1;
@@ -57,9 +58,9 @@ fn test_urban_ruins_favors_weapons() {
         }
     }
 
-    // Weapons should be the plurality (expect ~50% = 50 items)
+    // Weapons should be the plurality (expect ~50% = 500 items).
     assert!(
-        weapon_count > 30,
+        weapon_count > 300,
         "UrbanRuins should favor weapons: got {} weapons, {} shields, {} consumables",
         weapon_count,
         shield_count,
@@ -119,7 +120,7 @@ fn test_mountains_favors_combat_gear() {
     let mut shield_count = 0;
     let mut consumable_count = 0;
 
-    for _ in 0..100 {
+    for _ in 0..1000 {
         let item = Item::new_random_with_terrain(terrain, None);
         if item.is_weapon() {
             weapon_count += 1;
@@ -130,10 +131,10 @@ fn test_mountains_favors_combat_gear() {
         }
     }
 
-    // Combat gear (weapons + shields) should dominate
+    // Combat gear (weapons + shields) should dominate.
     let combat_gear = weapon_count + shield_count;
     assert!(
-        combat_gear > 60,
+        combat_gear > 600,
         "Mountains should favor combat gear: got {} weapons + {} shields = {} total",
         weapon_count,
         shield_count,
@@ -154,7 +155,9 @@ fn test_tundra_distribution() {
     let mut shield_count = 0;
     let mut consumable_count = 0;
 
-    for _ in 0..100 {
+    // Use a larger sample so the 0.3/0.4/0.3 distribution stabilises
+    // (n=100 regularly produced ties given the narrow shield margin).
+    for _ in 0..1000 {
         let item = Item::new_random_with_terrain(terrain, None);
         if item.is_weapon() {
             weapon_count += 1;


### PR DESCRIPTION
## Summary

Cleanup of two latent test-suite issues in the `game` crate surfaced while
closing out the ongoing test-repair work (`2ox`, `x65`). The originally
listed failures in those issues were already fixed upstream in PR #103;
this PR cleans up the remaining real failures that running the full
suite still exposed.

## Changes

- **Doctest module paths** (`game/src/messages.rs`, `game/src/items/mod.rs`):
  Replace stale `hangrier_games::...` paths with `game::...` in 4
  doctests. The crate was renamed to `game` in `Cargo.toml`, leaving
  these doctests failing to compile with E0433.
- **Item distribution test flakiness** (`game/tests/item_distribution_test.rs`):
  `Item::new_random_with_terrain` uses the global `rand::rng()`, so
  deterministic seeding is not available. Bump sample sizes on the
  desert / urban-ruins / mountains / tundra tests from 100 to 1000 so
  assertions sit at >3σ tolerance. Thresholds scaled proportionally.
  `test_clearing_balanced_distribution` already has sufficient margin
  at n=150 and is untouched.

## Verification

```
cargo test --package game        # 605 tests, 0 failures (lib + integration + doc)
cargo fmt --check                # clean
cargo clippy --package game      # clean
```

Ran the distribution suite 3× back-to-back; all runs stable.

## Follow-ups

- Closes `hangrier_games-2ox`
- Closes `hangrier_games-x65`
- `hangrier_games-fjq` (game-crate test repairs from psychotic-break / messages refactors) is still open and unrelated to this PR.