### PR TITLE
fix(api): adapt integration tests to axum-test 20.0 API

### DIFF
--- a/api/tests/IMPLEMENTATION_SUMMARY.md
+++ b/api/tests/IMPLEMENTATION_SUMMARY.md
@@ -86,7 +86,7 @@ async fn test_feature() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
     
     // Test code here
     

--- a/api/tests/README.md
+++ b/api/tests/README.md
@@ -145,7 +145,7 @@ async fn test_my_feature() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
     
     // Your test code here
     

--- a/api/tests/auth_tests.rs
+++ b/api/tests/auth_tests.rs
@@ -10,7 +10,7 @@ async fn test_user_registration() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let test_user = TestUser::new("testuser1");
 
@@ -38,7 +38,7 @@ async fn test_user_authentication() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let test_user = TestUser::new("testuser2");
 
@@ -77,7 +77,7 @@ async fn test_authentication_wrong_password() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let test_user = TestUser::new("testuser3");
 
@@ -112,7 +112,7 @@ async fn test_token_refresh() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let test_user = TestUser::new("testuser4");
 
@@ -157,7 +157,7 @@ async fn test_logout() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let test_user = TestUser::new("testuser5");
 
@@ -204,7 +204,7 @@ async fn test_duplicate_username() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let test_user = TestUser::new("duplicate_user");
 
@@ -244,7 +244,7 @@ async fn test_session_endpoint() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let test_user = TestUser::new("testuser6");
 
@@ -265,10 +265,7 @@ async fn test_session_endpoint() {
     // Call session endpoint with token
     let session_response = server
         .get("/api/users")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            format!("Bearer {}", access_token).parse().unwrap(),
-        )
+        .add_header("Authorization", format!("Bearer {}", access_token))
         .await;
 
     session_response.assert_status_ok();

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use api::AppState;
 use axum::Router;
 use std::sync::Arc;
@@ -64,7 +66,7 @@ impl TestDb {
     pub async fn cleanup(&self) {
         // Note: In a real test setup, you might want to drop the entire database
         // For now, we'll just clear the tables
-        let _: Result<Vec<serde_json::Value>, _> = self.db.query("REMOVE DATABASE $this").await;
+        let _ = self.db.query("REMOVE DATABASE $this").await;
     }
 }
 

--- a/api/tests/games_tests.rs
+++ b/api/tests/games_tests.rs
@@ -30,16 +30,13 @@ async fn test_create_game() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "game_creator1").await;
 
     let response = server
         .post("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 24,
             "tribute_pool": 24,
@@ -63,7 +60,7 @@ async fn test_list_games() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "game_lister").await;
 
@@ -71,10 +68,7 @@ async fn test_list_games() {
     for _ in 0..3 {
         server
             .post("/api/games")
-            .add_header(
-                "Authorization".parse().unwrap(),
-                user.auth_header().parse().unwrap(),
-            )
+            .add_header("Authorization", user.auth_header())
             .json(&json!({
                 "max_tributes": 24,
                 "tribute_pool": 24,
@@ -87,10 +81,7 @@ async fn test_list_games() {
     // List games
     let response = server
         .get("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     response.assert_status_ok();
@@ -111,17 +102,14 @@ async fn test_get_game() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "game_getter").await;
 
     // Create a game
     let create_response = server
         .post("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 24,
             "tribute_pool": 24,
@@ -135,10 +123,7 @@ async fn test_get_game() {
     // Get the game
     let get_response = server
         .get(&format!("/api/games/{}", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     get_response.assert_status_ok();
@@ -155,17 +140,14 @@ async fn test_update_game() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "game_updater").await;
 
     // Create a game
     let create_response = server
         .post("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 24,
             "tribute_pool": 24,
@@ -179,10 +161,7 @@ async fn test_update_game() {
     // Update the game
     let update_response = server
         .put(&format!("/api/games/{}", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 12,
         }))
@@ -202,17 +181,14 @@ async fn test_delete_game() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "game_deleter").await;
 
     // Create a game
     let create_response = server
         .post("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 24,
             "tribute_pool": 24,
@@ -226,10 +202,7 @@ async fn test_delete_game() {
     // Delete the game
     let delete_response = server
         .delete(&format!("/api/games/{}", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     delete_response.assert_status(axum::http::StatusCode::NO_CONTENT);
@@ -237,10 +210,7 @@ async fn test_delete_game() {
     // Try to get the deleted game - should return 404
     let get_response = server
         .get(&format!("/api/games/{}", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     get_response.assert_status(axum::http::StatusCode::NOT_FOUND);
@@ -254,17 +224,14 @@ async fn test_game_display() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "game_displayer").await;
 
     // Create a game
     let create_response = server
         .post("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 24,
             "tribute_pool": 24,
@@ -278,10 +245,7 @@ async fn test_game_display() {
     // Get the game display
     let display_response = server
         .get(&format!("/api/games/{}/display", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     display_response.assert_status_ok();
@@ -299,17 +263,14 @@ async fn test_game_areas() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "area_viewer").await;
 
     // Create a game
     let create_response = server
         .post("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 24,
             "tribute_pool": 24,
@@ -323,10 +284,7 @@ async fn test_game_areas() {
     // Get game areas
     let areas_response = server
         .get(&format!("/api/games/{}/areas", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     areas_response.assert_status_ok();
@@ -346,17 +304,14 @@ async fn test_publish_game() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "game_publisher").await;
 
     // Create a game
     let create_response = server
         .post("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 24,
             "tribute_pool": 24,
@@ -370,10 +325,7 @@ async fn test_publish_game() {
     // Publish the game
     let publish_response = server
         .put(&format!("/api/games/{}/publish", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     publish_response.assert_status_ok();
@@ -390,17 +342,14 @@ async fn test_unpublish_game() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "game_unpublisher").await;
 
     // Create and publish a game
     let create_response = server
         .post("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 24,
             "tribute_pool": 24,
@@ -413,20 +362,14 @@ async fn test_unpublish_game() {
 
     server
         .put(&format!("/api/games/{}/publish", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await
         .assert_status_ok();
 
     // Unpublish the game
     let unpublish_response = server
         .put(&format!("/api/games/{}/unpublish", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     unpublish_response.assert_status_ok();
@@ -443,7 +386,7 @@ async fn test_unauthorized_game_access() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     // Try to create a game without authentication
     let response = server

--- a/api/tests/simulation_tests.rs
+++ b/api/tests/simulation_tests.rs
@@ -33,10 +33,7 @@ async fn create_game_with_tributes(
     // Create game
     let game_response = server
         .post("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 24,
             "tribute_pool": 24,
@@ -52,10 +49,7 @@ async fn create_game_with_tributes(
         let district = (i % 12) + 1;
         server
             .post(&format!("/api/games/{}/tributes", game_id))
-            .add_header(
-                "Authorization".parse().unwrap(),
-                user.auth_header().parse().unwrap(),
-            )
+            .add_header("Authorization", user.auth_header())
             .json(&json!({
                 "name": format!("Tribute {}", i + 1),
                 "district": district,
@@ -73,7 +67,7 @@ async fn test_advance_game() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "game_advancer").await;
     let game_id = create_game_with_tributes(&server, &user, 4).await;
@@ -81,10 +75,7 @@ async fn test_advance_game() {
     // Advance the game
     let response = server
         .put(&format!("/api/games/{}/next", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     response.assert_status_ok();
@@ -105,7 +96,7 @@ async fn test_game_status_transitions() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "status_tester").await;
     let game_id = create_game_with_tributes(&server, &user, 2).await;
@@ -113,10 +104,7 @@ async fn test_game_status_transitions() {
     // Check initial status
     let get_response = server
         .get(&format!("/api/games/{}", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     let get_body = get_response.json::<serde_json::Value>();
@@ -125,10 +113,7 @@ async fn test_game_status_transitions() {
     // Advance game - should transition to running
     let advance_response = server
         .put(&format!("/api/games/{}/next", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     let advance_body = advance_response.json::<serde_json::Value>();
@@ -144,7 +129,7 @@ async fn test_game_day_logs() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "log_viewer").await;
     let game_id = create_game_with_tributes(&server, &user, 4).await;
@@ -152,20 +137,14 @@ async fn test_game_day_logs() {
     // Advance game to generate logs
     server
         .put(&format!("/api/games/{}/next", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await
         .assert_status_ok();
 
     // Get logs for day 1
     let log_response = server
         .get(&format!("/api/games/{}/log/1", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     log_response.assert_status_ok();
@@ -182,7 +161,7 @@ async fn test_tribute_day_logs() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "tribute_log_viewer").await;
     let game_id = create_game_with_tributes(&server, &user, 4).await;
@@ -190,10 +169,7 @@ async fn test_tribute_day_logs() {
     // Get tribute ID
     let game_response = server
         .get(&format!("/api/games/{}", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     let game_body = game_response.json::<serde_json::Value>();
@@ -203,20 +179,14 @@ async fn test_tribute_day_logs() {
     // Advance game
     server
         .put(&format!("/api/games/{}/next", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await
         .assert_status_ok();
 
     // Get tribute logs for day 1
     let log_response = server
         .get(&format!("/api/games/{}/log/1/{}", game_id, tribute_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     log_response.assert_status_ok();
@@ -233,7 +203,7 @@ async fn test_multiple_game_cycles() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "cycle_tester").await;
     let game_id = create_game_with_tributes(&server, &user, 4).await;
@@ -242,10 +212,7 @@ async fn test_multiple_game_cycles() {
     for _ in 0..3 {
         let response = server
             .put(&format!("/api/games/{}/next", game_id))
-            .add_header(
-                "Authorization".parse().unwrap(),
-                user.auth_header().parse().unwrap(),
-            )
+            .add_header("Authorization", user.auth_header())
             .await;
 
         response.assert_status_ok();
@@ -258,10 +225,7 @@ async fn test_multiple_game_cycles() {
     // Verify final state
     let get_response = server
         .get(&format!("/api/games/{}", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     let get_body = get_response.json::<serde_json::Value>();
@@ -277,7 +241,7 @@ async fn test_game_finishes_with_winner() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "winner_tester").await;
     let game_id = create_game_with_tributes(&server, &user, 2).await;
@@ -289,10 +253,7 @@ async fn test_game_finishes_with_winner() {
     while status != "finished" && iterations < 50 {
         let response = server
             .put(&format!("/api/games/{}/next", game_id))
-            .add_header(
-                "Authorization".parse().unwrap(),
-                user.auth_header().parse().unwrap(),
-            )
+            .add_header("Authorization", user.auth_header())
             .await;
 
         if response.status_code() != axum::http::StatusCode::OK {
@@ -317,7 +278,7 @@ async fn test_advance_finished_game() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "finished_game_tester").await;
     let game_id = create_game_with_tributes(&server, &user, 2).await;
@@ -326,10 +287,7 @@ async fn test_advance_finished_game() {
     for _ in 0..50 {
         let response = server
             .put(&format!("/api/games/{}/next", game_id))
-            .add_header(
-                "Authorization".parse().unwrap(),
-                user.auth_header().parse().unwrap(),
-            )
+            .add_header("Authorization", user.auth_header())
             .await;
 
         if !response.status_code().is_success() {
@@ -345,10 +303,7 @@ async fn test_advance_finished_game() {
     // Try to advance the finished game
     let response = server
         .put(&format!("/api/games/{}/next", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     // Should either return error or return the same state
@@ -366,7 +321,7 @@ async fn test_game_state_persistence() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "persistence_tester").await;
     let game_id = create_game_with_tributes(&server, &user, 4).await;
@@ -374,20 +329,14 @@ async fn test_game_state_persistence() {
     // Advance game
     server
         .put(&format!("/api/games/{}/next", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await
         .assert_status_ok();
 
     // Get game state
     let get_response1 = server
         .get(&format!("/api/games/{}", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     let body1 = get_response1.json::<serde_json::Value>();
@@ -396,20 +345,14 @@ async fn test_game_state_persistence() {
     // Advance again
     server
         .put(&format!("/api/games/{}/next", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await
         .assert_status_ok();
 
     // Get game state again
     let get_response2 = server
         .get(&format!("/api/games/{}", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     let body2 = get_response2.json::<serde_json::Value>();

--- a/api/tests/tributes_tests.rs
+++ b/api/tests/tributes_tests.rs
@@ -28,10 +28,7 @@ async fn create_authenticated_user(server: &TestServer, username: &str) -> TestU
 async fn create_test_game(server: &TestServer, user: &TestUser) -> String {
     let response = server
         .post("/api/games")
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "max_tributes": 24,
             "tribute_pool": 24,
@@ -49,17 +46,14 @@ async fn test_create_tribute() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "tribute_creator1").await;
     let game_id = create_test_game(&server, &user).await;
 
     let response = server
         .post(&format!("/api/games/{}/tributes", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "name": "Katniss Everdeen",
             "district": 12,
@@ -84,7 +78,7 @@ async fn test_get_tribute() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "tribute_getter").await;
     let game_id = create_test_game(&server, &user).await;
@@ -92,10 +86,7 @@ async fn test_get_tribute() {
     // Create a tribute
     let create_response = server
         .post(&format!("/api/games/{}/tributes", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "name": "Peeta Mellark",
             "district": 12,
@@ -108,10 +99,7 @@ async fn test_get_tribute() {
     // Get the tribute
     let get_response = server
         .get(&format!("/api/games/{}/tributes/{}", game_id, tribute_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     get_response.assert_status_ok();
@@ -129,7 +117,7 @@ async fn test_update_tribute() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "tribute_updater").await;
     let game_id = create_test_game(&server, &user).await;
@@ -137,10 +125,7 @@ async fn test_update_tribute() {
     // Create a tribute
     let create_response = server
         .post(&format!("/api/games/{}/tributes", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "name": "Rue",
             "district": 11,
@@ -153,10 +138,7 @@ async fn test_update_tribute() {
     // Update the tribute
     let update_response = server
         .put(&format!("/api/games/{}/tributes/{}", game_id, tribute_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "name": "Rue (Updated)",
         }))
@@ -176,7 +158,7 @@ async fn test_delete_tribute() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "tribute_deleter").await;
     let game_id = create_test_game(&server, &user).await;
@@ -184,10 +166,7 @@ async fn test_delete_tribute() {
     // Create a tribute
     let create_response = server
         .post(&format!("/api/games/{}/tributes", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "name": "Cato",
             "district": 2,
@@ -200,10 +179,7 @@ async fn test_delete_tribute() {
     // Delete the tribute
     let delete_response = server
         .delete(&format!("/api/games/{}/tributes/{}", game_id, tribute_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     delete_response.assert_status(axum::http::StatusCode::NO_CONTENT);
@@ -211,10 +187,7 @@ async fn test_delete_tribute() {
     // Try to get the deleted tribute - should return 404
     let get_response = server
         .get(&format!("/api/games/{}/tributes/{}", game_id, tribute_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     get_response.assert_status(axum::http::StatusCode::NOT_FOUND);
@@ -228,7 +201,7 @@ async fn test_create_multiple_tributes() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "multi_tribute_creator").await;
     let game_id = create_test_game(&server, &user).await;
@@ -239,10 +212,7 @@ async fn test_create_multiple_tributes() {
     for (name, district) in tributes {
         let response = server
             .post(&format!("/api/games/{}/tributes", game_id))
-            .add_header(
-                "Authorization".parse().unwrap(),
-                user.auth_header().parse().unwrap(),
-            )
+            .add_header("Authorization", user.auth_header())
             .json(&json!({
                 "name": name,
                 "district": district,
@@ -261,7 +231,7 @@ async fn test_tribute_log() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "tribute_logger").await;
     let game_id = create_test_game(&server, &user).await;
@@ -269,10 +239,7 @@ async fn test_tribute_log() {
     // Create a tribute
     let create_response = server
         .post(&format!("/api/games/{}/tributes", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "name": "Finnick Odair",
             "district": 4,
@@ -288,10 +255,7 @@ async fn test_tribute_log() {
             "/api/games/{}/tributes/{}/log",
             game_id, tribute_id
         ))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     log_response.assert_status_ok();
@@ -308,7 +272,7 @@ async fn test_tribute_items() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "tribute_item_tester").await;
     let game_id = create_test_game(&server, &user).await;
@@ -316,10 +280,7 @@ async fn test_tribute_items() {
     // Create a tribute
     let create_response = server
         .post(&format!("/api/games/{}/tributes", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "name": "Johanna Mason",
             "district": 7,
@@ -332,10 +293,7 @@ async fn test_tribute_items() {
     // Get tribute details (should include items)
     let get_response = server
         .get(&format!("/api/games/{}/tributes/{}", game_id, tribute_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .await;
 
     get_response.assert_status_ok();
@@ -352,7 +310,7 @@ async fn test_create_tribute_validation() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "tribute_validator").await;
     let game_id = create_test_game(&server, &user).await;
@@ -360,10 +318,7 @@ async fn test_create_tribute_validation() {
     // Try to create tribute without name
     let response = server
         .post(&format!("/api/games/{}/tributes", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "district": 1,
         }))
@@ -384,7 +339,7 @@ async fn test_tribute_district_validation() {
     let test_db = TestDb::new().await;
     let app_state = test_db.app_state();
     let router = create_test_router(app_state);
-    let server = TestServer::new(router).unwrap();
+    let server = TestServer::new(router);
 
     let user = create_authenticated_user(&server, "district_validator").await;
     let game_id = create_test_game(&server, &user).await;
@@ -392,10 +347,7 @@ async fn test_tribute_district_validation() {
     // Try to create tribute with invalid district
     let response = server
         .post(&format!("/api/games/{}/tributes", game_id))
-        .add_header(
-            "Authorization".parse().unwrap(),
-            user.auth_header().parse().unwrap(),
-        )
+        .add_header("Authorization", user.auth_header())
         .json(&json!({
             "name": "Invalid District",
             "district": 99,


### PR DESCRIPTION
## Summary

Restores `cargo check -p api --tests` and `cargo clippy -p api --tests -- -D warnings` to a clean state. Pre-existing breakage from `axum-test` upgrade to 20.0 had left every API integration test file failing to compile.

Closes hangrier_games-dz9.

## Changes

- `TestServer::new(...)` no longer returns `Result` in axum-test 20.0 — stripped `.unwrap()` from all call sites in `auth_tests.rs`, `tributes_tests.rs`, `simulation_tests.rs`, `games_tests.rs` (plus the matching examples in `README.md` and `IMPLEMENTATION_SUMMARY.md`).
- `add_header(...)` now accepts `TryInto<HeaderName>` / `TryInto<HeaderValue>` directly. The previous `"Bearer ...".parse().unwrap()` form triggered `E0284` (cannot infer the target type). Removed the redundant `.parse().unwrap()` so the compiler picks the impls directly.
- `common/mod.rs` `cleanup()` had an `E0308` mismatch — `surrealdb::Surreal::query(...).await` returns `Result<surrealdb::Response, surrealdb::Error>`, not `Result<Vec<serde_json::Value>, _>`. Replaced the misleading annotation with a plain `let _ = ...`.
- Added `#![allow(dead_code)]` to `api/tests/common/mod.rs`. The shared test harness (`TestUser`, `create_test_router`, `surreal_jwt`, etc.) is intentionally kept available for future tests but not every helper is referenced from every test binary; without this, `-D warnings` from `dead_code` blocks compilation.

## Verification

- ` cargo check -p api --tests` ✅ clean
- `cargo clippy -p api --tests -- -D warnings` ✅ clean
- `cargo clippy -p api -p game -- -D warnings` ✅ clean
- `cargo test -p game` ✅ all doctests pass
- ⚠️ `cargo test -p api --tests --no-run` not exercised in this change — link step exceeded local timeout (axum-test + surrealdb + tokio-tungstenite is a heavy dep tree). Runtime tests also require a live SurrealDB. Compile-only fix; tracked as a follow-up.

## Follow-ups

- Open: hangrier_games-54e (web crate clippy debt, ~32 warnings — next PR)
- New (will file): verify api integration tests pass at runtime against a live SurrealDB
- New (will file): add `.github/workflows/ci.yml` running `just quality` on PRs to `main` so this class of regression is caught at PR time