### PR TITLE
chore(web): fix pre-existing clippy warnings

### DIFF
--- a/web/src/components/accounts.rs
+++ b/web/src/components/accounts.rs
@@ -175,13 +175,12 @@ fn LoginForm() -> Element {
                                         let navigator = use_navigator();
                                         navigator.replace(Routes::GamesList {});
                                 }
-                            } else if let MutationState::Settled(Err(err)) = mutate.result().deref() {
-                                if let MutationError::UnableToAuthenticateUser = err {
+                            } else if let MutationState::Settled(Err(err)) = mutate.result().deref()
+                                && let MutationError::UnableToAuthenticateUser = err {
                                         username_error_signal.set("Unable to authenticate user".to_string());
                                         disabled_signal.set(false);
 
                                 }
-                            }
                         });
                     }
                 },
@@ -298,24 +297,22 @@ fn RegisterForm() -> Element {
                             };
                             mutate.mutate_async(user).await;
                             match mutate.result().deref() {
-                                MutationState::Settled(Ok(result)) => {
-                                    if let MutationValue::User(user) = result {
-                                        client.invalidate_queries(&[QueryKey::User]);
-                                        disabled_signal.set(false);
-                                        username_signal.set(String::default());
-                                        password_signal.set(String::default());
-                                        password2_signal.set(String::default());
-                                        password_error_signal.set(String::default());
-                                        username_error_signal.set(String::default());
+                                MutationState::Settled(Ok(MutationValue::User(user))) => {
+                                    client.invalidate_queries(&[QueryKey::User]);
+                                    disabled_signal.set(false);
+                                    username_signal.set(String::default());
+                                    password_signal.set(String::default());
+                                    password2_signal.set(String::default());
+                                    password_error_signal.set(String::default());
+                                    username_error_signal.set(String::default());
 
-                                        let mut state = storage.get();
-                                        state.jwt = Some(user.jwt.clone());
-                                        state.username = Some(username.clone());
-                                        storage.set(state);
+                                    let mut state = storage.get();
+                                    state.jwt = Some(user.jwt.clone());
+                                    state.username = Some(username.clone());
+                                    storage.set(state);
 
-                                        let navigator = use_navigator();
-                                        navigator.replace(Routes::GamesList {});
-                                    }
+                                    let navigator = use_navigator();
+                                    navigator.replace(Routes::GamesList {});
                                 },
                                 MutationState::Settled(Err(err)) => {
                                     if let MutationError::UnableToRegisterUser = err {
@@ -376,7 +373,7 @@ fn RegisterForm() -> Element {
                 }
                 div {
                     ThemedButton {
-                        disabled: Some(disabled_signal.read().clone()),
+                        disabled: Some(*disabled_signal.read()),
                         r#type: "submit",
                         "Register"
                     }

--- a/web/src/components/app.rs
+++ b/web/src/components/app.rs
@@ -18,7 +18,7 @@ pub fn App() -> Element {
 
     let storage = use_persistent("hangry-games", AppState::default);
 
-    let loading_signal: Signal<LoadingState> = use_signal(|| LoadingState::default());
+    let loading_signal: Signal<LoadingState> = use_signal(LoadingState::default);
     use_context_provider(|| loading_signal);
 
     let theme_signal: Signal<Colorscheme> = use_signal(|| storage.get().colorscheme);

--- a/web/src/components/create_game.rs
+++ b/web/src/components/create_game.rs
@@ -58,12 +58,11 @@ pub fn CreateGameButton() -> Element {
         let token = storage.get().jwt.expect("No JWT found");
         spawn(async move {
             mutate.mutate_async((None, token)).await;
-            if let MutationState::Settled(Ok(result)) = mutate.result().deref() {
-                if let MutationValue::NewGame(_game) = result {
+            if let MutationState::Settled(Ok(result)) = mutate.result().deref()
+                && let MutationValue::NewGame(_game) = result {
                     client.invalidate_queries(&[QueryKey::Games]);
                     loading_signal.set(LoadingState::Loaded);
-                }
-            };
+                };
         });
     };
 
@@ -94,13 +93,12 @@ pub fn CreateGameForm() -> Element {
 
         spawn(async move {
             mutate.mutate_async((Some(name), token)).await;
-            if let MutationState::Settled(Ok(result)) = mutate.result().deref() {
-                if let MutationValue::NewGame(_game) = result {
+            if let MutationState::Settled(Ok(result)) = mutate.result().deref()
+                && let MutationValue::NewGame(_game) = result {
                     client.invalidate_queries(&[QueryKey::Games]);
                     loading_signal.set(LoadingState::Loaded);
                     game_name_signal.set(String::default());
                 }
-            }
         });
     };
 

--- a/web/src/components/game_detail.rs
+++ b/web/src/components/game_detail.rs
@@ -144,7 +144,7 @@ async fn handle_next_step(
                 | MutationValue::GameFinished(game_identifier)
                 | MutationValue::GameAdvanced(game_identifier) => {
                     client.invalidate_queries(&[
-                        QueryKey::DisplayGame(game_identifier.clone().into()),
+                        QueryKey::DisplayGame(game_identifier.clone()),
                         QueryKey::Games,
                     ]);
                     loading_signal.set(LoadingState::Loaded);
@@ -284,9 +284,9 @@ fn GameState(identifier: String) -> Element {
             let next_step_handler = move |_| {
                 let game_id_clone = game_id.clone();
                 let token_clone = token_clone.clone();
-                let mutate_clone = mutate.clone();
-                let client_clone = client.clone();
-                let loading_signal_clone = loading_signal.clone();
+                let mutate_clone = mutate;
+                let client_clone = client;
+                let loading_signal_clone = loading_signal;
 
                 spawn(async move {
                     handle_next_step(

--- a/web/src/components/game_edit.rs
+++ b/web/src/components/game_edit.rs
@@ -41,11 +41,11 @@ pub fn GameEdit(identifier: String, name: String, icon_class: String, private: b
 
     let onclick = move |_| {
         let name = name.clone();
-        let private = private.clone();
+        let private = private;
         edit_game_signal.set(Some(EditGame {
             identifier: identifier.clone(),
             name: name.clone(),
-            private: private.clone(),
+            private,
         }));
     };
 
@@ -109,15 +109,12 @@ pub fn EditGameForm() -> Element {
 
         let data = e.data().values();
         let name = data.get("name").expect("No name value").0[0].clone();
-        let private = {
-            match data.get("private").expect("No private value").0[0]
+        let private = matches!(
+            data.get("private").expect("No private value").0[0]
                 .clone()
-                .as_str()
-            {
-                "on" => true,
-                _ => false,
-            }
-        };
+                .as_str(),
+            "on"
+        );
 
         if !name.is_empty() {
             let edit_game = EditGame {

--- a/web/src/components/game_tributes.rs
+++ b/web/src/components/game_tributes.rs
@@ -180,7 +180,7 @@ pub fn GameTributeListMember(
     game_status: GameStatus,
 ) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
-    let token = storage.get().jwt.expect("No JWT found");
+    let _token = storage.get().jwt.expect("No JWT found");
 
     let fist_item = Item::new_weapon("basic fist");
 

--- a/web/src/components/games_list.rs
+++ b/web/src/components/games_list.rs
@@ -9,7 +9,7 @@ use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
 use dioxus_query::prelude::{QueryResult, QueryState, use_get_query, use_query_client};
 use serde::{Deserialize, Serialize};
-use shared::{DisplayGame, GameStatus, ListDisplayGame, PaginationMetadata};
+use shared::{GameStatus, ListDisplayGame, PaginationMetadata};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct PaginatedGamesResponse {
@@ -213,7 +213,7 @@ pub fn GameListMember(game: ListDisplayGame) -> Element {
                         GameEdit {
                             identifier: game.identifier.clone(),
                             name: game.name.clone(),
-                            private: game.private.clone(),
+                            private: game.private,
                             icon_class: r#"
                             size-4
                             theme1:fill-amber-600
@@ -303,10 +303,10 @@ pub fn GameListMember(game: ListDisplayGame) -> Element {
 #[component]
 fn LoadMoreButton(current_offset: u32, limit: u32) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
-    let token = storage.get().jwt.expect("No JWT found");
+    let _token = storage.get().jwt.expect("No JWT found");
     let client = use_query_client::<QueryValue, QueryError, QueryKey>();
 
-    let next_offset = current_offset + limit;
+    let _next_offset = current_offset + limit;
 
     let onclick = move |_| {
         // TODO: Implement actual loading - for now just refresh to get next page

--- a/web/src/components/input.rs
+++ b/web/src/components/input.rs
@@ -12,7 +12,7 @@ pub struct InputProperties {
 
 #[component]
 pub fn Input(props: InputProperties) -> Element {
-    let classes = props.class.clone().unwrap_or(String::new());
+    let classes = props.class.clone().unwrap_or_default();
 
     rsx! {
         input {

--- a/web/src/components/loading_modal.rs
+++ b/web/src/components/loading_modal.rs
@@ -7,10 +7,7 @@ use dioxus::prelude::*;
 pub fn LoadingModal() -> Element {
     let loading_signal = use_context::<Signal<LoadingState>>();
 
-    let open = match *loading_signal.read() {
-        LoadingState::Loading => true,
-        _ => false,
-    };
+    let open = matches!(*loading_signal.read(), LoadingState::Loading);
 
     let props = ModalProps {
         title: "Loading...".to_string(),

--- a/web/src/components/map.rs
+++ b/web/src/components/map.rs
@@ -11,7 +11,6 @@ pub fn Map(areas: Vec<AreaDetails>) -> Element {
             (
                 area.clone()
                     .area
-                    .clone()
                     .unwrap()
                     .to_string()
                     .to_lowercase(),

--- a/web/src/components/navbar.rs
+++ b/web/src/components/navbar.rs
@@ -14,7 +14,7 @@ pub fn Navbar() -> Element {
         let jwt_string = storage.get().jwt.clone().unwrap_or_default();
         dioxus_logger::tracing::debug!("JWT String: {}", &jwt_string);
         let decoded = jwt_rustcrypto::decode_only(&jwt_string).expect("Failed to decode JWT");
-        let is_expired = decoded.payload.get("exp").map_or(false, |exp| {
+        let is_expired = decoded.payload.get("exp").is_some_and(|exp| {
             let exp_time = exp.as_i64().unwrap_or(0);
             let current_time = chrono::Utc::now().timestamp();
             dioxus_logger::tracing::debug!("difference: {}", current_time - exp_time);

--- a/web/src/components/server_version.rs
+++ b/web/src/components/server_version.rs
@@ -7,7 +7,7 @@ async fn fetch_server_version(keys: Vec<QueryKey>) -> QueryResult<QueryValue, Qu
     if let Some(QueryKey::ServerVersion) = keys.first() {
         let client = reqwest::Client::new();
 
-        let request = client.request(reqwest::Method::GET, format!("{}", APP_API_HOST));
+        let request = client.request(reqwest::Method::GET, APP_API_HOST.to_string());
 
         match request.send().await {
             Ok(response) => match response.json::<String>().await {

--- a/web/src/components/tribute_edit.rs
+++ b/web/src/components/tribute_edit.rs
@@ -116,7 +116,7 @@ pub fn EditTributeForm() -> Element {
     let identifier = tribute_details.identifier.clone();
 
     let mut avatar_preview = use_signal(|| avatar.clone());
-    let mut upload_status = use_signal(|| String::new());
+    let mut upload_status = use_signal(String::new);
 
     let mutate = use_mutation(edit_tribute);
 
@@ -177,9 +177,9 @@ pub fn EditTributeForm() -> Element {
         spawn(async move {
             let files = e.files();
 
-            if let Some(file_engine) = files {
-                if let Some(file_name) = file_engine.files().into_iter().next() {
-                    if let Some(file_data) = file_engine.read_file(&file_name).await {
+            if let Some(file_engine) = files
+                && let Some(file_name) = file_engine.files().into_iter().next()
+                    && let Some(file_data) = file_engine.read_file(&file_name).await {
                         // Upload file using multipart/form-data
                         let client = reqwest::Client::new();
                         let url = format!(
@@ -201,12 +201,11 @@ pub fn EditTributeForm() -> Element {
 
                         match response {
                             Ok(resp) if resp.status().is_success() => {
-                                if let Ok(json) = resp.json::<serde_json::Value>().await {
-                                    if let Some(url) = json.get("url").and_then(|v| v.as_str()) {
+                                if let Ok(json) = resp.json::<serde_json::Value>().await
+                                    && let Some(url) = json.get("url").and_then(|v| v.as_str()) {
                                         avatar_preview.set(url.to_string());
                                         upload_status.set("Upload successful!".to_string());
                                     }
-                                }
                             }
                             Ok(resp) => {
                                 upload_status.set(format!("Upload failed: {}", resp.status()));
@@ -216,8 +215,6 @@ pub fn EditTributeForm() -> Element {
                             }
                         }
                     }
-                }
-            }
         });
     };
 
@@ -272,7 +269,7 @@ pub fn EditTributeForm() -> Element {
                 form {
                     class: "mb-2",
                     onchange: upload_avatar,
-                    prevent_default: "onsubmit",
+                    onsubmit: |e| e.prevent_default(),
 
                     input {
                         r#type: "file",


### PR DESCRIPTION
## Summary

Resolves all 31 clippy warnings in the `web/` crate. Pre-existing debt; no behavior changes intended.

## Changes

- **collapsible_if / collapsible_match** (9): merged nested `if`/`match` blocks
- **clone_on_copy** (6): removed `.clone()` on `Copy` types (`bool`, `Signal`, `UseQueryClient`, `UseMutation`, `Option<Area>`)
- **match_like_matches_macro** (3): rewrote `match x { A => true, _ => false }` as `matches!(x, A)`
- **redundant_closure** (2): replaced `|x| f(x)` with `f`
- **useless_format / useless_conversion / unwrap_or_default / unnecessary_map_or / redundant_field_names**: standard cleanups
- **deprecated `prevent_default` attribute** (`tribute_edit.rs`): replaced with explicit `onsubmit: |e| e.prevent_default()` per Dioxus deprecation guidance

24 fixes applied via `cargo clippy --fix --lib -p web`; 7 manual.

## Verification

```
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' \
  cargo clippy --target wasm32-unknown-unknown -- -D warnings   # clean
cargo clippy --workspace --exclude web -- -D warnings           # clean
cargo fmt --check                                                # clean
cargo test -p game                                               # 4/4 doctests pass
```

## Follow-ups

- hangrier_games-qz4 — add `.github/workflows/ci.yml` running `just quality` on PRs (next PR)
- hangrier_games-t6p — verify api integration tests pass at runtime against live SurrealDB

Closes hangrier_games-54e