### PR TITLE
fix(api): SurrealDB JWT claims, refresh token datetime, and duplicate username conflict

### DIFF
--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -2,10 +2,11 @@ use crate::{AppError, AppState};
 use axum::extract::State;
 use axum::routing::post;
 use axum::{Json, Router};
+use chrono::Utc;
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
-use surrealdb::sql::Thing;
+use surrealdb::sql::{Datetime, Thing};
 use time::OffsetDateTime;
 use uuid::Uuid;
 use validator::Validate;
@@ -25,11 +26,9 @@ pub struct RefreshToken {
     pub token: String,
     pub user_id: Thing,
     pub username: String,
-    #[serde(with = "time::serde::rfc3339")]
-    pub expires_at: OffsetDateTime,
+    pub expires_at: Datetime,
     pub revoked: bool,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
+    pub created_at: Datetime,
 }
 
 #[derive(Serialize, Deserialize, Debug, Validate)]
@@ -48,16 +47,16 @@ impl RefreshToken {
     /// Generate a new refresh token for a user
     pub fn new(user_id: Thing, username: String) -> Self {
         let token = Uuid::new_v4().to_string();
-        let now = OffsetDateTime::now_utc();
-        let expires_at = now + time::Duration::days(7);
+        let now = Utc::now();
+        let expires_at = now + chrono::Duration::days(7);
 
         RefreshToken {
             token,
             user_id,
             username,
-            expires_at,
+            expires_at: Datetime::from(expires_at),
             revoked: false,
-            created_at: now,
+            created_at: Datetime::from(now),
         }
     }
 
@@ -67,8 +66,7 @@ impl RefreshToken {
             return false;
         }
 
-        let now = OffsetDateTime::now_utc();
-        self.expires_at > now
+        self.expires_at.0 > Utc::now()
     }
 }
 
@@ -91,8 +89,8 @@ pub async fn get_refresh_token(state: &AppState, token: &str) -> Result<RefreshT
     let token_owned = token.to_string();
     let mut result = state
         .db
-        .query("SELECT * FROM refresh_token WHERE token = $token LIMIT 1")
-        .bind(("token", token_owned))
+        .query("SELECT * FROM refresh_token WHERE token = $tk LIMIT 1")
+        .bind(("tk", token_owned))
         .await
         .map_err(|e| AppError::DbError(format!("Failed to query refresh token: {}", e)))?;
 
@@ -111,8 +109,8 @@ pub async fn revoke_refresh_token(state: &AppState, token: &str) -> Result<(), A
     let token_owned = token.to_string();
     let _: Option<RefreshToken> = state
         .db
-        .query("UPDATE refresh_token SET revoked = true WHERE token = $token")
-        .bind(("token", token_owned))
+        .query("UPDATE refresh_token SET revoked = true WHERE token = $tk")
+        .bind(("tk", token_owned))
         .await
         .map_err(|e| AppError::DbError(format!("Failed to revoke refresh token: {}", e)))?
         .take(0)
@@ -228,7 +226,7 @@ mod tests {
         assert_eq!(token.username, username);
         assert_eq!(token.token.len(), 36); // UUID v4 length
         assert!(!token.revoked);
-        assert!(token.expires_at > OffsetDateTime::now_utc());
+        assert!(token.expires_at.0 > Utc::now());
     }
 
     #[test]
@@ -238,16 +236,16 @@ mod tests {
         let token_str = Uuid::new_v4().to_string();
 
         // Create a token that expired 1 day ago
-        let now = OffsetDateTime::now_utc();
-        let expired = now - time::Duration::days(1);
+        let now = Utc::now();
+        let expired = now - chrono::Duration::days(1);
 
         let token = RefreshToken {
             token: token_str,
             user_id,
             username,
-            expires_at: expired,
+            expires_at: Datetime::from(expired),
             revoked: false,
-            created_at: now - time::Duration::days(8),
+            created_at: Datetime::from(now - chrono::Duration::days(8)),
         };
 
         assert!(!token.is_valid());
@@ -260,16 +258,16 @@ mod tests {
         let token_str = Uuid::new_v4().to_string();
 
         // Create a token that's not expired but is revoked
-        let now = OffsetDateTime::now_utc();
-        let expires_at = now + time::Duration::days(7);
+        let now = Utc::now();
+        let expires_at = now + chrono::Duration::days(7);
 
         let token = RefreshToken {
             token: token_str,
             user_id,
             username,
-            expires_at,
+            expires_at: Datetime::from(expires_at),
             revoked: true,
-            created_at: now,
+            created_at: Datetime::from(now),
         };
 
         assert!(!token.is_valid());

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -39,6 +39,8 @@ pub enum AppError {
     GameFull(String),
     #[error("Database error")]
     DbError(String),
+    #[error("Conflict")]
+    Conflict(String),
     #[error("Invalid status")]
     InvalidStatus(String),
     #[error("Validation error")]
@@ -54,6 +56,7 @@ impl IntoResponse for AppError {
             AppError::Unauthorized(message) => (StatusCode::UNAUTHORIZED, message),
             AppError::GameFull(message) => (StatusCode::BAD_REQUEST, message),
             AppError::DbError(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
+            AppError::Conflict(message) => (StatusCode::CONFLICT, message),
             AppError::InvalidStatus(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
             AppError::ValidationError(message) => (StatusCode::BAD_REQUEST, message),
         };

--- a/api/src/users.rs
+++ b/api/src/users.rs
@@ -122,7 +122,21 @@ async fn user_create(
             let token_pair = create_token_pair(&state, jwt, user_id, username).await?;
             Ok(Json(token_pair))
         }
-        Err(_) => Err(AppError::DbError("Failed to create user".to_string())),
+        Err(e) => {
+            // SurrealDB returns a generic "record access signup query failed" error
+            // for any signup-block failure; in this code path the only realistic
+            // failure mode is the unique_username index, so map to 409 Conflict.
+            let combined = format!("{e} {e:?}").to_lowercase();
+            if combined.contains("unique_username")
+                || combined.contains("already")
+                || combined.contains("duplicate")
+                || combined.contains("signup query failed")
+            {
+                Err(AppError::Conflict("Username already taken".to_string()))
+            } else {
+                Err(AppError::DbError(format!("Failed to create user: {e}")))
+            }
+        }
     }
 }
 

--- a/api/src/users.rs
+++ b/api/src/users.rs
@@ -19,16 +19,28 @@ pub static USERS_ROUTER: LazyLock<Router<AppState>> = LazyLock::new(|| {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct JwtClaims {
+    // SurrealDB-issued JWTs serialize the record id as `ID` (uppercase).
+    // Our own `generate_access_token` (api/src/auth.rs) emits `id` (lowercase).
+    // Accept both via rename + alias.
+    #[serde(rename = "ID", alias = "id")]
     id: String,
-    #[serde(rename = "sub")]
-    username: String,
+    // SurrealDB record-auth JWTs do NOT include `sub`; only our own tokens do.
+    // Optional so signup/signin tokens decode successfully.
+    #[serde(default, alias = "sub")]
+    sub: Option<String>,
 }
 
-/// Helper function to extract user ID and username from JWT token
-fn extract_user_from_jwt(jwt: &str) -> Result<(Thing, String), AppError> {
+/// Helper function to extract the user record id from a JWT token.
+///
+/// Returns the parsed `Thing` for the user record. The username is intentionally
+/// not returned here because SurrealDB-issued signup/signin JWTs do not carry a
+/// `sub` claim — callers already have the username in scope and pass it through.
+fn extract_user_id_from_jwt(jwt: &str) -> Result<Thing, AppError> {
     // Decode JWT with validation disabled since we trust our own tokens
     let mut validation = Validation::new(Algorithm::HS512);
     validation.validate_exp = false; // We just created this token, no need to validate expiration
+    // SurrealDB-issued JWTs don't set `sub`; jsonwebtoken validates `sub` only
+    // when a required value is configured, so default validation is fine.
 
     let token_data = decode::<JwtClaims>(
         jwt,
@@ -44,7 +56,7 @@ fn extract_user_from_jwt(jwt: &str) -> Result<(Thing, String), AppError> {
         AppError::InternalServerError(format!("Failed to parse user ID from JWT: {}", e))
     })?;
 
-    Ok((user_id, claims.username))
+    Ok(user_id)
 }
 
 /// Helper function to create both access and refresh tokens
@@ -103,8 +115,9 @@ async fn user_create(
         Ok(auth_result) => {
             let jwt = auth_result.into_insecure_token();
 
-            // Extract user ID directly from JWT instead of querying the database
-            let (user_id, username) = extract_user_from_jwt(&jwt)?;
+            // Extract user ID directly from JWT instead of querying the database.
+            // Username is already in scope from the request payload.
+            let user_id = extract_user_id_from_jwt(&jwt)?;
 
             let token_pair = create_token_pair(&state, jwt, user_id, username).await?;
             Ok(Json(token_pair))
@@ -141,8 +154,9 @@ async fn user_authenticate(
         Ok(auth_result) => {
             let jwt = auth_result.into_insecure_token();
 
-            // Extract user ID directly from JWT instead of querying the database
-            let (user_id, username) = extract_user_from_jwt(&jwt)?;
+            // Extract user ID directly from JWT instead of querying the database.
+            // Username is already in scope from the request payload.
+            let user_id = extract_user_id_from_jwt(&jwt)?;
 
             let token_pair = create_token_pair(&state, jwt, user_id, username).await?;
             Ok(Json(token_pair))

--- a/api/tests/auth_tests.rs
+++ b/api/tests/auth_tests.rs
@@ -230,6 +230,7 @@ async fn test_duplicate_username() {
         .await;
 
     // Should return error (400 or 409)
+
     assert!(
         response.status_code() == axum::http::StatusCode::BAD_REQUEST
             || response.status_code() == axum::http::StatusCode::CONFLICT


### PR DESCRIPTION
## Summary

Fixes three pre-existing bugs in the API auth path that combined to keep `api/tests/auth_tests.rs` at 0/7 passing. After this PR all 7 integration tests pass.

Resolves `hangrier_games-c7m` (P2). Likely unblocks `hangrier_games-a94`.

## Changes

**Commit 1 — `fix(api): decode SurrealDB-issued JWTs with uppercase ID claim`**
- `JwtClaims.id` now uses `#[serde(rename = "ID", alias = "id")]` so JWTs issued by SurrealDB record-auth signup/signin (which serialize the ID claim as uppercase `ID`) decode alongside our own access tokens (which emit lowercase `id` + `sub`).
- `JwtClaims.sub` becomes `Option<String>` with `#[serde(default, alias = "sub")]` because SurrealDB-issued tokens don't populate it.
- Renamed `extract_user_from_jwt` → `extract_user_id_from_jwt`; callers in `user_create` and `user_authenticate` use the in-scope `username` directly.

**Commit 2 — `fix(api): refresh token datetime serialization and reserved $token variable`**
- `RefreshToken.expires_at` and `created_at` switched from `time::OffsetDateTime` (with `time::serde::rfc3339`) to `surrealdb::sql::Datetime`. SurrealDB schema declares both fields as `datetime` and rejected the JSON strings produced by the rfc3339 serializer.
- Renamed query bind variable from `$token` to `$tk` in `get_refresh_token` and `revoke_refresh_token`. `$token` is a reserved auth-context variable in SurrealDB and could not be set as a bind parameter (caused `'token' is a protected variable` errors on logout/refresh).
- Updated unit tests to construct `RefreshToken`s with `chrono::Utc::now()` + `Datetime::from(...)`.

**Commit 3 — `fix(api): map duplicate username signup to 409 Conflict`**
- Added `AppError::Conflict(String)` variant mapping to `StatusCode::CONFLICT`.
- `user_create` now inspects the signup error and returns `Conflict` on duplicate-username indicators (`unique_username`, `signup query failed`, etc.) instead of a generic 500.

## Verification

```
cargo fmt --check                                          # clean
cargo clippy -p api --tests --no-deps -- -D warnings       # clean
cargo test -p api --lib -- --test-threads=1                # 9 passed; 0 failed
cargo test -p api --test auth_tests -- --test-threads=1    # 7 passed; 0 failed
```

Tests run against a local SurrealDB (`surreal start --user root --pass root memory`) using the per-test NS/DB harness from `api/tests/common/mod.rs` (PR #119).

## Follow-ups

- `hangrier_games-c7m` — closing once this PR merges.
- `hangrier_games-a94` (api integration test binaries) — was blocked on `c7m`; should now be in scope to verify and close.