### PR TITLE
feat(api): make SurrealDB namespace and database configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@ SURREAL_HOST=ws://localhost:8000
 SURREAL_USER=root
 SURREAL_PASS=root
 
+# SurrealDB namespace and database (optional; defaults shown)
+APP_SURREAL_NAMESPACE=hangry-games
+APP_SURREAL_DATABASE=games
+
 # CORS Configuration
 # Comma-separated list of allowed origins for CORS (e.g., http://localhost:8080,https://example.com)
 # IMPORTANT: Wildcards (*) are NOT allowed in production mode

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -121,7 +121,12 @@ pub async fn revoke_refresh_token(state: &AppState, token: &str) -> Result<(), A
 }
 
 /// Generate a new access token for a user
-fn generate_access_token(user_id: &Thing, username: &str) -> Result<String, AppError> {
+fn generate_access_token(
+    user_id: &Thing,
+    username: &str,
+    namespace: &str,
+    database: &str,
+) -> Result<String, AppError> {
     // Create JWT claims matching SurrealDB's format
     let now = OffsetDateTime::now_utc().unix_timestamp();
     let exp = now + 3600; // 1 hour expiration
@@ -131,8 +136,8 @@ fn generate_access_token(user_id: &Thing, username: &str) -> Result<String, AppE
         "iat": now,
         "nbf": now,
         "exp": exp,
-        "ns": "hangry-games",
-        "db": "games",
+        "ns": namespace,
+        "db": database,
         "ac": "user",
         "id": user_id.to_string(),
         "sub": username,
@@ -178,7 +183,12 @@ async fn refresh_token(
     store_refresh_token(&state, &new_refresh_token).await?;
 
     // Generate new access token
-    let access_token = generate_access_token(&token.user_id, &token.username)?;
+    let access_token = generate_access_token(
+        &token.user_id,
+        &token.username,
+        &state.namespace,
+        &state.database,
+    )?;
 
     Ok(Json(TokenResponse {
         access_token,

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -21,6 +21,8 @@ pub struct AppState {
     pub db: Arc<Surreal<Any>>,
     pub storage: Arc<dyn storage::StorageBackend>,
     pub broadcaster: Arc<websocket::GameBroadcaster>,
+    pub namespace: String,
+    pub database: String,
 }
 
 #[derive(Debug, Error)]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -93,11 +93,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .map_err(|e| format!("Failed to authenticate to database: {}", e))?;
     tracing::debug!("authenticated to SurrealDB");
 
-    db.use_ns("hangry-games")
-        .use_db("games")
+    let surreal_namespace =
+        env::var("APP_SURREAL_NAMESPACE").unwrap_or_else(|_| "hangry-games".to_string());
+    let surreal_database = env::var("APP_SURREAL_DATABASE").unwrap_or_else(|_| "games".to_string());
+
+    db.use_ns(&surreal_namespace)
+        .use_db(&surreal_database)
         .await
         .map_err(|e| format!("Failed to use database: {}", e))?;
-    tracing::debug!("Using 'hangry-games' namespace and 'games' database");
+    tracing::debug!(
+        "Using '{}' namespace and '{}' database",
+        surreal_namespace,
+        surreal_database
+    );
 
     MigrationRunner::new(&db)
         .up()
@@ -209,6 +217,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         db: db.clone(),
         storage,
         broadcaster,
+        namespace: surreal_namespace,
+        database: surreal_database,
     };
 
     // Start cleanup scheduler for refresh tokens

--- a/api/src/users.rs
+++ b/api/src/users.rs
@@ -91,8 +91,8 @@ async fn user_create(
         .db
         .signup(Record {
             access: "user",
-            namespace: "hangry-games",
-            database: "games",
+            namespace: &state.namespace,
+            database: &state.database,
             params: RegistrationUser {
                 username: username.clone(),
                 password: password.clone(),
@@ -129,8 +129,8 @@ async fn user_authenticate(
         .db
         .signin(Record {
             access: "user",
-            namespace: "hangry-games",
-            database: "games",
+            namespace: &state.namespace,
+            database: &state.database,
             params: RegistrationUser {
                 username: username.clone(),
                 password: password.clone(),

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -12,6 +12,8 @@ use surrealdb_migrations::MigrationRunner;
 /// Test configuration for SurrealDB
 pub struct TestDb {
     pub db: Arc<Surreal<Any>>,
+    pub namespace: String,
+    pub database: String,
 }
 
 impl TestDb {
@@ -44,7 +46,8 @@ impl TestDb {
             "test_{}",
             uuid::Uuid::new_v4().to_string().replace('-', "_")
         );
-        db.use_ns("hangry-games-test")
+        let test_ns = "hangry-games-test".to_string();
+        db.use_ns(&test_ns)
             .use_db(&test_db_name)
             .await
             .expect("Failed to use test database");
@@ -66,7 +69,11 @@ impl TestDb {
             .await
             .expect("Failed to apply migrations");
 
-        TestDb { db }
+        TestDb {
+            db,
+            namespace: test_ns,
+            database: test_db_name,
+        }
     }
 
     /// Get the AppState for testing
@@ -78,6 +85,8 @@ impl TestDb {
             db: self.db.clone(),
             storage: Arc::new(LocalStorage::new("test_uploads", "/uploads")),
             broadcaster: Arc::new(GameBroadcaster::default()),
+            namespace: self.namespace.clone(),
+            database: self.database.clone(),
         }
     }
 


### PR DESCRIPTION
## Summary

The `api` crate hardcoded the SurrealDB namespace `hangry-games` and database `games` in 8 places across 4 files. This blocked integration tests from using isolated per-test databases because records created via the Record API and JWT claim emission always pointed at the production NS/DB regardless of the connection's actual namespace/database. This change makes both configurable via `AppState`, sourced from new optional environment variables.

Refs: `hangrier_games-0hw`

## Changes

- **`api/src/lib.rs`** — added `pub namespace: String, pub database: String` fields to `AppState`.
- **`api/src/main.rs`** — read `APP_SURREAL_NAMESPACE` and `APP_SURREAL_DATABASE` from env (defaults `hangry-games`/`games`), pass them into `db.use_ns(...).use_db(...)` and store them on `AppState`.
- **`api/src/auth.rs`** — `generate_access_token` now takes `namespace: &str, database: &str` and uses them for the JWT `ns`/`db` claims. The single call site in `refresh_token` passes `&state.namespace, &state.database`.
- **`api/src/users.rs`** — both `Record` literals (signup, signin) replace hardcoded namespace/database strings with `&state.namespace` / `&state.database`.
- **`api/tests/common/mod.rs`** — `TestDb` exposes `namespace` and `database` fields; `app_state()` propagates them so per-test databases actually apply to handler logic.
- **`.env.example`** — documents the two new optional environment variables.

## Verification

```
cargo fmt --check                                   # clean
cargo clippy -p api --tests --no-deps -- -D warnings  # clean
cargo test -p api --lib -- --test-threads=1         # 9/9 passed
```

`cargo test -p api --test auth_tests -- --test-threads=1` is now blocked by a separate, pre-existing JWT claim case-mismatch (uppercase `ID` from SurrealDB-issued JWTs vs. lowercase `id` expected by `JwtClaims`). That issue was previously masked because signup itself failed on the NS/DB mismatch before ever issuing a JWT. See follow-up `hangrier_games-c7m`.

## Follow-ups

- `hangrier_games-c7m` (P2) — auth: `JwtClaims` expects lowercase `id` but SurrealDB-issued JWTs use uppercase `ID`. Now blocks `hangrier_games-a94`.
- `hangrier_games-a94` (P2) — re-verify all `api` integration test binaries pass once both `0hw` and `c7m` land.