### PR TITLE
ci(github-actions): add quality workflow for PRs to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  quality:
+    name: Quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: web/assets/package-lock.json
+
+      - name: Build Tailwind CSS
+        # web/src/components/app.rs references asset!("/assets/dist/main.css")
+        # via the dioxus asset! macro, which fails at compile time if the
+        # file is missing. Tailwind isn't a cargo build step, so we run it
+        # explicitly here.
+        run: just build-css
+
+      - name: Generate web/src/env.rs (via build.rs)
+        # web/build.rs creates web/src/env.rs from APP_* env vars at build
+        # time. cargo fmt resolves `mod env;` and fails if the file is
+        # missing, so run a check pass first to materialize it.
+        run: cargo check --workspace
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace -- -D warnings
+
+      - name: Test (game)
+        run: cargo test --package game

--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -124,7 +124,7 @@ async fn create_game_area_edge(
     let game_id = RecordId::from(("game", &game_identifier_str));
 
     // Does the `area` exist for the game?
-    let existing_area: Option<Area> = db
+    let mut resp = db
         .query(
             r#"
         SELECT identifier
@@ -135,7 +135,9 @@ async fn create_game_area_edge(
         .bind(("name", area))
         .bind(("game_id", game_identifier_str.clone()))
         .await
-        .and_then(|mut resp| resp.take(0))
+        .map_err(|e| AppError::InternalServerError(format!("Failed to find area: {}", e)))?;
+    let existing_area: Option<Area> = resp
+        .take(0)
         .map_err(|e| AppError::InternalServerError(format!("Failed to find area: {}", e)))?;
 
     let area_uuid = if let Some(identifier) = existing_area {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
 edition = "2024"
-fn_single_line = true

--- a/web/src/cache.rs
+++ b/web/src/cache.rs
@@ -55,6 +55,7 @@ pub(crate) enum QueryValue {
 }
 
 #[allow(dead_code)]
+#[allow(clippy::large_enum_variant)]
 #[derive(PartialEq, Debug)]
 pub(crate) enum MutationValue {
     NewGame(Game),

--- a/web/src/components/create_game.rs
+++ b/web/src/components/create_game.rs
@@ -59,10 +59,11 @@ pub fn CreateGameButton() -> Element {
         spawn(async move {
             mutate.mutate_async((None, token)).await;
             if let MutationState::Settled(Ok(result)) = mutate.result().deref()
-                && let MutationValue::NewGame(_game) = result {
-                    client.invalidate_queries(&[QueryKey::Games]);
-                    loading_signal.set(LoadingState::Loaded);
-                };
+                && let MutationValue::NewGame(_game) = result
+            {
+                client.invalidate_queries(&[QueryKey::Games]);
+                loading_signal.set(LoadingState::Loaded);
+            };
         });
     };
 
@@ -94,11 +95,12 @@ pub fn CreateGameForm() -> Element {
         spawn(async move {
             mutate.mutate_async((Some(name), token)).await;
             if let MutationState::Settled(Ok(result)) = mutate.result().deref()
-                && let MutationValue::NewGame(_game) = result {
-                    client.invalidate_queries(&[QueryKey::Games]);
-                    loading_signal.set(LoadingState::Loaded);
-                    game_name_signal.set(String::default());
-                }
+                && let MutationValue::NewGame(_game) = result
+            {
+                client.invalidate_queries(&[QueryKey::Games]);
+                loading_signal.set(LoadingState::Loaded);
+                game_name_signal.set(String::default());
+            }
         });
     };
 

--- a/web/src/components/map.rs
+++ b/web/src/components/map.rs
@@ -9,11 +9,7 @@ pub fn Map(areas: Vec<AreaDetails>) -> Element {
         .into_iter()
         .map(|area| {
             (
-                area.clone()
-                    .area
-                    .unwrap()
-                    .to_string()
-                    .to_lowercase(),
+                area.clone().area.unwrap().to_string().to_lowercase(),
                 area.is_open(),
             )
         })

--- a/web/src/components/tribute_edit.rs
+++ b/web/src/components/tribute_edit.rs
@@ -179,42 +179,43 @@ pub fn EditTributeForm() -> Element {
 
             if let Some(file_engine) = files
                 && let Some(file_name) = file_engine.files().into_iter().next()
-                    && let Some(file_data) = file_engine.read_file(&file_name).await {
-                        // Upload file using multipart/form-data
-                        let client = reqwest::Client::new();
-                        let url = format!(
-                            "{}/api/games/{}/tributes/{}/avatar",
-                            APP_API_HOST, game_id, tribute_id
-                        );
+                && let Some(file_data) = file_engine.read_file(&file_name).await
+            {
+                // Upload file using multipart/form-data
+                let client = reqwest::Client::new();
+                let url = format!(
+                    "{}/api/games/{}/tributes/{}/avatar",
+                    APP_API_HOST, game_id, tribute_id
+                );
 
-                        let part =
-                            reqwest::multipart::Part::bytes(file_data).file_name(file_name.clone());
+                let part = reqwest::multipart::Part::bytes(file_data).file_name(file_name.clone());
 
-                        let form = reqwest::multipart::Form::new().part("avatar", part);
+                let form = reqwest::multipart::Form::new().part("avatar", part);
 
-                        let response = client
-                            .post(&url)
-                            .bearer_auth(token)
-                            .multipart(form)
-                            .send()
-                            .await;
+                let response = client
+                    .post(&url)
+                    .bearer_auth(token)
+                    .multipart(form)
+                    .send()
+                    .await;
 
-                        match response {
-                            Ok(resp) if resp.status().is_success() => {
-                                if let Ok(json) = resp.json::<serde_json::Value>().await
-                                    && let Some(url) = json.get("url").and_then(|v| v.as_str()) {
-                                        avatar_preview.set(url.to_string());
-                                        upload_status.set("Upload successful!".to_string());
-                                    }
-                            }
-                            Ok(resp) => {
-                                upload_status.set(format!("Upload failed: {}", resp.status()));
-                            }
-                            Err(e) => {
-                                upload_status.set(format!("Upload error: {}", e));
-                            }
+                match response {
+                    Ok(resp) if resp.status().is_success() => {
+                        if let Ok(json) = resp.json::<serde_json::Value>().await
+                            && let Some(url) = json.get("url").and_then(|v| v.as_str())
+                        {
+                            avatar_preview.set(url.to_string());
+                            upload_status.set("Upload successful!".to_string());
                         }
                     }
+                    Ok(resp) => {
+                        upload_status.set(format!("Upload failed: {}", resp.status()));
+                    }
+                    Err(e) => {
+                        upload_status.set(format!("Upload error: {}", e));
+                    }
+                }
+            }
         });
     };
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs the project's quality gates on every PR to `main` and on pushes to `main`. Closes hangrier_games-qz4 and prevents regressions of the kind seen in dz9.

## Changes

- **`.github/workflows/ci.yml`** (new): single `quality` job on `ubuntu-latest`
  - `actions/checkout@v4`
  - `dtolnay/rust-toolchain@stable` with `rustfmt`, `clippy`
  - `Swatinem/rust-cache@v2` for cargo cache
  - `extractions/setup-just@v2`
  - Runs:
    - `cargo fmt --all -- --check`
    - `cargo check --workspace`
    - `cargo clippy --workspace -- -D warnings`
    - `cargo test --package game`
  - Env: `CARGO_TERM_COLOR=always`, `RUSTFLAGS=-D warnings`
  - Triggers: `pull_request` to `main`, `push` to `main`
  - Does **not** call `just quality` directly because that recipe depends on `fmt` (mutating); CI uses `fmt --check`.

- **`rustfmt.toml`**: dropped `fn_single_line = true` (nightly-only; stable rustfmt silently ignored it and CI would have diverged from local nightly formatting). Now contains only `edition = \"2024\"`.

- **`web/` clippy cleanup** (14 files): fixed all 32 clippy warnings so the workspace builds clean under `-D warnings`.
  - 24 auto-fixed via `cargo clippy --fix --lib -p web`
  - 6 manually fixed:
    - `web/src/cache.rs` — `#[allow(clippy::large_enum_variant)]` on `MutationValue`
    - `web/src/components/accounts.rs` — collapsed nested `Settled(Ok(...))` + `if let MutationValue::User(..)` into a single pattern
    - `web/src/components/game_edit.rs` — redundant field shorthand; `match` \u2192 `matches!` for the `\"on\"` checkbox parse
    - `web/src/components/loading_modal.rs` — `match` \u2192 `matches!`
    - `web/src/components/tribute_edit.rs` — removed deprecated no-op `prevent_default: \"onsubmit\"` attribute

## Verification

Ran locally on `ci-quality-workflow` (commit 0345f61a):

- `cargo fmt --all -- --check` \u2192 clean
- `cargo check --workspace` \u2192 clean
- `cargo clippy --workspace -- -D warnings` \u2192 clean
- `cargo test --package game` \u2192 all green

## Follow-ups

- **hangrier_games-vja** (P2 bug): `web/tests/{info_detail_test,tribute_status_icon_test,mod}.rs` are pre-existing broken (reference removed prop names; 55 errors). Not caught by this CI because the workflow only runs `cargo test --package game` and not `--all-targets`. Fix or delete in a follow-up so we can extend CI to the full workspace test surface.
- **hangrier_games-t6p** (P2 task): verify api integration tests at runtime against a live SurrealDB \u2014 the next CI scope expansion candidate.