### PR TITLE
feat(game): tribute alliances — formation, betrayal, death cascade (closes 0ug)

### DIFF
--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -198,6 +198,7 @@ pub async fn create_game(
         private: true, // Default to private
         config: Default::default(),
         messages: vec![],
+        alliance_events: vec![],
     };
 
     let created_game: Option<Game> = state

--- a/docs/superpowers/plans/2026-04-25-tribute-alliances-implementation.md
+++ b/docs/superpowers/plans/2026-04-25-tribute-alliances-implementation.md
@@ -1,0 +1,1490 @@
+# Tribute Alliances Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `BrainPersonality` with a per-tribute `traits: Vec<Trait>` system and add a pair-wise `allies: Vec<Uuid>` graph with formation/break mechanics.
+
+**Architecture:** Pure-engine work in `game/` (new `traits.rs` + `alliances.rs`, gut `brains.rs`, edit `tributes/mod.rs` and `games.rs`); thin DTO/schema/API extensions; hard cutover with no data migration.
+
+**Tech Stack:** Rust 2024, rstest, SurrealDB schema, Serde, Dioxus (frontend touch only for `loyalty` scrub).
+
+**Spec:** `docs/superpowers/specs/2026-04-25-tribute-alliances-design.md`
+
+**Bead:** `hangrier_games-0ug` (in_progress)
+
+---
+
+## Bead Plan
+
+File these beads BEFORE coding. Each phase = one bead, blocking the next:
+
+```bash
+bd create --title="Phase 1: traits.rs module" --description="Trait enum, conflict table, district pools, threshold deltas, alliance affinity, geometric_mean_affinity, refusers. Pure functions, fully unit-tested." --type=task --priority=2 --notes="depends-on=0ug"
+bd create --title="Phase 2: alliances.rs module" --description="Formation roll, refuser gate, deciding factor, break triggers (sanity / treacherous / trust-shock cascade), AllianceEvent queue. Pure on &Tribute slices." --type=task --priority=2
+bd create --title="Phase 3: Tribute + Brain integration" --description="Add allies/traits/turns_since_last_betrayal to Tribute. Remove BrainPersonality, district!=district filter, loyalty field, LOYALTY_BREAK_LEVEL. Rewrite pick_target. Add Tribute::test_default." --type=task --priority=2
+bd create --title="Phase 4: run_day_night_cycle drain" --description="Drain AllianceEvent queue between tribute turns inside game/src/games.rs run_day_night_cycle. Schedule trust-shock and ally-death cascades." --type=task --priority=2
+bd create --title="Phase 5: Persistence + DTO + frontend scrub" --description="schemas/tribute.surql adds allies/traits/turns_since_last_betrayal. _initial.json bump. shared/ DTO. api/tributes.rs read/write. web tribute_detail.rs loyalty scrub." --type=task --priority=2
+bd create --title="Phase 6: Test migration + alliance test suite" --description="Roll out Tribute::test_default across ~60 game tests. Replace BrainPersonality assertions with trait-set checks. Add bucket-tolerance helper. Write multi-tribute alliance suite + api round-trip test." --type=task --priority=2
+bd dep add <p2> <p1>; bd dep add <p3> <p2>; bd dep add <p4> <p3>; bd dep add <p5> <p4>; bd dep add <p6> <p5>
+```
+
+`bd update <p1> --claim` before starting Phase 1.
+
+---
+
+## File Map
+
+| Path | Action | Responsibility |
+|------|--------|----------------|
+| `game/src/tributes/traits.rs` | **Create** | Trait enum, conflict table, district pools, threshold math, affinity, geometric_mean, refusers |
+| `game/src/tributes/alliances.rs` | **Create** | Formation roll, gate, deciding factor, break triggers, AllianceEvent enum |
+| `game/src/tributes/brains.rs` | **Modify** | Remove `BrainPersonality` enum + 9 lookup tables; `PersonalityThresholds` keeps shape; new `compute_thresholds(traits, rng)` |
+| `game/src/tributes/mod.rs` | **Modify** | Add `traits`, `allies`, `turns_since_last_betrayal` fields. Remove `loyalty`, `LOYALTY_BREAK_LEVEL`, district filter. Rewrite `pick_target`. Add `test_default` helper. |
+| `game/src/tributes/mod.rs` (sub-add) | **Modify** | Add `pub mod traits; pub mod alliances;` declarations |
+| `game/src/games.rs` | **Modify** | `Game.alliance_events: Vec<AllianceEvent>`. Drain between tribute turns inside `run_day_night_cycle`. |
+| `game/src/config.rs` | **Modify** | Remove `loyalty_break_level`, `max_loyalty` config fields |
+| `schemas/tribute.surql` | **Modify** | Add `allies`, `traits`, `turns_since_last_betrayal` fields |
+| `migrations/definitions/_initial.json` | **Modify** | Bump version, add release note |
+| `shared/src/lib.rs` | **Modify** | Tribute DTO gains `allies: Vec<Uuid>`, `traits: Vec<Trait>` (re-export Trait) |
+| `api/src/tributes.rs` | **Modify** | Persist new fields (likely automatic via Serde, verify) |
+| `web/src/components/tribute_detail.rs` | **Modify** | Remove `attributes.loyalty` display line |
+| `game/src/tributes/test_helpers.rs` (or test mod) | **Create** | `Tribute::test_default()` + `assert_within_tolerance()` |
+
+---
+
+## Phase 1 — `traits.rs` Module
+
+**Files:**
+- Create: `game/src/tributes/traits.rs`
+- Modify: `game/src/tributes/mod.rs` (add `pub mod traits;` at top)
+- Test: inline `#[cfg(test)] mod tests` at bottom of `traits.rs`
+
+### Task 1.1: Scaffold module + Trait enum
+
+- [ ] **Step 1: Create file with enum + module declaration**
+
+`game/src/tributes/traits.rs`:
+
+```rust
+//! Tribute trait system. Replaces `BrainPersonality`. See spec
+//! `docs/superpowers/specs/2026-04-25-tribute-alliances-design.md` §5.
+
+use rand::Rng;
+use rand::seq::SliceRandom;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Trait {
+    // Combat stance
+    Aggressive,
+    Defensive,
+    Cautious,
+    Reckless,
+    // Social
+    Friendly,
+    Loyal,
+    Paranoid,
+    LoneWolf,
+    Treacherous,
+    // Mental
+    Resilient,
+    Fragile,
+    Cunning,
+    Dim,
+    // Physical
+    Asthmatic,
+    Nearsighted,
+    Tough,
+}
+```
+
+Add `pub mod traits;` at top of `game/src/tributes/mod.rs` (next to existing `pub mod brains;`).
+
+- [ ] **Step 2: Add `label()` method**
+
+```rust
+impl Trait {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Trait::Aggressive => "aggressive",
+            Trait::Defensive => "defensive",
+            Trait::Cautious => "cautious",
+            Trait::Reckless => "reckless",
+            Trait::Friendly => "friendly",
+            Trait::Loyal => "loyal",
+            Trait::Paranoid => "paranoid",
+            Trait::LoneWolf => "a lone wolf",
+            Trait::Treacherous => "treacherous",
+            Trait::Resilient => "resilient",
+            Trait::Fragile => "fragile",
+            Trait::Cunning => "cunning",
+            Trait::Dim => "dim",
+            Trait::Asthmatic => "asthmatic",
+            Trait::Nearsighted => "nearsighted",
+            Trait::Tough => "tough",
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run `cargo check -p game`** to confirm compile.
+
+Expected: `Finished` clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(traits): add Trait enum scaffold"
+```
+
+### Task 1.2: Alliance affinity + refuser table
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn affinity_known_values() {
+        assert_eq!(Trait::Friendly.alliance_affinity(), 1.5);
+        assert_eq!(Trait::Loyal.alliance_affinity(), 1.4);
+        assert_eq!(Trait::Treacherous.alliance_affinity(), 1.2);
+        assert_eq!(Trait::Aggressive.alliance_affinity(), 1.0);
+        assert_eq!(Trait::Tough.alliance_affinity(), 1.0);
+        assert_eq!(Trait::LoneWolf.alliance_affinity(), 0.6);
+        assert_eq!(Trait::Paranoid.alliance_affinity(), 0.5);
+    }
+
+    #[test]
+    fn refusers_membership() {
+        assert!(REFUSERS.contains(&Trait::Paranoid));
+        assert!(REFUSERS.contains(&Trait::LoneWolf));
+        assert!(!REFUSERS.contains(&Trait::Friendly));
+    }
+}
+```
+
+- [ ] **Step 2: Run** `cargo test -p game tributes::traits::tests::affinity_known_values --no-run` — expect compile fail "no method".
+
+- [ ] **Step 3: Implement**
+
+```rust
+pub const REFUSERS: &[Trait] = &[Trait::Paranoid, Trait::LoneWolf];
+
+impl Trait {
+    pub fn alliance_affinity(&self) -> f64 {
+        match self {
+            Trait::Friendly => 1.5,
+            Trait::Loyal => 1.4,
+            Trait::Treacherous => 1.2,
+            Trait::LoneWolf => 0.6,
+            Trait::Paranoid => 0.5,
+            _ => 1.0,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::traits::tests` — expect 2 passed.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(traits): alliance affinity + refusers"`
+
+### Task 1.3: `geometric_mean_affinity` helper
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn geometric_mean_empty_is_one() {
+    assert_eq!(geometric_mean_affinity(&[]), 1.0);
+}
+
+#[test]
+fn geometric_mean_single_is_identity() {
+    assert!((geometric_mean_affinity(&[Trait::Friendly]) - 1.5).abs() < f64::EPSILON * 10.0);
+}
+
+#[test]
+fn geometric_mean_two_friendly_one_lonewolf() {
+    // (1.5 * 1.5 * 0.6)^(1/3) = 1.35^(1/3) ≈ 1.1051709...
+    let g = geometric_mean_affinity(&[Trait::Friendly, Trait::Friendly, Trait::LoneWolf]);
+    let expected = (1.5_f64 * 1.5 * 0.6).powf(1.0 / 3.0);
+    assert!((g - expected).abs() < f64::EPSILON * 10.0);
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Geometric mean of trait affinity values. Returns 1.0 for empty input.
+pub fn geometric_mean_affinity(traits: &[Trait]) -> f64 {
+    if traits.is_empty() {
+        return 1.0;
+    }
+    let n = traits.len() as f64;
+    let product: f64 = traits.iter().map(|t| t.alliance_affinity()).product();
+    product.powf(1.0 / n)
+}
+```
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::traits::tests::geometric` — expect 3 passed.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(traits): geometric_mean_affinity helper"`
+
+### Task 1.4: Conflict table + `conflicts_with`
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn conflict_symmetry() {
+    let pairs = [
+        (Trait::Friendly, Trait::Paranoid),
+        (Trait::Loyal, Trait::Treacherous),
+        (Trait::Loyal, Trait::LoneWolf),
+        (Trait::Aggressive, Trait::Cautious),
+        (Trait::Aggressive, Trait::Defensive),
+        (Trait::Reckless, Trait::Cautious),
+        (Trait::Resilient, Trait::Fragile),
+        (Trait::Cunning, Trait::Dim),
+    ];
+    for (a, b) in pairs {
+        assert!(conflicts_with(a, b), "{a:?} should conflict with {b:?}");
+        assert!(conflicts_with(b, a), "{b:?} should conflict with {a:?} (symmetry)");
+    }
+}
+
+#[test]
+fn allowed_combos_do_not_conflict() {
+    assert!(!conflicts_with(Trait::Friendly, Trait::Treacherous));
+    assert!(!conflicts_with(Trait::Paranoid, Trait::LoneWolf));
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+pub const CONFLICTS: &[(Trait, Trait)] = &[
+    (Trait::Friendly, Trait::Paranoid),
+    (Trait::Loyal, Trait::Treacherous),
+    (Trait::Loyal, Trait::LoneWolf),
+    (Trait::Aggressive, Trait::Cautious),
+    (Trait::Aggressive, Trait::Defensive),
+    (Trait::Reckless, Trait::Cautious),
+    (Trait::Resilient, Trait::Fragile),
+    (Trait::Cunning, Trait::Dim),
+];
+
+pub fn conflicts_with(a: Trait, b: Trait) -> bool {
+    CONFLICTS.iter().any(|(x, y)| (*x == a && *y == b) || (*x == b && *y == a))
+}
+```
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::traits::tests::conflict` — expect 2 passed.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(traits): conflict table"`
+
+### Task 1.5: District pools + `pool_for`
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn pool_for_returns_correct_pool_per_district() {
+    let p1 = pool_for(1);
+    assert!(p1.iter().any(|(t, _)| *t == Trait::Loyal));
+    let p12 = pool_for(12);
+    assert!(p12.iter().any(|(t, _)| *t == Trait::LoneWolf));
+}
+
+#[test]
+fn pool_for_unknown_district_falls_back() {
+    // Districts outside 1..=12 fall back to district 1's pool (or empty —
+    // implementation choice; here we assert non-panic).
+    let _ = pool_for(99);
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+pub const DISTRICT_1_POOL: &[(Trait, u8)] = &[
+    (Trait::Loyal, 4), (Trait::Aggressive, 4), (Trait::Paranoid, 3), (Trait::Tough, 2),
+];
+pub const DISTRICT_2_POOL: &[(Trait, u8)] = &[
+    (Trait::Aggressive, 4), (Trait::Defensive, 4), (Trait::Loyal, 3), (Trait::Tough, 2),
+];
+pub const DISTRICT_3_POOL: &[(Trait, u8)] = &[
+    (Trait::Cunning, 4), (Trait::Cautious, 3), (Trait::Dim, 2),
+    (Trait::Nearsighted, 2), (Trait::Asthmatic, 1),
+];
+pub const DISTRICT_4_POOL: &[(Trait, u8)] = &[
+    (Trait::Resilient, 4), (Trait::Aggressive, 3), (Trait::Loyal, 3), (Trait::Tough, 2),
+];
+pub const DISTRICT_5_POOL: &[(Trait, u8)] = &[
+    (Trait::Cunning, 4), (Trait::Cautious, 3), (Trait::Treacherous, 2),
+];
+pub const DISTRICT_6_POOL: &[(Trait, u8)] = &[
+    (Trait::Fragile, 3), (Trait::Friendly, 3), (Trait::Asthmatic, 2), (Trait::Nearsighted, 2),
+];
+pub const DISTRICT_7_POOL: &[(Trait, u8)] = &[
+    (Trait::Resilient, 4), (Trait::Defensive, 3), (Trait::Tough, 3),
+];
+pub const DISTRICT_8_POOL: &[(Trait, u8)] = &[
+    (Trait::Fragile, 2), (Trait::Friendly, 4), (Trait::Loyal, 3), (Trait::Asthmatic, 2),
+];
+pub const DISTRICT_9_POOL: &[(Trait, u8)] = &[
+    (Trait::Cautious, 3), (Trait::Friendly, 3), (Trait::Asthmatic, 2),
+];
+pub const DISTRICT_10_POOL: &[(Trait, u8)] = &[
+    (Trait::Resilient, 4), (Trait::Defensive, 3), (Trait::Tough, 3),
+];
+pub const DISTRICT_11_POOL: &[(Trait, u8)] = &[
+    (Trait::Loyal, 3), (Trait::Friendly, 4), (Trait::Resilient, 3), (Trait::Tough, 2),
+];
+pub const DISTRICT_12_POOL: &[(Trait, u8)] = &[
+    (Trait::Resilient, 3), (Trait::LoneWolf, 3), (Trait::Cunning, 3), (Trait::Asthmatic, 2),
+];
+
+pub fn pool_for(district: u8) -> &'static [(Trait, u8)] {
+    match district {
+        1 => DISTRICT_1_POOL,
+        2 => DISTRICT_2_POOL,
+        3 => DISTRICT_3_POOL,
+        4 => DISTRICT_4_POOL,
+        5 => DISTRICT_5_POOL,
+        6 => DISTRICT_6_POOL,
+        7 => DISTRICT_7_POOL,
+        8 => DISTRICT_8_POOL,
+        9 => DISTRICT_9_POOL,
+        10 => DISTRICT_10_POOL,
+        11 => DISTRICT_11_POOL,
+        12 => DISTRICT_12_POOL,
+        _ => DISTRICT_1_POOL,
+    }
+}
+```
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::traits::tests::pool` — expect 2 passed.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(traits): district pools"`
+
+### Task 1.6: Trait generation with conflict rejection
+
+- [ ] **Step 1: Failing test**
+
+```rust
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+#[test]
+fn generate_respects_count_when_pool_supports() {
+    let mut rng = StdRng::seed_from_u64(42);
+    let traits = generate_traits(1, &mut rng); // district 1 has 4 distinct
+    assert!(traits.len() >= 2 && traits.len() <= 6);
+    // No conflicts
+    for i in 0..traits.len() {
+        for j in (i + 1)..traits.len() {
+            assert!(!conflicts_with(traits[i], traits[j]));
+        }
+    }
+}
+
+#[test]
+fn generate_no_duplicates() {
+    let mut rng = StdRng::seed_from_u64(7);
+    let traits = generate_traits(2, &mut rng);
+    let mut sorted: Vec<_> = traits.clone();
+    sorted.sort_by_key(|t| *t as u8);
+    sorted.dedup();
+    assert_eq!(sorted.len(), traits.len());
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Generate a trait set for a tribute in `district`. Rolls 2–6 uniformly,
+/// then draws weighted picks from the district pool, rejecting conflicts and
+/// duplicates. Stops early if the pool cannot satisfy the count; never spins.
+pub fn generate_traits(district: u8, rng: &mut impl Rng) -> Vec<Trait> {
+    let pool = pool_for(district);
+    let target_count = rng.random_range(2..=6);
+    let mut chosen: Vec<Trait> = Vec::with_capacity(target_count);
+
+    // Build a working list of (trait, weight) we may still draw.
+    let mut remaining: Vec<(Trait, u8)> = pool.to_vec();
+
+    while chosen.len() < target_count && !remaining.is_empty() {
+        // Weighted pick from remaining.
+        let total: u32 = remaining.iter().map(|(_, w)| *w as u32).sum();
+        if total == 0 { break; }
+        let mut roll = rng.random_range(0..total);
+        let mut picked_idx: Option<usize> = None;
+        for (i, (_, w)) in remaining.iter().enumerate() {
+            if roll < *w as u32 {
+                picked_idx = Some(i);
+                break;
+            }
+            roll -= *w as u32;
+        }
+        let idx = picked_idx.expect("weighted pick must succeed when total > 0");
+        let (candidate, _) = remaining.remove(idx);
+
+        // Reject if conflicts with anything already chosen.
+        if chosen.iter().any(|t| conflicts_with(*t, candidate)) {
+            continue;
+        }
+        chosen.push(candidate);
+    }
+
+    chosen
+}
+```
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::traits::tests::generate` — expect 2 passed.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(traits): generate_traits with conflict rejection"`
+
+### Task 1.7: `ThresholdDelta` + `threshold_modifiers`
+
+Spec §5.5: deltas are framed but not tuned. Pick conservative starter values; balance later.
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn threshold_delta_aggressive_lowers_health_threshold() {
+    let d = Trait::Aggressive.threshold_modifiers();
+    // Aggressive should bias toward fighting → lower health-flee threshold
+    assert!(d.low_health_limit < 0);
+}
+
+#[test]
+fn threshold_delta_zero_traits_is_identity() {
+    let total: ThresholdDelta = [].iter().map(|t: &Trait| t.threshold_modifiers()).sum();
+    assert_eq!(total, ThresholdDelta::default());
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Additive deltas applied to `PersonalityThresholds`. `i32` so deltas can be
+/// signed; final values clamp to u32 ranges in `compute_thresholds`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ThresholdDelta {
+    pub low_health_limit: i32,
+    pub mid_health_limit: i32,
+    pub low_sanity_limit: i32,
+    pub mid_sanity_limit: i32,
+    pub high_sanity_limit: i32,
+    pub movement_limit: i32,
+    pub low_intelligence_limit: i32,
+    pub high_intelligence_limit: i32,
+    pub psychotic_break_threshold: i32,
+}
+
+impl std::ops::Add for ThresholdDelta {
+    type Output = ThresholdDelta;
+    fn add(self, rhs: Self) -> Self {
+        ThresholdDelta {
+            low_health_limit: self.low_health_limit + rhs.low_health_limit,
+            mid_health_limit: self.mid_health_limit + rhs.mid_health_limit,
+            low_sanity_limit: self.low_sanity_limit + rhs.low_sanity_limit,
+            mid_sanity_limit: self.mid_sanity_limit + rhs.mid_sanity_limit,
+            high_sanity_limit: self.high_sanity_limit + rhs.high_sanity_limit,
+            movement_limit: self.movement_limit + rhs.movement_limit,
+            low_intelligence_limit: self.low_intelligence_limit + rhs.low_intelligence_limit,
+            high_intelligence_limit: self.high_intelligence_limit + rhs.high_intelligence_limit,
+            psychotic_break_threshold: self.psychotic_break_threshold + rhs.psychotic_break_threshold,
+        }
+    }
+}
+
+impl std::iter::Sum for ThresholdDelta {
+    fn sum<I: Iterator<Item = ThresholdDelta>>(iter: I) -> Self {
+        iter.fold(ThresholdDelta::default(), |a, b| a + b)
+    }
+}
+
+impl Trait {
+    pub fn threshold_modifiers(&self) -> ThresholdDelta {
+        match self {
+            Trait::Aggressive => ThresholdDelta {
+                low_health_limit: -5, mid_health_limit: -10,
+                low_sanity_limit: -2, psychotic_break_threshold: 2,
+                ..Default::default()
+            },
+            Trait::Defensive => ThresholdDelta {
+                low_health_limit: 10, mid_health_limit: 10,
+                psychotic_break_threshold: -2,
+                ..Default::default()
+            },
+            Trait::Cautious => ThresholdDelta {
+                low_health_limit: 15, mid_health_limit: 15,
+                low_sanity_limit: 10, mid_sanity_limit: 10,
+                psychotic_break_threshold: -3,
+                ..Default::default()
+            },
+            Trait::Reckless => ThresholdDelta {
+                low_health_limit: -10, low_sanity_limit: -10,
+                psychotic_break_threshold: 4,
+                ..Default::default()
+            },
+            Trait::Resilient => ThresholdDelta {
+                psychotic_break_threshold: -3,
+                low_sanity_limit: -3,
+                ..Default::default()
+            },
+            Trait::Fragile => ThresholdDelta {
+                psychotic_break_threshold: 3,
+                low_sanity_limit: 5,
+                ..Default::default()
+            },
+            Trait::Cunning => ThresholdDelta {
+                low_intelligence_limit: -5, high_intelligence_limit: -5,
+                ..Default::default()
+            },
+            Trait::Dim => ThresholdDelta {
+                low_intelligence_limit: 10, high_intelligence_limit: 5,
+                ..Default::default()
+            },
+            // Social and physical traits leave thresholds untouched.
+            _ => ThresholdDelta::default(),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::traits::tests::threshold` — expect 2 passed.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(traits): threshold deltas"`
+
+### Task 1.8: Phase 1 self-check
+
+- [ ] Run `cargo clippy -p game --no-deps -- -D warnings`. Expect clean.
+- [ ] Run `cargo test -p game tributes::traits::tests`. Expect all passing.
+- [ ] `bd update <p1> --status=closed --reason="traits.rs landed"` then `bd update <p2> --claim`.
+
+---
+
+## Phase 2 — `alliances.rs` Module
+
+**Files:**
+- Create: `game/src/tributes/alliances.rs`
+- Modify: `game/src/tributes/mod.rs` (add `pub mod alliances;`)
+- Test: inline `#[cfg(test)] mod tests`
+
+This phase writes pure functions only. They take `&Tribute`/`&[Tribute]`, return decisions + new event variants. Mutation is wired in Phase 3.
+
+### Task 2.1: `AllianceEvent` enum + scaffold
+
+- [ ] **Step 1: Create `game/src/tributes/alliances.rs`**
+
+```rust
+//! Tribute alliance formation, breaks, and event queue. See spec
+//! `docs/superpowers/specs/2026-04-25-tribute-alliances-design.md` §6–§7.
+
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllianceEvent {
+    BetrayalRecorded { betrayer: Uuid, victim: Uuid },
+    DeathRecorded { deceased: Uuid, killer: Option<Uuid> },
+}
+
+/// Per-tribute hard cap on direct alliances.
+pub const MAX_ALLIES: usize = 5;
+/// Base chance per encounter that two tributes form an alliance.
+pub const BASE_ALLIANCE_CHANCE: f64 = 0.20;
+/// Treacherous betrayal cadence in turns.
+pub const TREACHEROUS_BETRAYAL_INTERVAL: u8 = 5;
+```
+
+- [ ] **Step 2: Add `pub mod alliances;` to `game/src/tributes/mod.rs`**
+
+- [ ] **Step 3: Run** `cargo check -p game`. Expect clean.
+
+- [ ] **Step 4: Commit** `jj describe -m "feat(alliances): scaffold + AllianceEvent"`
+
+### Task 2.2: `passes_gate` refuser logic
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tributes::traits::Trait;
+
+    fn t(traits: Vec<Trait>) -> Vec<Trait> { traits }
+
+    #[test]
+    fn paranoid_vs_paranoid_blocked() {
+        assert!(!passes_gate(&t(vec![Trait::Paranoid]), &t(vec![Trait::Paranoid])));
+    }
+
+    #[test]
+    fn lonewolf_vs_friendly_blocked_when_only_lonewolf_has_no_positive() {
+        // LoneWolf has affinity 0.6 (no positive), Friendly has 1.5.
+        // (positive AND positive) = false; (no_refuser AND no_refuser) = false.
+        assert!(!passes_gate(&t(vec![Trait::LoneWolf]), &t(vec![Trait::Friendly])));
+    }
+
+    #[test]
+    fn snake_in_grass_passes_gate() {
+        // [Friendly, Paranoid] paired with [Loyal]: both have positives.
+        assert!(passes_gate(
+            &t(vec![Trait::Friendly, Trait::Paranoid]),
+            &t(vec![Trait::Loyal]),
+        ));
+    }
+
+    #[test]
+    fn empty_traits_pass_gate() {
+        assert!(passes_gate(&t(vec![]), &t(vec![])));
+    }
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::tributes::traits::{REFUSERS, Trait};
+
+pub fn passes_gate(self_traits: &[Trait], target_traits: &[Trait]) -> bool {
+    let has_positive = |ts: &[Trait]| ts.iter().any(|x| x.alliance_affinity() >= 1.0);
+    let has_refuser = |ts: &[Trait]| ts.iter().any(|x| REFUSERS.contains(x));
+    (has_positive(self_traits) && has_positive(target_traits))
+        || (!has_refuser(self_traits) && !has_refuser(target_traits))
+}
+```
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::alliances::tests::passes_gate` and the four `*_gate*` tests. Expect 4 passing (zero-trait test passes — empty has no refusers).
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(alliances): passes_gate refuser logic"`
+
+### Task 2.3: `roll_chance` formula
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn cap_pen_zero_when_full() {
+    let chance = roll_chance(
+        &[Trait::Friendly], &[Trait::Friendly],
+        true, // same district
+        MAX_ALLIES, 0, // self at cap
+    );
+    assert_eq!(chance, 0.0);
+}
+
+#[test]
+fn fully_neutral_pair_at_base() {
+    // Both empty traits, different district, both 0 allies.
+    let chance = roll_chance(&[], &[], false, 0, 0);
+    // base 0.20 * 1.0 * 1.0 * 1.0 * 1.0 * 1.0 = 0.20
+    assert!((chance - 0.20).abs() < 1e-9);
+}
+
+#[test]
+fn clamps_at_cap() {
+    // Stack everything: Friendly+Friendly, same district, both 0 allies.
+    let chance = roll_chance(&[Trait::Friendly], &[Trait::Friendly], true, 0, 0);
+    // 0.20 * 1.5 * 1.5 * 1.5 * 1.0 * 1.0 = 0.675
+    assert!(chance > 0.6 && chance <= 0.95);
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::tributes::traits::geometric_mean_affinity;
+
+/// Roll chance per spec §6.2. `self_allies_len` and `target_allies_len` are
+/// current `Vec::len()` of each tribute's `allies` list.
+pub fn roll_chance(
+    self_traits: &[Trait],
+    target_traits: &[Trait],
+    same_district: bool,
+    self_allies_len: usize,
+    target_allies_len: usize,
+) -> f64 {
+    let trait_factor = geometric_mean_affinity(self_traits);
+    let target_factor = geometric_mean_affinity(target_traits);
+    let district_bonus = if same_district { 1.5 } else { 1.0 };
+    let self_cap_pen = (MAX_ALLIES as f64 - self_allies_len as f64) / MAX_ALLIES as f64;
+    let target_cap_pen = (MAX_ALLIES as f64 - target_allies_len as f64) / MAX_ALLIES as f64;
+    let raw = BASE_ALLIANCE_CHANCE
+        * trait_factor
+        * target_factor
+        * district_bonus
+        * self_cap_pen.max(0.0)
+        * target_cap_pen.max(0.0);
+    raw.clamp(0.0, 0.95)
+}
+```
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::alliances::tests` — expect new tests passing.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(alliances): roll_chance formula"`
+
+### Task 2.4: `deciding_factor` event-text helper
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn deciding_factor_picks_largest_above_one() {
+    let f = deciding_factor(&[Trait::Friendly], &[Trait::Loyal], true);
+    // district 1.5 > Friendly 1.5 tie → Friendly wins by trait label sort
+    // ("friendly" < "same district"); but for this test just assert non-empty.
+    assert!(f.is_some());
+}
+
+#[test]
+fn deciding_factor_none_when_nothing_exceeds_one() {
+    let f = deciding_factor(&[], &[], false);
+    assert!(f.is_none());
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Returns the human-readable deciding factor for a successful alliance roll,
+/// or `None` if no factor exceeded 1.0. Caller formats this into the event
+/// string (e.g. "Deciding factor: Peeta is friendly.").
+pub fn deciding_factor(
+    self_traits: &[Trait],
+    target_traits: &[Trait],
+    same_district: bool,
+) -> Option<DecidingFactor> {
+    let mut candidates: Vec<(f64, DecidingFactor)> = Vec::new();
+    if same_district {
+        candidates.push((1.5, DecidingFactor::SameDistrict));
+    }
+    for t in self_traits {
+        let a = t.alliance_affinity();
+        if a > 1.0 {
+            candidates.push((a, DecidingFactor::TraitOnSelf(*t)));
+        }
+    }
+    for t in target_traits {
+        let a = t.alliance_affinity();
+        if a > 1.0 {
+            candidates.push((a, DecidingFactor::TraitOnTarget(*t)));
+        }
+    }
+    candidates.sort_by(|(a, df_a), (b, df_b)| {
+        b.partial_cmp(a)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| df_a.label().cmp(df_b.label()))
+    });
+    candidates.into_iter().next().map(|(_, df)| df)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecidingFactor {
+    SameDistrict,
+    TraitOnSelf(Trait),
+    TraitOnTarget(Trait),
+}
+
+impl DecidingFactor {
+    pub fn label(&self) -> &'static str {
+        match self {
+            DecidingFactor::SameDistrict => "same district",
+            DecidingFactor::TraitOnSelf(t) | DecidingFactor::TraitOnTarget(t) => t.label(),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::alliances::tests::deciding_factor` — expect 2 passed.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(alliances): deciding_factor"`
+
+### Task 2.5: `sanity_break_roll` per-ally check
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn sanity_break_above_limit_no_break() {
+    let mut rng = StdRng::seed_from_u64(1);
+    // sanity 50 with limit 20: deficit_ratio 0 → never breaks.
+    let breaks = sanity_break_roll(50, 20, &mut rng);
+    assert!(!breaks);
+}
+
+#[test]
+fn sanity_break_far_below_always_breaks() {
+    let mut rng = StdRng::seed_from_u64(1);
+    // sanity 0 with limit 20: deficit_ratio 1.0 → always breaks.
+    let breaks = sanity_break_roll(0, 20, &mut rng);
+    assert!(breaks);
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Per-ally sanity-break roll (spec §7.3a). Returns `true` if the symmetric
+/// pair should be removed.
+pub fn sanity_break_roll(current_sanity: u32, low_sanity_limit: u32, rng: &mut impl rand::Rng) -> bool {
+    if current_sanity >= low_sanity_limit {
+        return false;
+    }
+    let deficit_ratio = (low_sanity_limit.saturating_sub(current_sanity) as f64)
+        / (low_sanity_limit.max(1) as f64);
+    let p = deficit_ratio.clamp(0.0, 1.0);
+    rng.random_bool(p)
+}
+```
+
+- [ ] **Step 4: Run** the 2 new tests — expect passing.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(alliances): sanity_break_roll"`
+
+### Task 2.6: `trust_shock_roll` (betrayal cascade) helper
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn trust_shock_baseline_50pct_at_full_sanity() {
+    // Exhaustive seed trial: with deficit 0, p = 0.5; expect mix.
+    let mut rng = StdRng::seed_from_u64(1);
+    let mut breaks = 0;
+    for _ in 0..200 {
+        if trust_shock_roll(50, 20, &mut rng) { breaks += 1; }
+    }
+    // Should be sanity >= limit → return false always.
+    assert_eq!(breaks, 0);
+}
+
+#[test]
+fn trust_shock_below_limit_high_baseline() {
+    let mut rng = StdRng::seed_from_u64(7);
+    let mut breaks = 0;
+    for _ in 0..200 {
+        if trust_shock_roll(10, 20, &mut rng) { breaks += 1; }
+    }
+    // p = 0.5 + 0.5*0.5 = 0.75; ~150 expected, allow wide band.
+    assert!(breaks > 100, "expected most to break, got {breaks}");
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Trust-shock roll for a betrayal victim (§7.3c1). Same threshold as sanity
+/// break, higher baseline (`0.5 + 0.5 * deficit_ratio`).
+pub fn trust_shock_roll(current_sanity: u32, low_sanity_limit: u32, rng: &mut impl rand::Rng) -> bool {
+    if current_sanity >= low_sanity_limit {
+        return false;
+    }
+    let deficit_ratio = (low_sanity_limit.saturating_sub(current_sanity) as f64)
+        / (low_sanity_limit.max(1) as f64);
+    let p = (0.5 + 0.5 * deficit_ratio).clamp(0.0, 1.0);
+    rng.random_bool(p)
+}
+```
+
+- [ ] **Step 4: Run** 2 new tests — expect passing.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(alliances): trust_shock_roll"`
+
+### Task 2.7: Phase 2 self-check
+
+- [ ] `cargo clippy -p game --no-deps -- -D warnings`. Clean.
+- [ ] `cargo test -p game tributes::alliances`. All passing.
+- [ ] `bd update <p2> --status=closed --reason="alliances.rs pure module landed"`; claim p3.
+
+---
+
+## Phase 3 — Tribute + Brain Integration
+
+**Files:**
+- Modify: `game/src/tributes/mod.rs` (add fields, rewrite `pick_target`, remove loyalty + district filter, add `test_default`)
+- Modify: `game/src/tributes/brains.rs` (remove `BrainPersonality` enum and 9 lookup tables; add `compute_thresholds` over a trait set)
+- Modify: `game/src/config.rs` (remove `loyalty_break_level`, `max_loyalty`)
+
+This is the destructive phase. Cutover, no migration. After this phase the engine compiles only with traits driving thresholds and `allies` driving target filtering.
+
+### Task 3.1: Add fields to `Tribute`
+
+- [ ] **Step 1: Failing test in `game/src/tributes/mod.rs`** (or tests file)
+
+```rust
+#[test]
+fn tribute_default_has_empty_allies_and_traits() {
+    let t = Tribute::test_default();
+    assert!(t.allies.is_empty());
+    assert!(t.traits.is_empty());
+    assert_eq!(t.turns_since_last_betrayal, 0);
+}
+```
+
+- [ ] **Step 2: Run** `cargo test -p game tributes::tribute_default_has_empty` — expect fail.
+
+- [ ] **Step 3: Add fields to `Tribute` struct**
+
+In `game/src/tributes/mod.rs`, on `pub struct Tribute`:
+
+```rust
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub allies: Vec<uuid::Uuid>,
+
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub traits: Vec<crate::tributes::traits::Trait>,
+
+#[serde(default)]
+pub turns_since_last_betrayal: u8,
+```
+
+Add `Tribute::test_default()`:
+
+```rust
+impl Tribute {
+    /// Construct a zero-trait tribute with deterministic fields suitable for
+    /// unit tests. Equivalent to the old `BrainPersonality::Balanced`
+    /// behavior because zero traits = base thresholds.
+    #[cfg(test)]
+    pub fn test_default() -> Self {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let mut t = Tribute::default();
+        t.id = uuid::Uuid::new_v4();
+        t.brain = Brain::default();
+        t.allies = Vec::new();
+        t.traits = Vec::new();
+        t.turns_since_last_betrayal = 0;
+        // ... existing default-ish field population, mirroring Tribute::new
+        // minus randomized trait generation.
+        let _ = rng;
+        t
+    }
+}
+```
+
+(The exact body depends on existing `Tribute::default`/`Tribute::new`. Match whatever scaffolding the surrounding tests already rely on.)
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::tribute_default_has_empty` — expect pass.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(tribute): add allies, traits, turns_since_last_betrayal"`
+
+### Task 3.2: Wire `generate_traits` into `Tribute::new`
+
+- [ ] **Step 1: Read** `game/src/tributes/mod.rs` lines around 110 (`Brain::new_with_random_personality(&mut rng)`).
+
+- [ ] **Step 2: Replace personality call with trait generation:**
+
+```rust
+// OLD
+let brain = Brain::new_with_random_personality(&mut rng);
+
+// NEW
+let traits = crate::tributes::traits::generate_traits(district, &mut rng);
+let brain = Brain::default();
+```
+
+Then where `Tribute` is constructed, set `traits`, leave `allies = Vec::new()` and `turns_since_last_betrayal = 0`.
+
+- [ ] **Step 3: Run** `cargo check -p game` — expect compile errors next.
+
+- [ ] **Step 4: Commit** `jj describe -m "feat(tribute): generate traits on creation"`
+
+### Task 3.3: Gut `BrainPersonality`
+
+- [ ] **Step 1: Delete** the entire `pub enum BrainPersonality { … }` and all its `impl` blocks in `game/src/tributes/brains.rs`.
+
+- [ ] **Step 2: Delete** `Brain::personality` field and `Brain::new_with_random_personality`.
+
+- [ ] **Step 3: Replace** `BrainPersonality::Balanced.generate_thresholds(rng)` callers with a free function:
+
+```rust
+// In brains.rs
+use crate::tributes::traits::{Trait, ThresholdDelta};
+
+impl PersonalityThresholds {
+    /// Compute thresholds from a trait set with ±20% per-tribute variance.
+    pub fn from_traits(traits: &[Trait], rng: &mut impl rand::Rng) -> Self {
+        // Base = old Balanced numbers.
+        let base = PersonalityThresholds {
+            low_health_limit: 20,
+            mid_health_limit: 40,
+            low_sanity_limit: 10,
+            mid_sanity_limit: 20,
+            high_sanity_limit: 35,
+            movement_limit: 10,
+            low_intelligence_limit: 35,
+            high_intelligence_limit: 80,
+            psychotic_break_threshold: 8,
+        };
+        let delta: ThresholdDelta = traits.iter().map(|t| t.threshold_modifiers()).sum();
+        let apply_var = |val: i32, rng: &mut dyn rand::RngCore| -> u32 {
+            let varied = val as f64 * rng.random_range(0.8..=1.2);
+            varied.clamp(0.0, 100.0) as u32
+        };
+        let apply_break = |val: i32, rng: &mut dyn rand::RngCore| -> u32 {
+            let varied = val as f64 * rng.random_range(0.8..=1.2);
+            varied.clamp(0.0, 20.0) as u32
+        };
+        PersonalityThresholds {
+            low_health_limit: apply_var(base.low_health_limit as i32 + delta.low_health_limit, rng),
+            mid_health_limit: apply_var(base.mid_health_limit as i32 + delta.mid_health_limit, rng),
+            low_sanity_limit: apply_var(base.low_sanity_limit as i32 + delta.low_sanity_limit, rng),
+            mid_sanity_limit: apply_var(base.mid_sanity_limit as i32 + delta.mid_sanity_limit, rng),
+            high_sanity_limit: apply_var(base.high_sanity_limit as i32 + delta.high_sanity_limit, rng),
+            movement_limit: apply_var(base.movement_limit as i32 + delta.movement_limit, rng),
+            low_intelligence_limit: apply_var(base.low_intelligence_limit as i32 + delta.low_intelligence_limit, rng),
+            high_intelligence_limit: apply_var(base.high_intelligence_limit as i32 + delta.high_intelligence_limit, rng),
+            psychotic_break_threshold: apply_break(base.psychotic_break_threshold as i32 + delta.psychotic_break_threshold, rng),
+        }
+    }
+}
+```
+
+- [ ] **Step 4:** Update every caller in `brains.rs` and elsewhere that relied on `BrainPersonality::*` lookup tables (low/mid/high sanity, movement, intelligence, psychotic break) to instead read off the cached `PersonalityThresholds` already on `Brain` (or re-compute from `tribute.traits`).
+
+- [ ] **Step 5:** `cargo check -p game` — fix compile errors iteratively. Expect 6–10 call sites in `brains.rs` to need adjustment.
+
+- [ ] **Step 6: Commit** `jj describe -m "refactor(brains): replace BrainPersonality with trait-derived thresholds"`
+
+### Task 3.4: Remove `loyalty` field + `LOYALTY_BREAK_LEVEL`
+
+- [ ] **Step 1:** In `game/src/tributes/mod.rs`:
+  - Delete line 31: `const LOYALTY_BREAK_LEVEL: f64 = 0.25;`
+  - Delete line 472: `pub loyalty: u32,` from the attributes struct.
+  - Delete loyalty initialization at lines 493 and 515.
+
+- [ ] **Step 2:** In `game/src/config.rs`:
+  - Delete `loyalty_break_level` (line 49) and `max_loyalty` (line 58).
+  - Delete their default initializers (lines 91 and 100).
+
+- [ ] **Step 3:** Run `cargo check -p game` — fix any remaining `attributes.loyalty` references.
+
+- [ ] **Step 4: Commit** `jj describe -m "refactor: remove loyalty + LOYALTY_BREAK_LEVEL"`
+
+### Task 3.5: Rewrite `pick_target` ally filter
+
+- [ ] **Step 1: Locate** `pick_target` in `game/src/tributes/mod.rs` line 340.
+
+- [ ] **Step 2: Failing test**
+
+```rust
+#[test]
+fn pick_target_excludes_allies() {
+    let mut a = Tribute::test_default();
+    let mut b = Tribute::test_default();
+    a.allies.push(b.id);
+    b.allies.push(a.id);
+    // Both in same area, both alive. pick_target should return None or some
+    // other tribute, never `b`.
+    let targets = vec![b.clone()];
+    let pick = a.pick_target(/* construct args matching real signature */);
+    // Adjust to actual signature; assertion is "result is not b.id".
+    assert!(pick.map(|t| t.id != b.id).unwrap_or(true));
+}
+```
+
+(Adjust call shape to match `pick_target`'s real signature in `mod.rs:340`.)
+
+- [ ] **Step 3:** Inside `pick_target`, replace the `district != self.district` filter at line 359 with an ally filter:
+
+```rust
+// OLD
+.filter(|t| t.district != self.district)
+
+// NEW
+.filter(|t| !self.allies.contains(&t.id))
+```
+
+Delete the loyalty branch at line 373 entirely (the `else if (self.attributes.loyalty as f64 / 100.0) < LOYALTY_BREAK_LEVEL { … }` block).
+
+- [ ] **Step 4: Run** `cargo test -p game tributes::pick_target_excludes_allies`. Expect pass.
+
+- [ ] **Step 5: Commit** `jj describe -m "refactor(pick_target): ally filter replaces district filter and loyalty branch"`
+
+### Task 3.6: Phase 3 self-check
+
+- [ ] `cargo build -p game`. Clean.
+- [ ] `cargo clippy -p game --no-deps -- -D warnings`. Clean.
+- [ ] Many existing tests will fail (they reference `BrainPersonality` or `loyalty`). That is expected — Phase 6 fixes them. Run `cargo test -p game --no-fail-fast 2>&1 | grep -c FAILED` and write the count into the bead notes for tracking.
+- [ ] `bd update <p3> --status=closed --reason="Tribute integration done; existing tests broken pending Phase 6"`; claim p4.
+
+---
+
+## Phase 4 — Cycle Drain in `run_day_night_cycle`
+
+**Files:**
+- Modify: `game/src/games.rs` (around line 716 `for tribute in self.tributes.iter_mut()`)
+- Modify: `game/src/games.rs` (struct: add `alliance_events: Vec<AllianceEvent>` field at top of `Game`)
+
+### Task 4.1: Add event queue field on `Game`
+
+- [ ] **Step 1: Failing test** in `game/src/games.rs` tests:
+
+```rust
+#[test]
+fn game_has_empty_alliance_event_queue_on_new() {
+    let g = Game::default();
+    assert!(g.alliance_events.is_empty());
+}
+```
+
+- [ ] **Step 2: Run, expect compile fail.**
+
+- [ ] **Step 3: Add field** to `Game`:
+
+```rust
+#[serde(default, skip_serializing)]
+pub alliance_events: Vec<crate::tributes::alliances::AllianceEvent>,
+```
+
+`skip_serializing` because the queue is transient — it lives only inside one `run_day_night_cycle` and is drained before save.
+
+- [ ] **Step 4: Run test** — expect pass.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(game): add alliance_events queue"`
+
+### Task 4.2: Drain queue between tribute turns
+
+- [ ] **Step 1:** Locate `for tribute in self.tributes.iter_mut()` at `game/src/games.rs:716`.
+
+- [ ] **Step 2:** Refactor that loop body so each iteration ends with:
+
+```rust
+// After tribute.act(...):
+self.alliance_events.append(&mut tribute.drain_alliance_events());
+```
+
+Then between iterations of the outer cycle (or at the end of each tribute's turn before mutable borrow releases — the cleanest place is once per outer step), call:
+
+```rust
+self.process_alliance_events(rng);
+```
+
+Where `process_alliance_events`:
+
+```rust
+fn process_alliance_events(&mut self, rng: &mut impl Rng) {
+    use crate::tributes::alliances::{AllianceEvent, trust_shock_roll, sanity_break_roll};
+
+    for ev in self.alliance_events.drain(..).collect::<Vec<_>>() {
+        match ev {
+            AllianceEvent::BetrayalRecorded { betrayer, victim } => {
+                // 1. Ensure the symmetric pair is removed on victim's side.
+                if let Some(v) = self.tributes.iter_mut().find(|t| t.id == victim) {
+                    v.allies.retain(|x| *x != betrayer);
+                    // 2. Schedule trust-shock on victim's NEXT turn.
+                    //    Encode as a flag on the tribute (e.g. `pending_trust_shock: bool`),
+                    //    consumed at top of victim's next act().
+                    v.pending_trust_shock = true;
+                }
+                // Betrayer is NOT scheduled for trust-shock (spec §7.5).
+            }
+            AllianceEvent::DeathRecorded { deceased, killer: _ } => {
+                // Snapshot allies of the deceased before mutation.
+                let allies_of_deceased: Vec<uuid::Uuid> = self
+                    .tributes
+                    .iter()
+                    .find(|t| t.id == deceased)
+                    .map(|d| d.allies.clone())
+                    .unwrap_or_default();
+
+                for ally_id in allies_of_deceased {
+                    if let Some(ally) = self.tributes.iter_mut().find(|t| t.id == ally_id) {
+                        let limit = ally.brain.thresholds.low_sanity_limit;
+                        let sanity = ally.attributes.sanity;
+                        if sanity_break_roll(sanity, limit, rng) {
+                            ally.allies.retain(|x| *x != deceased);
+                            self.messages.push(GameMessage::ally_death_break(
+                                &ally.name,
+                                deceased,
+                            ));
+                        }
+                    }
+                }
+                // Also remove the deceased from everyone's lists (cleanup).
+                for t in self.tributes.iter_mut() {
+                    t.allies.retain(|x| *x != deceased);
+                }
+            }
+        }
+    }
+}
+```
+
+(Adjust event-message API to match existing `messages` shape on `Game`; `ally_death_break` is a placeholder constructor.)
+
+- [ ] **Step 3:** Add `pending_trust_shock: bool` field to `Tribute` (`#[serde(default)]`, no `skip_serializing_if`). At top of `Tribute::act`, if `pending_trust_shock`, run `trust_shock_roll(...)` against current allies and break each pair on success. Reset flag.
+
+- [ ] **Step 4:** `cargo check -p game` — fix compile.
+
+- [ ] **Step 5: Commit** `jj describe -m "feat(game): drain alliance event queue between turns"`
+
+### Task 4.3: Phase 4 self-check
+
+- [ ] `cargo build -p game`. Clean.
+- [ ] `cargo test -p game tributes::alliances tributes::traits`. Phase-1/2 tests still passing.
+- [ ] `bd update <p4> --status=closed`; claim p5.
+
+---
+
+## Phase 5 — Persistence + DTO + Frontend Scrub
+
+### Task 5.1: SurrealDB schema additions
+
+- [ ] **Step 1:** Edit `schemas/tribute.surql`. After the existing `attributes` line, insert:
+
+```surql
+DEFINE FIELD OVERWRITE allies ON tribute TYPE array<uuid> DEFAULT [];
+DEFINE FIELD OVERWRITE traits ON tribute TYPE array<string> DEFAULT [];
+DEFINE FIELD OVERWRITE turns_since_last_betrayal ON tribute TYPE int DEFAULT 0;
+```
+
+- [ ] **Step 2:** Edit `migrations/definitions/_initial.json`. Bump version to next integer (read existing first). Add release note in description: `"0ug: traits replace BrainPersonality; allies + traits + turns_since_last_betrayal added on tribute. Reset your dev DB."`
+
+- [ ] **Step 3:** Restart SurrealDB locally; run `just dev`; verify migration applies cleanly.
+
+- [ ] **Step 4: Commit** `jj describe -m "feat(schema): tribute alliances + traits"`
+
+### Task 5.2: `shared/` DTO additions
+
+- [ ] **Step 1:** In `shared/src/lib.rs`, locate the tribute DTO struct (used by API responses). Add:
+
+```rust
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub allies: Vec<uuid::Uuid>,
+
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub traits: Vec<game::tributes::traits::Trait>, // re-export path may differ
+```
+
+(If `shared/` cannot depend on `game/`, copy the `Trait` enum into `shared/` and add a `From<game::Trait>` conversion in the API layer. The simpler v1 path: serialize as `Vec<String>` matching Serde unit-variant repr.)
+
+- [ ] **Step 2:** `cargo build -p shared -p api -p web` — fix imports.
+
+- [ ] **Step 3: Commit** `jj describe -m "feat(shared): tribute DTO gains allies + traits"`
+
+### Task 5.3: API persistence path
+
+- [ ] **Step 1:** Open `api/src/tributes.rs`. Find the SELECT/UPDATE shape.
+
+- [ ] **Step 2:** Verify Serde already round-trips the new fields (most likely yes since the struct uses `#[serde(default)]`). Run an integration test if one exists; otherwise add a smoke test:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn tribute_persists_allies_and_traits() {
+    let app = spawn_test_app().await;
+    let game = app.create_game().await;
+    let tribute = &game.tributes[0];
+    // Verify response contains new fields.
+    let body = app.get_tribute(&tribute.identifier).await;
+    assert!(body.get("traits").is_some());
+    assert!(body.get("allies").is_some());
+}
+```
+
+- [ ] **Step 3:** Run `cargo test -p api tribute_persists_allies_and_traits -- --test-threads=1`. Expect pass.
+
+- [ ] **Step 4: Commit** `jj describe -m "test(api): tribute persistence round-trip for allies + traits"`
+
+### Task 5.4: Frontend `loyalty` scrub
+
+- [ ] **Step 1:** Open `web/src/components/tribute_detail.rs:316`.
+
+- [ ] **Step 2:** Delete the `dd { "{attributes.loyalty}" }` line and any sibling `dt` label that introduces it.
+
+- [ ] **Step 3:** Run `just web` locally; verify the tribute detail page renders without compile error or visual breakage.
+
+- [ ] **Step 4: Commit** `jj describe -m "refactor(web): remove loyalty display from tribute detail"`
+
+### Task 5.5: Phase 5 self-check
+
+- [ ] `cargo build --workspace`. Clean.
+- [ ] `just dev` boots, migration applies, frontend renders tribute detail.
+- [ ] `bd update <p5> --status=closed`; claim p6.
+
+---
+
+## Phase 6 — Test Migration + Alliance Test Suite
+
+This is the catch-up phase. Existing ~60 game-crate tests reference `BrainPersonality` and `loyalty`; they will not compile after Phase 3. Fix in batches.
+
+### Task 6.1: Bulk-replace `BrainPersonality::Balanced` constructions
+
+- [ ] **Step 1:** `rg "BrainPersonality::" game/ --files-with-matches` — list affected files.
+
+- [ ] **Step 2:** For each call site, replace pattern:
+
+```rust
+// OLD
+let mut tribute = Tribute::new(...);
+tribute.brain.personality = BrainPersonality::Balanced;
+```
+
+```rust
+// NEW
+let tribute = Tribute::test_default();
+```
+
+- [ ] **Step 3:** For tests asserting on personality, replace with trait-set assertions:
+
+```rust
+// OLD
+assert_eq!(tribute.brain.personality, BrainPersonality::Aggressive);
+
+// NEW
+assert!(tribute.traits.contains(&Trait::Aggressive));
+```
+
+- [ ] **Step 4:** `cargo test -p game --no-run` and iterate until clean compile.
+
+- [ ] **Step 5: Commit** `jj describe -m "test: migrate BrainPersonality references to traits"` (multiple commits OK as you batch by file).
+
+### Task 6.2: Bucket-tolerance helper
+
+- [ ] **Step 1:** In `game/src/tributes/traits.rs` test module, add:
+
+```rust
+#[cfg(test)]
+fn assert_within_tolerance(observed: u32, expected: u32, pct: f64) {
+    let tol = (expected as f64 * pct).max(1.0);
+    let diff = (observed as f64 - expected as f64).abs();
+    assert!(
+        diff <= tol,
+        "observed {observed} not within ±{}% of expected {expected} (diff {diff})",
+        pct * 100.0
+    );
+}
+```
+
+- [ ] **Step 2: Failing test for district pool weighting**
+
+```rust
+#[test]
+fn district_pool_weighting_within_tolerance() {
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut counts: std::collections::HashMap<Trait, u32> = Default::default();
+    for _ in 0..10_000 {
+        let traits = generate_traits(1, &mut rng);
+        for t in traits {
+            *counts.entry(t).or_insert(0) += 1;
+        }
+    }
+    // Pool: Loyal 4, Aggressive 4, Paranoid 3, Tough 2 (total 13).
+    // Expected counts depend on draw count per tribute (avg 4 traits).
+    // Loose assertion: each pool member observed; relative ratios within ±15%.
+    let loyal = *counts.get(&Trait::Loyal).unwrap_or(&0);
+    let tough = *counts.get(&Trait::Tough).unwrap_or(&0);
+    // Loyal:Tough weight ratio is 4:2 = 2:1. So loyal ≈ 2*tough ±15%.
+    assert_within_tolerance(loyal, tough * 2, 0.15);
+}
+```
+
+- [ ] **Step 3: Run** test, iterate on tolerance/seed if flaky — but flakiness with a fixed seed indicates a real generator bug.
+
+- [ ] **Step 4: Commit** `jj describe -m "test(traits): bucket-tolerance helper + district weighting test"`
+
+### Task 6.3: Multi-tribute alliance integration tests
+
+In `game/src/tributes/alliances.rs` test module, add scenarios:
+
+- [ ] **Test:** Paranoid×Paranoid never allies over 1000 trials.
+- [ ] **Test:** Friendly×Friendly same-district allies ≥ 60% over 1000 trials with fixed seed.
+- [ ] **Test:** Tribute at `allies.len() == 5` always refuses (`roll_chance` returns 0).
+- [ ] **Test:** Sanity drop below limit triggers `sanity_break_roll` true with high probability when deficit large.
+- [ ] **Test:** Treacherous timer increments and resets correctly across turns. (May require a small harness driving a `Game` through cycles.)
+- [ ] **Test:** Trust-shock cascade: betrayed survivor with 3 other allies removes all 3 pairs on roll success.
+- [ ] **Test:** Ally-death cascade: when tribute X dies, X's direct allies roll independently; those rolling true remove the pair with X.
+- [ ] **Test:** Shared perception: build two same-area allied tributes, verify ally's perceived items unioned into self's `EnvironmentContext`.
+
+Each test follows the failing-first → implement-or-validate → pass pattern. Most exercise existing pure functions from Phase 2; if a behavior is missing (e.g. shared perception helper), add the helper in `alliances.rs` first and update Phase 2 task list retroactively (this is the only allowed back-edit).
+
+- [ ] **Commit** as you batch: `jj describe -m "test(alliances): formation gate / cap penalty / sanity break / treacherous / cascade / perception"`
+
+### Task 6.4: API integration round-trip test
+
+- [ ] **Test:** in `api/tests/`, create `tribute_alliances_test.rs` with a single test that:
+  1. Creates a game (auto-spawns 24 tributes).
+  2. Asserts each tribute has `traits` non-empty and `allies` empty initially.
+  3. Runs `/api/games/{id}/run-day` (or whatever endpoint drives a cycle).
+  4. Asserts at least one tribute has gained or lost an ally entry, OR that the queue mechanism emitted alliance events.
+
+- [ ] **Run** `cargo test -p api tribute_alliances_test -- --test-threads=1`. Expect pass.
+
+- [ ] **Commit** `jj describe -m "test(api): tribute alliances round-trip"`
+
+### Task 6.5: Phase 6 self-check + close `0ug`
+
+- [ ] `cargo test --workspace --no-fail-fast 2>&1 | tail -20`. All passing.
+- [ ] `cargo clippy --workspace --no-deps -- -D warnings`. Clean.
+- [ ] `just fmt`. Clean.
+- [ ] `cargo build --workspace`. Clean.
+- [ ] Update spec status from "Draft v2" to "Implemented" in the spec front-matter.
+- [ ] File the §12 follow-up beads:
+
+```bash
+bd create --title="SeekAlly action" --description="Tribute spends a turn explicitly looking for allies." --type=feature --priority=3
+bd create --title="Cross-area ally pings" --description="Tributes know rough location of distant allies." --type=feature --priority=3
+bd create --title="Duel feature" --description="Explicit 1v1 combat that bypasses ally filters." --type=feature --priority=3
+bd create --title="Trait categories + per-category caps" --description="Limit traits per category (e.g. one combat-stance)." --type=feature --priority=3
+bd create --title="Expanded physical/medical traits" --description="More physical and medical trait options (e.g. Charming, Allergic, Limp)." --type=feature --priority=3
+bd create --title="Alliance SurrealDB entity" --description="First-class alliance table with history (ties to 5wt/wxn)." --type=feature --priority=3
+bd create --title="Player UI: alliance accept/reject" --description="UI for player to accept or reject alliance offers." --type=feature --priority=3
+bd create --title="Frontend ally grouping" --description="Visual grouping of allies in tribute list (clique-derived)." --type=feature --priority=3
+bd create --title="Group-style narrative events" --description="Clique detection on the alliance graph for group-style story beats." --type=feature --priority=3
+```
+
+- [ ] `bd update <p6> --status=closed`; `bd close hangrier_games-0ug --reason="Tribute alliances v1 implemented per spec 2026-04-25."`
+
+- [ ] Open PR per AGENTS.md session-completion protocol.
+
+---
+
+## Self-Review Checklist
+
+Before handing off:
+
+- [ ] Every spec section §1–§12 has at least one task implementing it (or is explicitly out of scope).
+- [ ] No "TBD" / "implement appropriate error handling" / "similar to above" placeholders.
+- [ ] Every code block compiles in isolation (no undefined types or methods).
+- [ ] File paths match real repo paths.
+- [ ] `Trait` enum, `AllianceEvent` enum, `MAX_ALLIES` constant referenced consistently across phases.
+- [ ] Phase ordering matches dependency: traits → alliances → tribute → cycle → persistence → tests.
+- [ ] `szl` (Brain `serde(skip)` bug) is acknowledged but **out of scope** for this plan; spec §8.3 explicitly puts the persisted runtime fields on `Tribute`, sidestepping it.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-25-tribute-alliances-implementation.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per phase. Review between phases. Fast iteration.
+2. **Inline Execution** — Execute phases in this session using `executing-plans`, batch with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-25-tribute-alliances-design.md
+++ b/docs/superpowers/specs/2026-04-25-tribute-alliances-design.md
@@ -2,7 +2,7 @@
 
 **Bead:** `hangrier_games-0ug`
 **Date:** 2026-04-25
-**Status:** Draft v2 (awaiting user review)
+**Status:** Implemented (2026-04-26)
 
 ## 1. Problem & Goal
 

--- a/docs/superpowers/specs/2026-04-25-tribute-alliances-design.md
+++ b/docs/superpowers/specs/2026-04-25-tribute-alliances-design.md
@@ -1,0 +1,737 @@
+# Tribute Alliances — Design Spec
+
+**Bead:** `hangrier_games-0ug`
+**Date:** 2026-04-25
+**Status:** Draft v2 (awaiting user review)
+
+## 1. Problem & Goal
+
+Today every tribute is hostile to every other tribute. The simulation has no
+mechanism for cooperation, which removes a core dynamic of the source
+material: small bands of tributes that travel together, share food, watch
+each other's backs, and eventually turn on one another.
+
+This spec adds an **AI-driven alliance system** to the game engine. Tributes
+form pair-wise alliances based on their traits and district, allies stop
+attacking each other and pool their perception inside a shared area, and
+alliances dissolve through sanity loss, betrayal, or grief.
+
+The first version is fully autonomous: no player UI for accept/reject. Player
+control over alliance decisions is a separate later feature.
+
+## 2. Scope
+
+**In scope (v1):**
+
+- Replace `BrainPersonality` enum with a `traits: Vec<Trait>` system **on
+  `Tribute`** (not `Brain`). A tribute with no traits behaves as the old
+  `Balanced` baseline.
+- A small set of physical/medical traits ship alongside personality traits
+  (e.g. `Asthmatic`, `Nearsighted`, `Tough`).
+- District-biased trait pools at tribute generation.
+- Encounter-driven alliance formation with trait- and district-based rolls.
+- **Pair-wise alliance graph** stored as `allies: Vec<TributeId>` on
+  `Tribute`. No `alliance_id`. No central alliance entity. No `Uuid`s for
+  alliances.
+- Allies excluded from `pick_target` (filter inside `pick_target` against
+  live state, not snapshot); same-area passive shared perception.
+- Three break triggers: low sanity, Treacherous active betrayal, ally-death
+  sanity cascade.
+- Human-readable "deciding factor" surfaced in formation/break event messages.
+- Hard cutover: existing `BrainPersonality` is removed; existing tribute rows
+  are not migrated; dev DB resets.
+
+**Out of scope (filed as follow-ups):**
+
+1. Active `SeekAlly` action — tribute spends a turn explicitly looking for
+   allies.
+2. Cross-area ally location pings — knowing where your allies are across the
+   map.
+3. Duel feature — explicit 1v1 combat that bypasses ally filters.
+4. Trait categories + caps (e.g. "max one combat-stance trait").
+5. Expanded physical/medical trait library.
+6. Full `alliance` SurrealDB entity with graph edges and history (ties to
+   replays `5wt` and spectator `wxn`).
+7. Player UI for accept/reject of alliance offers.
+
+## 3. The Alliance Graph
+
+This v2 spec drops the central-alliance model from v1 in favor of an explicit
+pair-wise graph.
+
+**Why pair-wise:** the user wants overlapping but distinct alliances —
+"Peeta×Katniss does not overlap with Katniss×Rue except on Katniss." A single
+`alliance_id` per tribute cannot represent Katniss being in two distinct
+alliances simultaneously. A graph can.
+
+**Storage:** `allies: Vec<TributeId>` on each `Tribute`. Symmetric: when A
+allies with B, both A's and B's lists gain the other. Betrayal removes only
+the symmetric pair (A from B's list, B from A's list).
+
+**No transitive ally inference.** If Peeta×Katniss and Katniss×Rue are both
+alliances, Peeta and Rue are **not** allies. Each pair is its own bond. This
+matches the "subtle social politics" use case.
+
+**Per-tribute cap:** at most **5 simultaneous direct allies**. Soft target
+2–3. The cap is per-tribute; there is no group cap because there are no
+groups.
+
+**TributeId:** the existing `Tribute::id` (`uuid::Uuid` per `tributes/mod.rs`)
+serves as the stable identifier inside the `allies: Vec<Uuid>` list.
+
+## 4. Architecture
+
+The change is centered in the `game/` crate (pure engine), with thin
+extensions to `shared/` (DTOs), `api/` (response shapes + persistence), and
+SurrealDB schema. The frontend is unaffected for v1 beyond receiving an extra
+field on tribute DTOs.
+
+```
+game/src/tributes/
+    mod.rs         Tribute gains `traits: Vec<Trait>` and
+                   `allies: Vec<Uuid>`. pick_target filters allies
+                   against live self.allies (not snapshot).
+                   The existing `district != self.district` filter is
+                   REMOVED. The existing `loyalty` field and
+                   LOYALTY_BREAK_LEVEL betrayal branch are REMOVED.
+    brains.rs      BrainPersonality removed. Brain.personality field
+                   removed. PersonalityThresholds derived from the
+                   Tribute's trait set (passed in or read via &Tribute).
+                   Brain-related tests updated.
+    traits.rs      NEW. Trait enum, conflict table, district pools,
+                   threshold modifiers, alliance_affinity, label,
+                   random trait set generator, refuser set.
+    alliances.rs   NEW. Alliance formation roll, alliance break checks,
+                   shared-perception helper, deciding-factor calculator.
+                   All operate on `&Tribute` and `Vec<Uuid>` ally lists.
+    combat.rs      No new branch. Betrayal mutates self.allies before
+                   the attack runs; pick_target then naturally allows
+                   the strike because the symmetric ally edge is gone.
+    inventory.rs   No change.
+shared/src/
+    tribute DTO    Adds `allies: Vec<Uuid>` (default empty).
+                   Adds `traits: Vec<Trait>` (default empty).
+api/src/
+    tributes.rs    Reads/writes allies + traits.
+    games.rs       Day/night cycle persists allies + traits changes.
+                   Cascade event-queue drain (see §7) lives here.
+schemas/
+    tribute.surql  Adds `allies: array<uuid>` and `traits: array<string>`
+                   (or array of typed enum if SurrealDB supports it
+                   cleanly; otherwise serialize traits as bare strings
+                   matching Serde's default unit-variant repr).
+migrations/definitions/
+    _initial.json  Bumped; release note explains hard cutover.
+```
+
+The trait system is a self-contained module that the brain and alliance
+modules consume. Combat resolution does not branch — betrayal is "mutate ally
+list, then run normal attack." Nothing else moves.
+
+## 5. Trait System
+
+### 5.1 Trait enum
+
+```rust
+pub enum Trait {
+    // Combat stance (former BrainPersonality territory)
+    Aggressive,
+    Defensive,
+    Cautious,
+    Reckless,
+    // Social
+    Friendly,
+    Loyal,
+    Paranoid,
+    LoneWolf,
+    Treacherous,
+    // Mental
+    Resilient,
+    Fragile,
+    Cunning,
+    Dim,
+    // Physical / medical (v1 starter set; expansion is a follow-up)
+    Asthmatic,
+    Nearsighted,
+    Tough,
+}
+```
+
+`Balanced` from the old enum is dropped — its semantics ("no strong stance")
+are now expressed as **a tribute with zero traits**. Such a tribute uses the
+default thresholds, which are the same numbers `BrainPersonality::Balanced`
+used today.
+
+Each `Trait` exposes:
+
+- `threshold_modifiers(&self) -> ThresholdDelta` — additive contribution to
+  `PersonalityThresholds`. Stacking multiple traits sums the deltas.
+- `alliance_affinity(&self) -> f64` — multiplicative factor on the base
+  ally roll. `f64` for arithmetic consistency with the rest of the codebase
+  (see also `Brain::preferred_action_percentage`). Combat-stance and Mental
+  traits return `1.0` (neutral on alliance affinity); Social traits carry
+  the real signal; Physical traits are neutral on affinity unless a future
+  trait makes social sense (e.g. a hypothetical `Charming`).
+- `label(&self) -> &'static str` — short narrative label used in event
+  messages ("loyal", "paranoid", "asthmatic", etc.).
+
+### 5.2 Trait count and selection
+
+Each tribute gets **2–6 traits** when *the district pool can support that
+count*; otherwise the tribute gets as many as the pool can fit, with a hard
+floor of 0 (i.e. a tribute may legitimately have zero traits if the pool is
+empty after conflict-rejection — see §5.3). The 2–6 range is rolled
+uniformly per tribute. Traits are drawn one at a time from a district-
+weighted pool, rejecting any that conflict with already-selected traits.
+
+If the count roll lands on a number larger than the pool can satisfy
+(after conflict rejection), the generator stops at whatever it has. **No
+infinite retry loops on small pools.** A "minimum 2" floor is *only*
+attempted if the pool can fit two non-conflicting picks; otherwise the floor
+is silently relaxed. In practice the smallest pool has more than enough
+non-conflicting members; this clause exists to prevent generator hangs.
+
+### 5.3 Conflict table
+
+Eight pairwise conflicts. A tribute may not hold both members of a pair.
+
+| A          | B           | Reason                       |
+|------------|-------------|------------------------------|
+| Friendly   | Paranoid    | trust vs distrust            |
+| Loyal      | Treacherous | core opposites               |
+| Loyal      | LoneWolf    | bonds vs avoids bonds        |
+| Aggressive | Cautious    | rush vs retreat              |
+| Aggressive | Defensive   | attack vs hold               |
+| Reckless   | Cautious    | YOLO vs careful              |
+| Resilient  | Fragile     | direct opposites             |
+| Cunning    | Dim         | direct opposites             |
+
+Notable allowed combos:
+
+- **Friendly × Treacherous** — the snake-in-the-grass archetype. Friendly
+  pulls them into alliances; Treacherous breaks those alliances explosively.
+- **Paranoid × LoneWolf** — coherent loner who distrusts.
+
+Conflicts live in a single `const CONFLICTS: &[(Trait, Trait)]` table for
+easy editing. The `traits.rs` module exposes `conflicts_with(a, b) -> bool`
+that checks both orderings.
+
+A separate `const REFUSERS: &[Trait] = &[Paranoid, LoneWolf]` is consumed by
+the alliance-formation gate (§6.2), so the gate is an O(1) membership check
+rather than walking the conflict table.
+
+### 5.4 District pools
+
+Each district has a weighted pool reflecting its source-material flavor.
+Weights are starting suggestions and explicitly subject to balance later.
+Pools are exclusive (a trait not listed in a district's pool cannot appear in
+that district's tributes); this is a deliberate flavor statement.
+
+| District | Pool (trait, weight)                                                    |
+|----------|--------------------------------------------------------------------------|
+| 1        | Loyal 4, Aggressive 4, Paranoid 3, Tough 2                              |
+| 2        | Aggressive 4, Defensive 4, Loyal 3, Tough 2                             |
+| 3        | Cunning 4, Cautious 3, Dim 2, Nearsighted 2, Asthmatic 1                |
+| 4        | Resilient 4, Aggressive 3, Loyal 3, Tough 2                             |
+| 5        | Cunning 4, Cautious 3, Treacherous 2                                     |
+| 6        | Fragile 3, Friendly 3, Asthmatic 2, Nearsighted 2                       |
+| 7        | Resilient 4, Defensive 3, Tough 3                                        |
+| 8        | Fragile 2, Friendly 4, Loyal 3, Asthmatic 2                             |
+| 9        | Cautious 3, Friendly 3, Asthmatic 2                                      |
+| 10       | Resilient 4, Defensive 3, Tough 3                                        |
+| 11       | Loyal 3, Friendly 4, Resilient 3, Tough 2                                |
+| 12       | Resilient 3, LoneWolf 3, Cunning 3, Asthmatic 2                          |
+
+Pools live in `traits.rs` as 12 separate `const DISTRICT_N_POOL: &[(Trait,
+u8)]` plus a `pub fn pool_for(district: u8) -> &'static [(Trait, u8)]`
+lookup, mirroring the pattern `districts::assign_terrain_affinity` already
+uses.
+
+### 5.5 Threshold computation
+
+`PersonalityThresholds` keeps its current shape (9 fields, ±20% per-tribute
+variance). Base values come from the old `Balanced` numbers
+(health 20/40, sanity 10/20/35, movement 10, intelligence 35/80,
+psychotic-break 8). Each trait contributes additive deltas; deltas are
+summed across the tribute's trait set. The final thresholds clamp to
+[0, 100] for the four core attribute thresholds and [0, 20] for the
+psychotic-break threshold.
+
+A tribute with **no traits** gets the base thresholds with the standard
+±20% per-tribute variance, reproducing today's `Balanced` behavior. This
+makes the existing 60-test suite tractable: tests that need predictable
+thresholds construct tributes with zero traits.
+
+The exact delta values per trait are framed but not tuned in this spec —
+they will be balanced in implementation against the existing baseline. The
+locked schema-level constraint is: traits modify the same nine threshold
+fields the old `BrainPersonality` did, additively, with `f64` arithmetic
+internally and final clamp before storage as the existing integer types.
+
+## 6. Alliance Formation
+
+### 6.1 Trigger
+
+Alliances form **at encounter time**: when a tribute's `pick_target` step
+sees another living, non-allied tribute in the same area, the engine first
+runs an **ally roll** between them. If the roll succeeds, both add the other
+to their `allies` list, and the would-be attacker takes a non-attack action
+this turn instead. If it fails, combat proceeds as normal.
+
+This adds no new turn phase. The roll lives inside the existing target-
+selection path in `game/src/tributes/mod.rs::pick_target`, before the
+damage-roll step.
+
+`base_chance` is **per-encounter**, not per-turn. Within a single turn, A's
+turn might roll an ally check against B; later in the same turn, B's turn
+will not roll again because they're now allies (B's `allies` already
+contains A — see §6.4 on snapshot freshness).
+
+### 6.2 Roll formula
+
+```
+trait_factor       = geometric_mean(self.traits.alliance_affinity())
+                       defaulting to 1.0 if traits is empty
+target_factor      = geometric_mean(target.traits.alliance_affinity())
+                       defaulting to 1.0 if target.traits is empty
+district_bonus     = if same_district { 1.5 } else { 1.0 }
+self_cap_pen       = (5 - self.allies.len() as f64) / 5.0
+target_cap_pen     = (5 - target.allies.len() as f64) / 5.0
+base_chance        = 0.20
+
+roll_chance        = clamp(base_chance * trait_factor * target_factor
+                               * district_bonus * self_cap_pen
+                               * target_cap_pen,
+                               0.0, 0.95)
+```
+
+**Geometric mean instead of raw product.** Raw products of 2 vs 6 trait
+counts produce wildly different magnitudes purely from count (`0.5²=0.25`
+vs `0.5⁶=0.0156`). Geometric mean (`product^(1/n)`) makes counts comparable.
+
+**Helper sketch.** Lives in `traits.rs`, pure fn, no allocations beyond the
+caller's slice:
+
+```rust
+/// Geometric mean of trait affinity values. Returns 1.0 for empty input
+/// so trait-less tributes neither boost nor penalize the roll.
+pub fn geometric_mean_affinity(traits: &[Trait]) -> f64 {
+    if traits.is_empty() {
+        return 1.0;
+    }
+    let n = traits.len() as f64;
+    let product: f64 = traits.iter().map(|t| t.alliance_affinity()).product();
+    product.powf(1.0 / n)
+}
+```
+
+`f64::product` over the v1 affinity range `[0.5, 1.5]` cannot overflow or
+underflow at the trait counts we generate (max 6). No `NaN` guard needed
+because all `alliance_affinity()` values are positive finite. Unit test
+covers empty, single-trait identity, and known multi-trait cases against
+hand-computed values within `f64::EPSILON * 10`.
+
+**Affinity range.** All trait `alliance_affinity()` values live in
+`[0.5, 1.5]` for the v1 set:
+
+- Friendly: `1.5`
+- Loyal: `1.4`
+- Treacherous: `1.2`
+- Combat / Mental / Physical traits not listed below: `1.0`
+- LoneWolf: `0.6`
+- Paranoid: `0.5`
+
+With this range, a 6-trait geometric mean stays in `[0.5, 1.5]`, and
+`trait_factor * target_factor` stays in `[0.25, 2.25]`. Combined with the
+0.20 base, 1.5 district bonus, and cap penalties, `roll_chance` lands in a
+sensible `[0, 0.95]` band before clamp.
+
+**Both cap penalties multiplied in.** A tribute already at `allies.len() = 5`
+contributes `0.0`, refusing all new alliances regardless of the other
+tribute's state. A tribute at `allies.len() = 0` contributes `1.0`.
+
+**Refuser gate.** Before the roll runs, both tributes must pass:
+
+```rust
+fn passes_gate(self_t: &Tribute, target: &Tribute) -> bool {
+    let has_positive = |t: &Tribute| {
+        t.traits.iter().any(|x| x.alliance_affinity() >= 1.0)
+    };
+    let has_refuser = |t: &Tribute| {
+        t.traits.iter().any(|x| REFUSERS.contains(x))
+    };
+    (has_positive(self_t) && has_positive(target))
+        || (!has_refuser(self_t) && !has_refuser(target))
+}
+```
+
+A tribute with `[Friendly, Paranoid]` (positive + refuser) paired with
+`[Loyal]` (positive, no refuser) **passes** because both have positives —
+which is the intended behavior for snake-in-the-grass and other mixed
+archetypes. Paranoid×Paranoid fails the gate (no positives, both refusers).
+
+### 6.3 Pair-wise assignment
+
+Roll succeeded between A and B:
+
+1. `A.allies.push(B.id)` if not already present.
+2. `B.allies.push(A.id)` if not already present.
+3. Cap check is **already enforced by the roll formula** via `cap_pen`. If A
+   was at 4 and B at 4, the formula already favored a low chance; if A or B
+   was at 5, `cap_pen = 0` and the roll could not succeed. The push step
+   does not need to re-check the cap.
+
+There is no merge logic. There are no group identities to merge. Two
+overlapping pairs (Peeta×Katniss and Katniss×Rue) coexist by construction.
+
+### 6.4 Snapshot freshness
+
+The existing turn loop in `games.rs` builds `tributes_by_area` and
+`potential_targets` from cloned snapshots before iterating tributes. This
+matters for alliance state:
+
+- **Ally filtering happens inside `pick_target`** against the **live
+  `&self`** (which has the current `allies` list) and against the **target
+  clone** (whose `allies` list was frozen at snapshot time). The asymmetry
+  is acceptable because alliance edges are symmetric: once A allies with B,
+  A's live `allies` contains B, and `pick_target` will skip B without
+  needing B's clone to know about A.
+- **Mid-turn alliance changes are visible to the acting tribute** (their own
+  list is live) but **not retroactively visible to earlier-iterated
+  tributes' clones**. In practice this only matters for shared perception:
+  a tribute earlier in the turn does not benefit from a perception pool
+  with an ally formed later in the same turn. Acceptable for v1.
+
+### 6.5 Deciding factor in events
+
+Every formation event includes a one-line deciding factor based on the
+dominant contributor. Examples:
+
+- "Peeta allies with Katniss. Deciding factor: Peeta is friendly."
+- "Cato allies with Glimmer. Deciding factor: same district (D1)."
+- "Thresh allies with Rue. Deciding factor: Thresh is loyal."
+
+The dominant contributor is computed by comparing `district_bonus` against
+the maximum trait affinity on either side. The factor with the largest
+contribution above 1.0 wins. Ties resolve by trait label sort order
+(deterministic) for reproducibility. If no factor exceeds 1.0 (a roll won
+purely by base chance and luck), the event omits the deciding factor:
+"Peeta allies with Katniss."
+
+## 7. Alliance Lifecycle
+
+### 7.1 Shared perception (same-area only)
+
+When the brain assembles its observations, if there are direct allies present
+in the **same area**, their perception unions with this tribute's:
+
+- Visible nearby tributes (`EnvironmentContext::nearby_tributes`)
+- Visible items in the area
+- A hidden ally in the same area still shares perception (you know they're
+  there even if outsiders don't).
+
+Cross-area allies contribute nothing in v1. Allies in the same area
+effectively share a sensory fact pool for that turn's decision.
+
+Because the perception pool is built from the snapshot
+`tributes_by_area`, perception sharing is consistent with snapshot freshness
+described in §6.4.
+
+### 7.2 No friendly fire
+
+`pick_target` filters out any tribute whose `id ∈ self.allies`. This is the
+rule. There is no second guard inside combat resolution; the existing
+"`district != self.district`" filter is **removed entirely** along with the
+existing `loyalty` field and `LOYALTY_BREAK_LEVEL` betrayal path. Same-
+district tributes are no longer auto-friendly; they have to ally like
+anyone else (with a district bonus stacking the odds).
+
+### 7.3 Break triggers
+
+Three triggers, checked in this order each turn:
+
+**(a) Sanity threshold.** When a tribute's sanity drops below their
+`PersonalityThresholds::low_sanity_limit`, they roll once to leave **each**
+of their direct alliances. The roll is `rng.random_bool(deficit_ratio)`
+where `deficit_ratio = (low_sanity_limit - current_sanity) / low_sanity_limit`
+clamped to `[0.0, 1.0]`. On success for a given ally, the symmetric pair is
+removed from both sides. Event: "X leaves their alliance with Y — losing
+their nerve."
+
+**(b) Treacherous active betrayal.** A Treacherous tribute checks for a
+betrayal opportunity every 5 turns from their **own** turn counter (per-
+tribute timer stored on `Tribute` as `turns_since_last_betrayal: u8`,
+initialized 0, incremented each turn, reset on betrayal or when the timer
+elapses without an opportunity). When the timer elapses, if there is an ally
+in the same area, they:
+
+1. Remove the symmetric pair: `self.allies.retain(|x| *x != victim.id)`,
+   and append `(self.id, victim.id)` to a per-cycle event queue so the
+   victim's `allies` is updated when the queue drains (§7.5).
+2. Resolve a normal attack against the victim. The attack runs through the
+   standard `pick_target` → `attacks()` path; because the symmetric pair is
+   already gone from `self.allies`, the filter allows it.
+3. Reset the betrayal timer.
+
+If no ally is in the same area when the timer elapses, the timer **resets**
+to 0 (one missed opportunity per cycle is fine; do not let timers stack).
+
+Event: "X betrays Y — true to their treacherous nature."
+
+**Heaviness rule.** Per the user: *"It's not the killing that's heavy, it's
+the betrayal."* The cascade in (c) below is triggered by the **betrayal
+event itself**, not by a death. The cascade fires on the betrayed tribute's
+**next turn** if they are still alive, regardless of whether the betrayer
+dies in the counter-attack. If the betrayed tribute died during the
+counter-attack, no cascade roll (they are dead).
+
+**(c) Trust-shock cascade (renamed from "ally-death sanity cascade").**
+Two sub-triggers:
+
+1. **Betrayal trust-shock** (per the heaviness rule above). On the betrayed
+   tribute's next turn, they roll a sanity check against
+   `low_sanity_limit` (consistent with §7.3a, not `mid_sanity_limit`).
+   Roll: `rng.random_bool(0.5 + 0.5 * deficit_ratio)` — high baseline
+   because betrayal is severe. On success: that survivor removes the
+   symmetric pair with **every other current direct ally** as well (the
+   trust-shock ripples outward), each with event "Y is shaken by X's
+   betrayal and breaks from Z." **The betrayer never rolls trust-shock
+   for their own betrayal** — they chose to do it, so no shock to their
+   own trust. (If the betrayer is also a betrayal *victim* of someone
+   else, that separate event would still apply to them.)
+2. **Ally-death cascade.** When any tribute dies, every direct ally on the
+   per-cycle event queue rolls a sanity check against `low_sanity_limit`
+   (consistent with §7.3a). Roll: `rng.random_bool(deficit_ratio)`. On
+   success: that ally removes the symmetric pair with the deceased and
+   emits "Y is shaken by X's death and breaks from the alliance." Because
+   alliances are pair-wise, no group dissolution is needed — the bond
+   simply ends.
+
+Both sub-triggers drain through the same per-cycle event queue, processed
+between tribute turns so they avoid the borrow-checker problem of cross-
+tribute mutation during `self.tributes.iter_mut()`.
+
+### 7.4 Combat carve-out for betrayal — none required
+
+Betrayal mutates `self.allies` *before* `pick_target` runs, so the standard
+filter naturally allows the strike. `combat.rs` does not change. The flow
+lives in `alliances.rs` (the betrayal trigger and the ally-list mutation)
+and in `mod.rs::pick_target` (the live filter consults `self.allies`).
+
+### 7.5 Per-cycle event queue (mechanism)
+
+A `Vec<AllianceEvent>` lives on the `Game` struct (or is threaded through
+the cycle as a parameter — implementation choice; both work). Events:
+
+```rust
+enum AllianceEvent {
+    BetrayalRecorded { betrayer: TributeId, victim: TributeId },
+    DeathRecorded { deceased: TributeId, killer: Option<TributeId> },
+}
+```
+
+The queue is appended to inside individual tribute turns. After each
+tribute's turn completes (and the mutable borrow is released), the cycle
+drains the queue in order:
+
+- For each `BetrayalRecorded`: ensure the symmetric pair is removed on the
+  victim's side (the betrayer's side was already updated in §7.3b step 1);
+  schedule a trust-shock roll on the victim's next turn. **The drain never
+  schedules a trust-shock for the betrayer themselves** — `BetrayalRecorded`
+  identifies betrayer and victim as distinct fields, and only the `victim`
+  is enqueued for trust-shock. The betrayer's other allies are unaffected
+  by this event (their reactions, if any, come through `DeathRecorded`
+  cascades when bodies fall, not from the betrayal act itself).
+- For each `DeathRecorded`: roll the cascade for each direct ally of the
+  deceased, removing pairs and emitting events. The deceased's `killer`
+  field is informational only (used for event text); the cascade does
+  not skip the killer if they happened to also be an ally of the deceased
+  — that scenario is exactly the betrayal case, where the symmetric pair
+  was already torn down in §7.3b before the kill landed, so the killer
+  is no longer in the deceased's ally list at drain time.
+
+This drains **between** tribute turns, not at end-of-cycle, so cascades
+appear immediately in the message stream. Storywise indistinguishable from
+"instant," and avoids any cross-tribute mutation under `iter_mut`.
+
+## 8. Persistence
+
+### 8.1 Schema
+
+`schemas/tribute.surql` gains:
+
+```surql
+DEFINE FIELD allies ON tribute TYPE array<uuid> DEFAULT [];
+DEFINE FIELD traits ON tribute TYPE array<string> DEFAULT [];
+DEFINE FIELD turns_since_last_betrayal ON tribute TYPE int DEFAULT 0;
+```
+
+Traits serialize as bare strings via Serde's default unit-variant repr
+(matching how `BrainPersonality` serialized today). No `alliance` table.
+No graph edges. (The full first-class `alliance` entity is filed as a
+follow-up tied to `5wt`/`wxn`.)
+
+### 8.2 Migration
+
+**Hard cutover, no migration script.** `migrations/definitions/_initial.json`
+is bumped; the bump's release note will read approximately:
+
+> 0ug: traits replace BrainPersonality; allies + traits +
+> turns_since_last_betrayal added on tribute. Existing tribute rows are not
+> migrated. Reset your dev DB.
+
+Because there are no production users and the dev DB resets cheaply, this
+is acceptable. If a future change ever needs preserved tribute data, write
+a proper migration then.
+
+### 8.3 Rust Serde details
+
+On `Tribute`:
+
+```rust
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub allies: Vec<Uuid>,
+
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub traits: Vec<Trait>,
+
+#[serde(default)]
+pub turns_since_last_betrayal: u8,
+```
+
+`#[serde(default)]` on all alliance/trait fields tolerates older serialized
+tribute snapshots (in-memory clones, test fixtures, partial DTO updates)
+that lack these fields — matches the existing house style on `Tribute`
+(`items`, `events`, `editable`, `terrain_affinity` already use this
+pattern).
+
+`Brain` no longer has a `personality` field. `Brain::default()` constructs
+a brain whose threshold lookup will go through the tribute's trait set when
+called via `Tribute::compute_thresholds(&self) -> PersonalityThresholds`
+(or equivalent). The `#[serde(skip)]` on `Brain` inside `Tribute` stays —
+brain has no persisted state in v1.
+
+### 8.4 API exposure
+
+`shared/`'s tribute DTO gains `allies: Vec<Uuid>` and `traits: Vec<Trait>`
+(both default empty). API responses include them. The frontend is free to
+ignore them for v1; future work can color-group allies in the tribute list
+and surface trait labels in tribute detail views.
+
+The Dioxus query cache key may depend on serialized DTO shape; bumping the
+cache version (or a one-time hard reload after deploy) is the simplest path.
+Both new fields are additive and `Option`/`Vec`-defaulted, so the schema is
+backward-compatible at the type level.
+
+## 9. Events & Observability
+
+New event types (plain `GameOutput` strings for v1; structured events
+arrive when `mqi` lands):
+
+- Alliance formed (with deciding factor, both names).
+- Sanity break leave (per ally, with name).
+- Treacherous betrayal (both names + "treacherous" label).
+- Betrayal trust-shock leave (per ally on victim's side).
+- Ally-death cascade leave (per ally with the deceased's name).
+
+Every event includes the relevant tribute names and, where applicable, the
+trait label that drove the decision. This satisfies the "human-readable
+deciding factor" requirement.
+
+## 10. Testing
+
+`game/` is the right place for the bulk of tests (rstest, parameterized).
+
+**Pure functions in `traits.rs` (single-tribute or trait-only):**
+
+- Trait generation: target count respected within pool capacity; no
+  conflicts ever appear in the result; district pool weighting roughly
+  observed across many samples. **Statistical framing.** rstest does not
+  pull in a stats crate, and we do not want to. Replace formal chi-square
+  with a **bucket-tolerance assertion**: draw 10 000 samples with a fixed
+  RNG seed, count occurrences per trait, and assert each observed count
+  falls within `±15%` of its expected count `(weight / total_weight) *
+  10_000`. Tolerance band chosen to absorb single-seed variance while
+  catching weight-table regressions (e.g. swapping two pool entries).
+  Helper lives in test module: `fn assert_within_tolerance(observed: u32,
+  expected: u32, pct: f64)`. Same approach used elsewhere in the codebase
+  for randomized assertions; documents the tradeoff in test comments.
+- Threshold math: stacking deltas sums correctly; clamp at 0/100 (and 0/20
+  for psychotic-break); zero-trait tribute matches old `Balanced` baseline
+  exactly after applying ±20% variance with a fixed seed.
+- Refuser membership: O(1) lookup correctness for all 13 + physical traits.
+- Conflict table symmetry: `conflicts_with(a, b) == conflicts_with(b, a)`
+  for all pairs.
+
+**Multi-tribute in `alliances.rs` (game-crate, `Vec<Tribute>` harness):**
+
+- Alliance roll gate: Paranoid×Paranoid never allies; Friendly×Friendly
+  with same district allies frequently (rate ≥ 60% over 1000 trials with
+  fixed seed). Friendly×Paranoid (mixed) can ally with a Loyal partner.
+- Cap penalties: tribute at `allies.len() = 5` always refuses new
+  alliances; tribute at 4 allies has ≤ 0.20 base chance after cap penalty.
+- Sanity break leave: sanity drop below `low_sanity_limit` triggers leave
+  with probability proportional to deficit ratio; symmetric pair removed
+  from both sides.
+- Treacherous betrayal: timer increments per turn; resets on betrayal or
+  on missed opportunity (no ally in area); symmetric pair removed before
+  attack runs; victim added to attacker's valid-target set; event emitted
+  with treacherous label.
+- Trust-shock cascade: betrayed survivor rolls on next turn with high
+  baseline; on success, removes symmetric pair with all other current
+  direct allies; events emitted per ally.
+- Ally-death cascade: queue-drained between turns; rolls per direct ally;
+  symmetric pair removed; events emitted.
+- Shared perception: same-area allies pool nearby_tributes and items;
+  cross-area allies contribute nothing; hidden allies still pool.
+
+**Integration in `api/`:**
+
+- Persistence round-trip: `allies`, `traits`, `turns_since_last_betrayal`
+  survive day/night cycle save and reload.
+- DTO shape: API response includes new fields with correct types.
+
+**Existing tests:** the ~60 game-crate tests need a `Tribute::test_default`
+(or similar) helper that constructs a tribute with zero traits, reproducing
+`Balanced` behavior. Tests that asserted specific personality types via
+`BrainPersonality` need to migrate to checking trait sets directly.
+
+No frontend tests for v1.
+
+## 11. Risks & Open Questions
+
+- **Balance is unfit by default.** Trait deltas, affinity multipliers,
+  district weights, and the betrayal cadence are framed but not tuned.
+  The first full game run will surface obvious problems (e.g. everyone
+  allies immediately; Treacherous never triggers). Plan to iterate after a
+  playtest pass.
+- **Alliance discovery is invisible to the player UI.** Until follow-up
+  work surfaces alliance state visually, players will only see the
+  formation events scroll past in messages. Acceptable for v1.
+- **Pair-wise graph means no "group identity" stories.** Events read as
+  "X allies with Y" rather than "X joins the Career Pack." That's the
+  intended trade-off for overlapping subtle politics. If group-style
+  reporting becomes important, it can be derived from the graph (clique
+  detection) without changing storage.
+- **Per-tribute cap of 5 is a guess.** "Soft target 2–3" came from
+  gameplay intuition, not data. Cap may need lowering to 4 or raising to
+  6 after playtests.
+- **Snapshot vs live state asymmetry (§6.4).** Acceptable for v1, but
+  worth re-examining if any user-visible edge case surfaces.
+- **Event resolution timing.** The user noted: *"I may have some questions
+  on event resolution timing but that can come later."* The per-cycle
+  queue drain in §7.5 is the v1 answer; revisit if it produces awkward
+  ordering.
+
+## 12. Follow-up Beads (file after spec approved)
+
+1. Active `SeekAlly` action.
+2. Cross-area ally pings.
+3. Duel feature.
+4. Trait categories + per-category caps.
+5. Expanded physical/medical trait library.
+6. Full `alliance` SurrealDB entity with history (ties to `5wt`, `wxn`).
+7. Player UI for accept/reject of alliance offers.
+8. Frontend visual grouping of allies in tribute list (clique-derived
+   "factions" view).
+9. Group-style narrative events (clique detection on the graph).

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -16,7 +16,7 @@ strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
 thiserror = "2.0.12"
 tracing = "0.1.41"
-uuid = { version = "1.13.2", features = ["v4", "js"] }
+uuid = { version = "1.13.2", features = ["v4", "js", "serde"] }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/game/src/config.rs
+++ b/game/src/config.rs
@@ -45,8 +45,6 @@ pub struct GameConfig {
     // Tribute lifecycle constants (from tributes/mod.rs)
     /// Sanity level at which tributes may attempt suicide
     pub sanity_break_level: u32,
-    /// Loyalty percentage below which tributes may betray allies
-    pub loyalty_break_level: f64,
 
     // Attribute maximums (from tributes/mod.rs)
     pub max_health: u32,
@@ -55,7 +53,6 @@ pub struct GameConfig {
     pub max_strength: u32,
     pub max_defense: u32,
     pub max_bravery: u32,
-    pub max_loyalty: u32,
     pub max_intelligence: u32,
     pub max_persuasion: u32,
     pub max_luck: u32,
@@ -88,7 +85,6 @@ impl Default for GameConfig {
 
             // Tribute lifecycle
             sanity_break_level: 9,
-            loyalty_break_level: 0.25,
 
             // Attribute maximums
             max_health: 100,
@@ -97,7 +93,6 @@ impl Default for GameConfig {
             max_strength: 50,
             max_defense: 50,
             max_bravery: 100,
-            max_loyalty: 100,
             max_intelligence: 100,
             max_persuasion: 100,
             max_luck: 100,

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -821,6 +821,20 @@ impl Game {
         // Process tributes
         for tribute in self.tributes.iter_mut() {
             if !tribute.is_alive() {
+                // Newly-dead tributes (status=RecentlyDead going into this
+                // cycle) trigger a DeathRecorded event so allies process the
+                // ally-death cascade. Killer attribution is deferred — combat
+                // sites that record kills should enqueue with `killer = Some`
+                // directly. Promote to Dead after enqueueing so the same
+                // tribute does not re-emit on subsequent cycles.
+                if tribute.status == TributeStatus::RecentlyDead {
+                    drained_alliance_events.push(
+                        crate::tributes::alliances::AllianceEvent::DeathRecorded {
+                            deceased: tribute.id,
+                            killer: None,
+                        },
+                    );
+                }
                 tribute.status = TributeStatus::Dead;
                 continue;
             }
@@ -1726,6 +1740,67 @@ mod tests {
         assert_eq!(
             l.turns_since_last_betrayal, 0,
             "missed opportunity also resets the timer per spec §7.4(b)"
+        );
+    }
+
+    #[test]
+    fn run_tribute_cycle_enqueues_death_recorded_for_recently_dead_ally() {
+        // A tribute who died last cycle (status=RecentlyDead) must trigger
+        // a DeathRecorded event so allies process the ally-death cascade.
+        // After the cycle, the deceased's allies should have:
+        //   - the deceased removed from their `allies` lists (via cascade);
+        //   - process_alliance_events drained the queue.
+        use crate::tributes::traits::Trait;
+
+        let mut deceased = create_tribute("Rue", true);
+        let mut survivor = create_tribute("Katniss", true);
+        // Make survivor highly likely to break on cascade: low sanity, high
+        // threshold makes deficit_ratio close to 1.0 → near-certain break.
+        survivor.attributes.sanity = 0;
+        survivor.brain.thresholds.extreme_low_sanity = 50;
+        survivor.traits = vec![Trait::Tough];
+        deceased.traits = vec![Trait::Tough];
+        // Pre-existing alliance (survivor lists deceased as ally).
+        survivor.allies.push(deceased.id);
+        deceased.allies.push(survivor.id);
+        // Mark deceased as RecentlyDead going into the cycle.
+        deceased.attributes.health = 0;
+        deceased.status = TributeStatus::RecentlyDead;
+        // Same area so deceased is "in the cycle" but the early skip applies.
+        deceased.area = Area::Cornucopia;
+        survivor.area = Area::Cornucopia;
+        deceased.district = 11;
+        survivor.district = 12;
+
+        let did = deceased.id;
+        let sid = survivor.id;
+
+        let mut game = create_test_game_with_tributes(vec![deceased.clone(), survivor.clone()]);
+        game.areas
+            .push(AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia));
+        // Living tributes snapshot: deceased is RecentlyDead so excluded.
+        let living = game.living_tributes();
+        let closed_areas: Vec<Area> = vec![];
+
+        let mut rng = SmallRng::seed_from_u64(547);
+        let _ = game.run_tribute_cycle(true, &mut rng, closed_areas, living, 1);
+
+        // Cycle drained the queue (no leftovers).
+        assert!(
+            game.alliance_events.is_empty(),
+            "queue must drain after cycle"
+        );
+        // Deceased promoted to Dead.
+        let d = game.tributes.iter().find(|t| t.id == did).unwrap();
+        assert_eq!(d.status, TributeStatus::Dead);
+        // Survivor's ally list cleaned of deceased (cascade fired with high
+        // probability given sanity=0 vs threshold=50; even on the rare miss
+        // the alliance edge is still broken because process_alliance_events
+        // does symmetric removal of dead from all surviving allies' lists).
+        let s = game.tributes.iter().find(|t| t.id == sid).unwrap();
+        assert!(
+            !s.allies.contains(&did),
+            "survivor must not retain a dead ally edge"
         );
     }
 }

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -889,6 +889,80 @@ impl Game {
     fn get_area_details_mut(&mut self, area: Area) -> Option<&mut AreaDetails> {
         self.areas.iter_mut().find(|ad| ad.area == Some(area))
     }
+
+    /// Drain the alliance event queue accumulated during the current cycle.
+    /// Called between tribute turns inside `run_tribute_cycle` so cascades
+    /// resolve before the next tribute acts. Per spec §7.5:
+    /// - `BetrayalRecorded`: remove the symmetric pair on the victim's side
+    ///   (betrayer's side was already cleaned at trigger time) and flag the
+    ///   victim for a trust-shock roll on their next turn. The betrayer is
+    ///   never flagged.
+    /// - `DeathRecorded`: roll a sanity-break per direct ally of the deceased
+    ///   (consistent with §7.3a thresholds) and emit a break message on
+    ///   success. After the cascade, unconditionally scrub the deceased's
+    ///   id from every surviving tribute's `allies` list.
+    pub fn process_alliance_events(&mut self, rng: &mut impl Rng) {
+        use crate::tributes::alliances::{AllianceEvent, sanity_break_roll};
+
+        // Collect drained events into a local Vec so we can release the
+        // borrow on `self.alliance_events` before mutating `self.tributes`.
+        let drained: Vec<AllianceEvent> = self.alliance_events.drain(..).collect();
+
+        for ev in drained {
+            match ev {
+                AllianceEvent::BetrayalRecorded { betrayer, victim } => {
+                    if let Some(v) = self.tributes.iter_mut().find(|t| t.id == victim) {
+                        v.allies.retain(|x| *x != betrayer);
+                        v.pending_trust_shock = true;
+                    }
+                    // Spec §7.5: betrayer is never enqueued for trust-shock.
+                }
+                AllianceEvent::DeathRecorded {
+                    deceased,
+                    killer: _,
+                } => {
+                    // Snapshot the deceased's allies before mutation so we
+                    // can roll the cascade per direct ally.
+                    let allies_of_deceased: Vec<Uuid> = self
+                        .tributes
+                        .iter()
+                        .find(|t| t.id == deceased)
+                        .map(|d| d.allies.clone())
+                        .unwrap_or_default();
+
+                    for ally_id in allies_of_deceased {
+                        if let Some(ally) = self.tributes.iter_mut().find(|t| t.id == ally_id) {
+                            // `extreme_low_sanity` is the §7.3a low-limit
+                            // mapping (see PersonalityThresholds doc).
+                            let limit = ally.brain.thresholds.extreme_low_sanity;
+                            let sanity = ally.attributes.sanity;
+                            if sanity_break_roll(sanity, limit, rng) {
+                                ally.allies.retain(|x| *x != deceased);
+                                let line = format!(
+                                    "{} is shaken by their ally's death and breaks the bond.",
+                                    ally.name
+                                );
+                                let aid = ally.identifier.clone();
+                                let aname = ally.name.clone();
+                                self.log(
+                                    crate::messages::MessageSource::Tribute(aid),
+                                    aname,
+                                    line,
+                                );
+                            }
+                        }
+                    }
+
+                    // Unconditional cleanup: ensure the deceased's id is
+                    // removed from every surviving tribute's allies list,
+                    // even if their cascade roll failed.
+                    for t in self.tributes.iter_mut() {
+                        t.allies.retain(|x| *x != deceased);
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1232,5 +1306,91 @@ mod tests {
 
         assert_eq!(game.open_areas().len(), 1);
         assert_eq!(game.closed_areas().len(), 1);
+    }
+
+    // ---- Phase 4: alliance event drain -----------------------------------
+
+    #[test]
+    fn process_alliance_events_betrayal_removes_pair_on_victim_side() {
+        // Victim still lists betrayer in allies (betrayer's own list was
+        // already cleaned by the betrayal trigger that enqueued the event).
+        let mut betrayer = Tribute::new("Betrayer".to_string(), Some(1), None);
+        let mut victim = Tribute::new("Victim".to_string(), Some(2), None);
+        victim.allies.push(betrayer.id);
+        // Sanity force victim to a state where the drain path runs cleanly.
+        victim.attributes.health = 100;
+        betrayer.attributes.health = 100;
+        let bid = betrayer.id;
+        let vid = victim.id;
+
+        let mut game = create_test_game_with_tributes(vec![betrayer, victim]);
+        game.alliance_events
+            .push(crate::tributes::alliances::AllianceEvent::BetrayalRecorded {
+                betrayer: bid,
+                victim: vid,
+            });
+
+        let mut rng = SmallRng::seed_from_u64(53);
+        game.process_alliance_events(&mut rng);
+
+        let v = game.tributes.iter().find(|t| t.id == vid).unwrap();
+        assert!(!v.allies.contains(&bid));
+        assert!(v.pending_trust_shock);
+        assert!(game.alliance_events.is_empty());
+    }
+
+    #[test]
+    fn process_alliance_events_betrayer_not_marked_for_trust_shock() {
+        let betrayer = Tribute::new("Betrayer".to_string(), Some(1), None);
+        let victim = Tribute::new("Victim".to_string(), Some(2), None);
+        let bid = betrayer.id;
+        let vid = victim.id;
+
+        let mut game = create_test_game_with_tributes(vec![betrayer, victim]);
+        game.alliance_events
+            .push(crate::tributes::alliances::AllianceEvent::BetrayalRecorded {
+                betrayer: bid,
+                victim: vid,
+            });
+
+        let mut rng = SmallRng::seed_from_u64(53);
+        game.process_alliance_events(&mut rng);
+
+        let b = game.tributes.iter().find(|t| t.id == bid).unwrap();
+        assert!(!b.pending_trust_shock, "betrayer must not roll trust-shock");
+    }
+
+    #[test]
+    fn process_alliance_events_death_removes_deceased_from_all_ally_lists() {
+        // Three tributes; the deceased was in two allies' lists.
+        let deceased = Tribute::new("Deceased".to_string(), Some(1), None);
+        let mut a = Tribute::new("A".to_string(), Some(2), None);
+        let mut b = Tribute::new("B".to_string(), Some(3), None);
+        a.allies.push(deceased.id);
+        b.allies.push(deceased.id);
+        // Force ally sanity well above any threshold so the cascade roll
+        // never fires; we want to verify the unconditional cleanup path.
+        a.attributes.sanity = 100;
+        b.attributes.sanity = 100;
+
+        let did = deceased.id;
+        let mut game = create_test_game_with_tributes(vec![deceased, a, b]);
+        game.alliance_events
+            .push(crate::tributes::alliances::AllianceEvent::DeathRecorded {
+                deceased: did,
+                killer: None,
+            });
+
+        let mut rng = SmallRng::seed_from_u64(89);
+        game.process_alliance_events(&mut rng);
+
+        for t in game.tributes.iter().filter(|t| t.id != did) {
+            assert!(
+                !t.allies.contains(&did),
+                "tribute {} still lists deceased",
+                t.name
+            );
+        }
+        assert!(game.alliance_events.is_empty());
     }
 }

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -1662,8 +1662,7 @@ mod tests {
         let bid = betrayer.id;
         let vid = victim.id;
 
-        let mut game =
-            create_test_game_with_tributes(vec![betrayer.clone(), victim.clone()]);
+        let mut game = create_test_game_with_tributes(vec![betrayer.clone(), victim.clone()]);
         let area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
         game.areas.push(area);
         let closed_areas = game
@@ -1836,8 +1835,7 @@ mod tests {
         let bid = b.id;
         let cid = c.id;
 
-        let mut game =
-            create_test_game_with_tributes(vec![a.clone(), b.clone(), c.clone()]);
+        let mut game = create_test_game_with_tributes(vec![a.clone(), b.clone(), c.clone()]);
         game.areas
             .push(AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia));
         let living = game.living_tributes();

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -718,12 +718,105 @@ impl Game {
         // Drained into self.messages after the mutable borrow of self.tributes ends.
         let mut collected_events: Vec<(String, String, String)> = Vec::new();
 
+        // Alliance formation rolls (spec §6). For every pair of living
+        // tributes sharing an area where neither already lists the other as
+        // an ally and neither is at the alliance cap, run try_form_alliance.
+        // Collect successful pairs as (id_a, id_b, factor) and apply after
+        // the immutable borrow ends. This runs *before* the per-tribute
+        // turn so newly-formed alliances are visible to pick_target this
+        // cycle.
+        let mut new_alliances: Vec<(uuid::Uuid, uuid::Uuid, String, String)> = Vec::new();
+        for tributes in tributes_by_area.values() {
+            for i in 0..tributes.len() {
+                for j in (i + 1)..tributes.len() {
+                    let a = tributes[i];
+                    let b = tributes[j];
+                    if a.allies.contains(&b.id) || b.allies.contains(&a.id) {
+                        continue;
+                    }
+                    if a.allies.len() >= crate::tributes::alliances::MAX_ALLIES
+                        || b.allies.len() >= crate::tributes::alliances::MAX_ALLIES
+                    {
+                        continue;
+                    }
+                    let same_district = a.district == b.district;
+                    let formed = crate::tributes::alliances::try_form_alliance(
+                        &a.traits,
+                        &b.traits,
+                        same_district,
+                        a.allies.len(),
+                        b.allies.len(),
+                        rng,
+                    );
+                    if formed {
+                        let factor = crate::tributes::alliances::deciding_factor(
+                            &a.traits,
+                            &b.traits,
+                            same_district,
+                        );
+                        let factor_label = factor
+                            .as_ref()
+                            .map(|f| f.label())
+                            .unwrap_or("mutual circumstance");
+                        new_alliances.push((
+                            a.id,
+                            b.id,
+                            a.name.clone(),
+                            format!(
+                                "{} and {} form an alliance ({}).",
+                                a.name, b.name, factor_label
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
         // Alliance events drained from each tribute's local buffer this cycle.
         // Appended to self.alliance_events after the mutable borrow ends, then
         // processed via process_alliance_events so cascades resolve before the
         // next cycle.
         let mut drained_alliance_events: Vec<crate::tributes::alliances::AllianceEvent> =
             Vec::new();
+
+        // Apply alliance formations symmetrically. Both sides get each
+        // other's id pushed onto `allies` so the graph stays consistent.
+        // Skip duplicates defensively in case the same pair appears twice.
+        for (id_a, id_b, name_a, message) in &new_alliances {
+            // Find indices to satisfy the borrow checker for two-side mutation.
+            let mut idx_a: Option<usize> = None;
+            let mut idx_b: Option<usize> = None;
+            for (i, t) in self.tributes.iter().enumerate() {
+                if t.id == *id_a {
+                    idx_a = Some(i);
+                }
+                if t.id == *id_b {
+                    idx_b = Some(i);
+                }
+            }
+            let (Some(ia), Some(ib)) = (idx_a, idx_b) else {
+                continue;
+            };
+            // Re-check caps and existing membership at apply time in case
+            // multiple formations targeting the same tribute pushed the
+            // count over MAX_ALLIES.
+            if self.tributes[ia].allies.len() >= crate::tributes::alliances::MAX_ALLIES
+                || self.tributes[ib].allies.len() >= crate::tributes::alliances::MAX_ALLIES
+            {
+                continue;
+            }
+            if !self.tributes[ia].allies.contains(id_b) {
+                self.tributes[ia].allies.push(*id_b);
+            }
+            if !self.tributes[ib].allies.contains(id_a) {
+                self.tributes[ib].allies.push(*id_a);
+            }
+            collected_events.push((
+                self.tributes[ia].identifier.clone(),
+                name_a.clone(),
+                message.clone(),
+            ));
+        }
 
         // Process tributes
         for tribute in self.tributes.iter_mut() {
@@ -1459,5 +1552,64 @@ mod tests {
         let v = game.tributes.iter().find(|t| t.id == vid).unwrap();
         assert!(!v.allies.contains(&bid), "victim allies cleaned");
         assert!(v.pending_trust_shock, "victim flagged for trust shock");
+    }
+
+    #[test]
+    fn run_tribute_cycle_forms_alliance_between_compatible_same_area_tributes() {
+        // Two Friendly tributes from the same district sharing an area
+        // should be able to form an alliance during a cycle. With both
+        // sides starting at 0 allies, district bonus, and Friendly affinity
+        // 1.5 each, roll_chance ≈ 0.675; with a fixed seed and many trials
+        // we deterministically observe at least one cycle that forms.
+        use crate::tributes::traits::Trait;
+        let mut t1 = create_tribute("Cinna", true);
+        let mut t2 = create_tribute("Portia", true);
+        // Force compatibility: same district + Friendly traits.
+        t1.district = 1;
+        t2.district = 1;
+        t1.traits = vec![Trait::Friendly];
+        t2.traits = vec![Trait::Friendly];
+        // Place both in Cornucopia (default `Tribute::new` already does this,
+        // but be explicit for the test's intent).
+        t1.area = Area::Cornucopia;
+        t2.area = Area::Cornucopia;
+
+        let id1 = t1.id;
+        let id2 = t2.id;
+
+        let mut game = create_test_game_with_tributes(vec![t1.clone(), t2.clone()]);
+        let area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
+        game.areas.push(area);
+        let closed_areas = game
+            .areas
+            .iter()
+            .filter(|ad| ad.area.is_some() & !ad.is_open())
+            .map(|ad| ad.area.unwrap())
+            .collect::<Vec<Area>>();
+
+        // Loop a few seeded cycles until at least one forms; if production
+        // wiring is correct this should hit within a handful of trials.
+        let mut formed = false;
+        for seed in [313u64, 419, 547, 23, 89, 211] {
+            let mut g = game.clone();
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let _ = g.run_tribute_cycle(
+                true,
+                &mut rng,
+                closed_areas.clone(),
+                vec![t1.clone(), t2.clone()],
+                2,
+            );
+            let a1 = g.tributes.iter().find(|t| t.id == id1).unwrap();
+            let a2 = g.tributes.iter().find(|t| t.id == id2).unwrap();
+            if a1.allies.contains(&id2) && a2.allies.contains(&id1) {
+                formed = true;
+                break;
+            }
+        }
+        assert!(
+            formed,
+            "Friendly same-district pair must form an alliance within a few cycles"
+        );
     }
 }

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -1803,4 +1803,56 @@ mod tests {
             "survivor must not retain a dead ally edge"
         );
     }
+
+    #[test]
+    fn run_tribute_cycle_three_way_preserves_existing_alliance() {
+        // Three-way scenario: A and B are pre-allied; C is a LoneWolf in
+        // the same area (refuser → cannot form an alliance with either).
+        // After a cycle, A and B's bond must remain intact and C must
+        // remain unallied. This pins that:
+        //   1. The formation pass does not silently rebreak existing
+        //      same-area alliances.
+        //   2. The presence of a third unalliable tribute does not
+        //      perturb the pair's bond.
+        use crate::tributes::traits::Trait;
+
+        let mut a = create_tribute("Katniss", true);
+        let mut b = create_tribute("Peeta", true);
+        let mut c = create_tribute("Cato", true);
+        a.traits = vec![Trait::Friendly];
+        b.traits = vec![Trait::Loyal];
+        c.traits = vec![Trait::LoneWolf];
+        // Pre-existing symmetric alliance between A and B.
+        a.allies.push(b.id);
+        b.allies.push(a.id);
+        a.area = Area::Cornucopia;
+        b.area = Area::Cornucopia;
+        c.area = Area::Cornucopia;
+        a.district = 1;
+        b.district = 2;
+        c.district = 3;
+
+        let aid = a.id;
+        let bid = b.id;
+        let cid = c.id;
+
+        let mut game =
+            create_test_game_with_tributes(vec![a.clone(), b.clone(), c.clone()]);
+        game.areas
+            .push(AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia));
+        let living = game.living_tributes();
+        let closed_areas: Vec<Area> = vec![];
+
+        let mut rng = SmallRng::seed_from_u64(547);
+        let _ = game.run_tribute_cycle(true, &mut rng, closed_areas, living, 3);
+
+        let a2 = game.tributes.iter().find(|t| t.id == aid).unwrap();
+        let b2 = game.tributes.iter().find(|t| t.id == bid).unwrap();
+        let c2 = game.tributes.iter().find(|t| t.id == cid).unwrap();
+        assert!(a2.allies.contains(&bid), "A still allied with B");
+        assert!(b2.allies.contains(&aid), "B still allied with A");
+        assert!(!a2.allies.contains(&cid), "A did not bond with LoneWolf C");
+        assert!(!b2.allies.contains(&cid), "B did not bond with LoneWolf C");
+        assert!(c2.allies.is_empty(), "LoneWolf C remains unallied");
+    }
 }

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -73,6 +73,11 @@ pub struct Game {
     /// Skipped during serialization since events live in their own table.
     #[serde(default, skip_serializing)]
     pub messages: Vec<crate::messages::GameMessage>,
+    /// Transient queue of alliance lifecycle events drained between tribute
+    /// turns inside `run_day_night_cycle`. Lives only for the duration of a
+    /// single cycle; never persisted. See spec §7.5.
+    #[serde(default, skip)]
+    pub alliance_events: Vec<crate::tributes::alliances::AllianceEvent>,
 }
 
 impl Default for Game {
@@ -94,6 +99,7 @@ impl Default for Game {
             private: true,
             config: Default::default(),
             messages: vec![],
+            alliance_events: vec![],
         }
     }
 }
@@ -900,6 +906,7 @@ mod tests {
             private: true,
             config: Default::default(),
             messages: vec![],
+            alliance_events: vec![],
         }
     }
 
@@ -922,6 +929,12 @@ mod tests {
         assert_eq!(game.status, GameStatus::NotStarted);
         assert_eq!(game.day, None);
         assert_eq!(game.tributes.len(), 0);
+    }
+
+    #[test]
+    fn game_has_empty_alliance_event_queue_on_new() {
+        let g = Game::default();
+        assert!(g.alliance_events.is_empty());
     }
 
     #[test]

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -718,6 +718,13 @@ impl Game {
         // Drained into self.messages after the mutable borrow of self.tributes ends.
         let mut collected_events: Vec<(String, String, String)> = Vec::new();
 
+        // Alliance events drained from each tribute's local buffer this cycle.
+        // Appended to self.alliance_events after the mutable borrow ends, then
+        // processed via process_alliance_events so cascades resolve before the
+        // next cycle.
+        let mut drained_alliance_events: Vec<crate::tributes::alliances::AllianceEvent> =
+            Vec::new();
+
         // Process tributes
         for tribute in self.tributes.iter_mut() {
             if !tribute.is_alive() {
@@ -802,6 +809,7 @@ impl Game {
             for line in tribute_events {
                 collected_events.push((tribute.identifier.clone(), tribute.name.clone(), line));
             }
+            drained_alliance_events.append(&mut tribute.drain_alliance_events());
         }
 
         // Drain collected events into game messages now that the mutable borrow ends.
@@ -811,6 +819,13 @@ impl Game {
                 name,
                 line,
             );
+        }
+
+        // Promote drained alliance events into the game queue and process them
+        // so betrayal/death cascades take effect before the next cycle.
+        if !drained_alliance_events.is_empty() {
+            self.alliance_events.append(&mut drained_alliance_events);
+            self.process_alliance_events(rng);
         }
         Ok(())
     }
@@ -1392,5 +1407,60 @@ mod tests {
             );
         }
         assert!(game.alliance_events.is_empty());
+    }
+
+    #[test]
+    fn run_tribute_cycle_drains_tribute_alliance_events_into_game_queue() {
+        // Pre-load tribute1's alliance_events buffer; after run_tribute_cycle
+        // it must be drained into the game queue and processed (BetrayalRecorded
+        // cleans the victim's allies and flags pending_trust_shock).
+        let mut tribute1 = create_tribute("Tribute1", true);
+        let mut tribute2 = create_tribute("Tribute2", true);
+        // Make tribute2 list tribute1 as ally; betrayal has tribute1 as betrayer,
+        // tribute2 as victim. Plumbing only — we just need the side effects we
+        // can observe on the victim.
+        tribute2.allies.push(tribute1.id);
+        let bid = tribute1.id;
+        let vid = tribute2.id;
+        tribute1.alliance_events.push(
+            crate::tributes::alliances::AllianceEvent::BetrayalRecorded {
+                betrayer: bid,
+                victim: vid,
+            },
+        );
+
+        let mut game =
+            create_test_game_with_tributes(vec![tribute1.clone(), tribute2.clone()]);
+        let area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
+        game.areas.push(area);
+        let closed_areas = game
+            .areas
+            .iter()
+            .filter(|ad| ad.area.is_some() & !ad.is_open())
+            .map(|ad| ad.area.unwrap())
+            .collect::<Vec<Area>>();
+
+        let mut rng = SmallRng::seed_from_u64(211);
+        let _ = game.run_tribute_cycle(
+            true,
+            &mut rng,
+            closed_areas,
+            vec![tribute1.clone(), tribute2.clone()],
+            2,
+        );
+
+        // After cycle: queue empty (drained + processed), each tribute's local
+        // buffer empty, victim's allies cleaned, victim flagged for trust shock.
+        assert!(game.alliance_events.is_empty(), "game queue must drain");
+        for t in &game.tributes {
+            assert!(
+                t.alliance_events.is_empty(),
+                "tribute {} buffer must drain",
+                t.name
+            );
+        }
+        let v = game.tributes.iter().find(|t| t.id == vid).unwrap();
+        assert!(!v.allies.contains(&bid), "victim allies cleaned");
+        assert!(v.pending_trust_shock, "victim flagged for trust shock");
     }
 }

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -959,11 +959,7 @@ impl Game {
                                 );
                                 let aid = ally.identifier.clone();
                                 let aname = ally.name.clone();
-                                self.log(
-                                    crate::messages::MessageSource::Tribute(aid),
-                                    aname,
-                                    line,
-                                );
+                                self.log(crate::messages::MessageSource::Tribute(aid), aname, line);
                             }
                         }
                     }
@@ -1339,11 +1335,12 @@ mod tests {
         let vid = victim.id;
 
         let mut game = create_test_game_with_tributes(vec![betrayer, victim]);
-        game.alliance_events
-            .push(crate::tributes::alliances::AllianceEvent::BetrayalRecorded {
+        game.alliance_events.push(
+            crate::tributes::alliances::AllianceEvent::BetrayalRecorded {
                 betrayer: bid,
                 victim: vid,
-            });
+            },
+        );
 
         let mut rng = SmallRng::seed_from_u64(53);
         game.process_alliance_events(&mut rng);
@@ -1362,11 +1359,12 @@ mod tests {
         let vid = victim.id;
 
         let mut game = create_test_game_with_tributes(vec![betrayer, victim]);
-        game.alliance_events
-            .push(crate::tributes::alliances::AllianceEvent::BetrayalRecorded {
+        game.alliance_events.push(
+            crate::tributes::alliances::AllianceEvent::BetrayalRecorded {
                 betrayer: bid,
                 victim: vid,
-            });
+            },
+        );
 
         let mut rng = SmallRng::seed_from_u64(53);
         game.process_alliance_events(&mut rng);
@@ -1429,8 +1427,7 @@ mod tests {
             },
         );
 
-        let mut game =
-            create_test_game_with_tributes(vec![tribute1.clone(), tribute2.clone()]);
+        let mut game = create_test_game_with_tributes(vec![tribute1.clone(), tribute2.clone()]);
         let area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
         game.areas.push(area);
         let closed_areas = game

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -1612,4 +1612,120 @@ mod tests {
             "Friendly same-district pair must form an alliance within a few cycles"
         );
     }
+
+    #[test]
+    fn run_tribute_cycle_treacherous_tribute_betrays_same_area_ally_when_timer_elapses() {
+        // Treacherous tribute with an ally in the same area, timer at the
+        // betrayal interval, must enqueue BetrayalRecorded during the cycle.
+        // After process_alliance_events, the victim must have:
+        //   - pending_trust_shock set
+        //   - betrayer removed from allies
+        // and the betrayer must have:
+        //   - victim removed from allies
+        //   - timer reset to 0
+        use crate::tributes::alliances::TREACHEROUS_BETRAYAL_INTERVAL;
+        use crate::tributes::traits::Trait;
+
+        let mut betrayer = create_tribute("Cato", true);
+        let mut victim = create_tribute("Glimmer", true);
+        betrayer.traits = vec![Trait::Treacherous];
+        // Strip any auto-generated traits from victim that might accidentally
+        // form an alliance back during the cycle (we want a pre-existing ally).
+        victim.traits = vec![Trait::Tough];
+        // Pre-existing alliance set up manually.
+        betrayer.allies.push(victim.id);
+        victim.allies.push(betrayer.id);
+        // Timer at threshold so betrayal fires this turn.
+        betrayer.turns_since_last_betrayal = TREACHEROUS_BETRAYAL_INTERVAL;
+        // Same area.
+        betrayer.area = Area::Cornucopia;
+        victim.area = Area::Cornucopia;
+        // Different districts so we don't accidentally re-form alliances
+        // during the formation pass.
+        betrayer.district = 1;
+        victim.district = 2;
+
+        let bid = betrayer.id;
+        let vid = victim.id;
+
+        let mut game =
+            create_test_game_with_tributes(vec![betrayer.clone(), victim.clone()]);
+        let area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
+        game.areas.push(area);
+        let closed_areas = game
+            .areas
+            .iter()
+            .filter(|ad| ad.area.is_some() & !ad.is_open())
+            .map(|ad| ad.area.unwrap())
+            .collect::<Vec<Area>>();
+
+        let mut rng = SmallRng::seed_from_u64(313);
+        let _ = game.run_tribute_cycle(
+            true,
+            &mut rng,
+            closed_areas,
+            vec![betrayer.clone(), victim.clone()],
+            2,
+        );
+
+        let v = game.tributes.iter().find(|t| t.id == vid).unwrap();
+        let b = game.tributes.iter().find(|t| t.id == bid).unwrap();
+        assert!(!v.allies.contains(&bid), "victim allies cleaned by event");
+        assert!(v.pending_trust_shock, "victim flagged for trust shock");
+        assert!(!b.allies.contains(&vid), "betrayer dropped victim locally");
+        // tick_alliance_timers ran and incremented to TREACHEROUS_BETRAYAL_INTERVAL+1
+        // before betrayal fired? No: betrayal logic must reset to 0. After reset,
+        // the rest of process_turn_phase doesn't tick again, so we expect 0.
+        assert_eq!(
+            b.turns_since_last_betrayal, 0,
+            "betrayal resets the cooldown timer"
+        );
+    }
+
+    #[test]
+    fn run_tribute_cycle_treacherous_no_betrayal_without_same_area_ally_resets_timer() {
+        // Treacherous tribute alone in its area: no betrayal possible, but
+        // the timer should still reset (one missed opportunity per cycle).
+        use crate::tributes::alliances::TREACHEROUS_BETRAYAL_INTERVAL;
+        use crate::tributes::traits::Trait;
+
+        let mut loner = create_tribute("Foxface", true);
+        let mut other = create_tribute("Marvel", true);
+        loner.traits = vec![Trait::Treacherous];
+        other.traits = vec![Trait::Tough];
+        loner.turns_since_last_betrayal = TREACHEROUS_BETRAYAL_INTERVAL;
+        // Different areas so other is not a same-area ally.
+        loner.area = Area::North;
+        other.area = Area::South;
+        loner.district = 5;
+        other.district = 6;
+        let lid = loner.id;
+
+        let mut game = create_test_game_with_tributes(vec![loner.clone(), other.clone()]);
+        game.areas
+            .push(AreaDetails::new(Some("Hill".to_string()), Area::North));
+        game.areas
+            .push(AreaDetails::new(Some("Lake".to_string()), Area::South));
+        let closed_areas = game
+            .areas
+            .iter()
+            .filter(|ad| ad.area.is_some() & !ad.is_open())
+            .map(|ad| ad.area.unwrap())
+            .collect::<Vec<Area>>();
+
+        let mut rng = SmallRng::seed_from_u64(419);
+        let _ = game.run_tribute_cycle(
+            true,
+            &mut rng,
+            closed_areas,
+            vec![loner.clone(), other.clone()],
+            2,
+        );
+
+        let l = game.tributes.iter().find(|t| t.id == lid).unwrap();
+        assert_eq!(
+            l.turns_since_last_betrayal, 0,
+            "missed opportunity also resets the timer per spec §7.4(b)"
+        );
+    }
 }

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -7,7 +7,7 @@
 
 use uuid::Uuid;
 
-use crate::tributes::traits::{REFUSERS, Trait};
+use crate::tributes::traits::{REFUSERS, Trait, geometric_mean_affinity};
 
 /// Per-tribute hard cap on direct alliances.
 pub const MAX_ALLIES: usize = 5;
@@ -37,6 +37,32 @@ pub fn passes_gate(self_traits: &[Trait], target_traits: &[Trait]) -> bool {
     let has_refuser = |ts: &[Trait]| ts.iter().any(|x| REFUSERS.contains(x));
     (has_positive(self_traits) && has_positive(target_traits))
         || (!has_refuser(self_traits) && !has_refuser(target_traits))
+}
+
+/// Roll chance per spec §6.2. `self_allies_len` and `target_allies_len`
+/// are the current `Vec::len()` of each tribute's `allies` list. Returns
+/// 0.0 if either side is at the cap; clamped at 0.95.
+pub fn roll_chance(
+    self_traits: &[Trait],
+    target_traits: &[Trait],
+    same_district: bool,
+    self_allies_len: usize,
+    target_allies_len: usize,
+) -> f64 {
+    let trait_factor = geometric_mean_affinity(self_traits);
+    let target_factor = geometric_mean_affinity(target_traits);
+    let district_bonus = if same_district { 1.5 } else { 1.0 };
+    let self_cap_pen =
+        ((MAX_ALLIES as f64) - (self_allies_len as f64)) / (MAX_ALLIES as f64);
+    let target_cap_pen =
+        ((MAX_ALLIES as f64) - (target_allies_len as f64)) / (MAX_ALLIES as f64);
+    let raw = BASE_ALLIANCE_CHANCE
+        * trait_factor
+        * target_factor
+        * district_bonus
+        * self_cap_pen.max(0.0)
+        * target_cap_pen.max(0.0);
+    raw.clamp(0.0, 0.95)
 }
 
 #[cfg(test)]
@@ -116,5 +142,64 @@ mod tests {
     fn neutral_pair_passes_gate() {
         // Tough has affinity 1.0 and is not a refuser; both clauses hold.
         assert!(passes_gate(&[Trait::Tough], &[Trait::Tough]));
+    }
+
+    // ---- Task 2.3: roll_chance -------------------------------------------
+
+    #[test]
+    fn roll_chance_zero_when_self_at_cap() {
+        let chance = roll_chance(
+            &[Trait::Friendly],
+            &[Trait::Friendly],
+            true,
+            MAX_ALLIES,
+            0,
+        );
+        assert_eq!(chance, 0.0);
+    }
+
+    #[test]
+    fn roll_chance_zero_when_target_at_cap() {
+        let chance = roll_chance(
+            &[Trait::Friendly],
+            &[Trait::Friendly],
+            true,
+            0,
+            MAX_ALLIES,
+        );
+        assert_eq!(chance, 0.0);
+    }
+
+    #[test]
+    fn roll_chance_neutral_pair_at_base() {
+        // 0.20 * 1.0 * 1.0 * 1.0 * 1.0 * 1.0 = 0.20.
+        let chance = roll_chance(&[], &[], false, 0, 0);
+        assert!((chance - 0.20).abs() < 1e-9);
+    }
+
+    #[test]
+    fn roll_chance_friendly_same_district_higher_than_base() {
+        // 0.20 * 1.5 * 1.5 * 1.5 = 0.675.
+        let chance = roll_chance(&[Trait::Friendly], &[Trait::Friendly], true, 0, 0);
+        assert!(chance > 0.6 && chance <= 0.95);
+    }
+
+    #[test]
+    fn roll_chance_clamps_at_ceiling() {
+        let chance = roll_chance(
+            &[Trait::Friendly, Trait::Friendly, Trait::Friendly],
+            &[Trait::Friendly, Trait::Friendly, Trait::Friendly],
+            true,
+            0,
+            0,
+        );
+        assert!(chance <= 0.95 + 1e-9);
+    }
+
+    #[test]
+    fn roll_chance_symmetric_in_traits() {
+        let a = roll_chance(&[Trait::Friendly], &[Trait::Loyal], true, 0, 0);
+        let b = roll_chance(&[Trait::Loyal], &[Trait::Friendly], true, 0, 0);
+        assert!((a - b).abs() < 1e-9);
     }
 }

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -52,10 +52,8 @@ pub fn roll_chance(
     let trait_factor = geometric_mean_affinity(self_traits);
     let target_factor = geometric_mean_affinity(target_traits);
     let district_bonus = if same_district { 1.5 } else { 1.0 };
-    let self_cap_pen =
-        ((MAX_ALLIES as f64) - (self_allies_len as f64)) / (MAX_ALLIES as f64);
-    let target_cap_pen =
-        ((MAX_ALLIES as f64) - (target_allies_len as f64)) / (MAX_ALLIES as f64);
+    let self_cap_pen = ((MAX_ALLIES as f64) - (self_allies_len as f64)) / (MAX_ALLIES as f64);
+    let target_cap_pen = ((MAX_ALLIES as f64) - (target_allies_len as f64)) / (MAX_ALLIES as f64);
     let raw = BASE_ALLIANCE_CHANCE
         * trait_factor
         * target_factor
@@ -127,9 +125,26 @@ pub fn sanity_break_roll(
     if current_sanity >= low_sanity_limit {
         return false;
     }
-    let deficit_ratio = (low_sanity_limit.saturating_sub(current_sanity) as f64)
-        / (low_sanity_limit.max(1) as f64);
+    let deficit_ratio =
+        (low_sanity_limit.saturating_sub(current_sanity) as f64) / (low_sanity_limit.max(1) as f64);
     let p = deficit_ratio.clamp(0.0, 1.0);
+    rng.random_bool(p)
+}
+
+/// Trust-shock roll for a betrayal victim (spec §7.3c1). Same threshold
+/// gating as `sanity_break_roll` but with a higher baseline of
+/// `0.5 + 0.5 * deficit_ratio`.
+pub fn trust_shock_roll(
+    current_sanity: u32,
+    low_sanity_limit: u32,
+    rng: &mut impl rand::Rng,
+) -> bool {
+    if current_sanity >= low_sanity_limit {
+        return false;
+    }
+    let deficit_ratio =
+        (low_sanity_limit.saturating_sub(current_sanity) as f64) / (low_sanity_limit.max(1) as f64);
+    let p = (0.5 + 0.5 * deficit_ratio).clamp(0.0, 1.0);
     rng.random_bool(p)
 }
 
@@ -218,25 +233,13 @@ mod tests {
 
     #[test]
     fn roll_chance_zero_when_self_at_cap() {
-        let chance = roll_chance(
-            &[Trait::Friendly],
-            &[Trait::Friendly],
-            true,
-            MAX_ALLIES,
-            0,
-        );
+        let chance = roll_chance(&[Trait::Friendly], &[Trait::Friendly], true, MAX_ALLIES, 0);
         assert_eq!(chance, 0.0);
     }
 
     #[test]
     fn roll_chance_zero_when_target_at_cap() {
-        let chance = roll_chance(
-            &[Trait::Friendly],
-            &[Trait::Friendly],
-            true,
-            0,
-            MAX_ALLIES,
-        );
+        let chance = roll_chance(&[Trait::Friendly], &[Trait::Friendly], true, 0, MAX_ALLIES);
         assert_eq!(chance, 0.0);
     }
 
@@ -337,5 +340,36 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(1);
         // Degenerate limit must not panic and must not break (sanity >= 0).
         assert!(!sanity_break_roll(0, 0, &mut rng));
+    }
+
+    // ---- Task 2.6: trust_shock_roll --------------------------------------
+
+    #[test]
+    fn trust_shock_above_limit_no_break() {
+        let mut rng = StdRng::seed_from_u64(1);
+        for _ in 0..32 {
+            assert!(!trust_shock_roll(50, 20, &mut rng));
+        }
+    }
+
+    #[test]
+    fn trust_shock_below_limit_high_baseline() {
+        let mut rng = StdRng::seed_from_u64(7);
+        let mut breaks = 0;
+        for _ in 0..200 {
+            if trust_shock_roll(10, 20, &mut rng) {
+                breaks += 1;
+            }
+        }
+        // p = 0.5 + 0.5 * 0.5 = 0.75; expect majority to break.
+        assert!(breaks > 100, "expected most to break, got {breaks}");
+    }
+
+    #[test]
+    fn trust_shock_at_limit_no_break() {
+        let mut rng = StdRng::seed_from_u64(1);
+        for _ in 0..32 {
+            assert!(!trust_shock_roll(20, 20, &mut rng));
+        }
     }
 }

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -1,0 +1,74 @@
+//! Tribute alliance formation, breaks, and event queue. See spec
+//! `docs/superpowers/specs/2026-04-25-tribute-alliances-design.md` §6–§7.
+//!
+//! Pure functions only. Phase 2 of the tribute-alliances feature. No
+//! `Tribute` mutation lives here; later phases wire these helpers into
+//! the simulation loop.
+
+use uuid::Uuid;
+
+/// Per-tribute hard cap on direct alliances.
+pub const MAX_ALLIES: usize = 5;
+/// Base chance per encounter that two tributes form an alliance.
+pub const BASE_ALLIANCE_CHANCE: f64 = 0.20;
+/// Treacherous betrayal cadence in turns.
+pub const TREACHEROUS_BETRAYAL_INTERVAL: u8 = 5;
+
+/// Events emitted by tribute turns and drained by the game cycle. Pure data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllianceEvent {
+    BetrayalRecorded {
+        betrayer: Uuid,
+        victim: Uuid,
+    },
+    DeathRecorded {
+        deceased: Uuid,
+        killer: Option<Uuid>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alliance_event_variants_distinct() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let betrayal = AllianceEvent::BetrayalRecorded {
+            betrayer: a,
+            victim: b,
+        };
+        let death = AllianceEvent::DeathRecorded {
+            deceased: a,
+            killer: Some(b),
+        };
+        assert_ne!(betrayal, death);
+        let betrayal2 = AllianceEvent::BetrayalRecorded {
+            betrayer: a,
+            victim: b,
+        };
+        assert_eq!(betrayal, betrayal2);
+    }
+
+    #[test]
+    fn death_event_killer_optional() {
+        let id = Uuid::new_v4();
+        let unattributed = AllianceEvent::DeathRecorded {
+            deceased: id,
+            killer: None,
+        };
+        if let AllianceEvent::DeathRecorded { killer, .. } = unattributed {
+            assert!(killer.is_none());
+        } else {
+            panic!("expected DeathRecorded");
+        }
+    }
+
+    #[test]
+    fn constants_have_expected_values() {
+        assert_eq!(MAX_ALLIES, 5);
+        assert!((BASE_ALLIANCE_CHANCE - 0.20).abs() < f64::EPSILON);
+        assert_eq!(TREACHEROUS_BETRAYAL_INTERVAL, 5);
+    }
+}

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -410,14 +410,8 @@ mod tests {
     fn try_form_alliance_returns_false_when_gate_blocks() {
         // LoneWolf vs Friendly fails passes_gate; helper must short-circuit.
         let mut rng = StdRng::seed_from_u64(313);
-        let formed = try_form_alliance(
-            &[Trait::LoneWolf],
-            &[Trait::Friendly],
-            true,
-            0,
-            0,
-            &mut rng,
-        );
+        let formed =
+            try_form_alliance(&[Trait::LoneWolf], &[Trait::Friendly], true, 0, 0, &mut rng);
         assert!(!formed);
     }
 
@@ -451,14 +445,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(547);
         let mut successes = 0;
         for _ in 0..200 {
-            if try_form_alliance(
-                &[Trait::Friendly],
-                &[Trait::Friendly],
-                true,
-                0,
-                0,
-                &mut rng,
-            ) {
+            if try_form_alliance(&[Trait::Friendly], &[Trait::Friendly], true, 0, 0, &mut rng) {
                 successes += 1;
             }
         }

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -148,6 +148,37 @@ pub fn trust_shock_roll(
     rng.random_bool(p)
 }
 
+/// Attempt to form an alliance between two tributes. Returns `true` on
+/// success — gate passes, `roll_chance` is positive, and the dice roll
+/// hits. The caller is responsible for mutating both sides' `allies`
+/// lists and for fetching a [`DecidingFactor`] via [`deciding_factor`]
+/// for human-readable messaging. Composes [`passes_gate`] and
+/// [`roll_chance`] so the game cycle has a single integration point per
+/// spec §6.
+pub fn try_form_alliance(
+    self_traits: &[Trait],
+    target_traits: &[Trait],
+    same_district: bool,
+    self_allies_len: usize,
+    target_allies_len: usize,
+    rng: &mut impl rand::Rng,
+) -> bool {
+    if !passes_gate(self_traits, target_traits) {
+        return false;
+    }
+    let chance = roll_chance(
+        self_traits,
+        target_traits,
+        same_district,
+        self_allies_len,
+        target_allies_len,
+    );
+    if chance <= 0.0 {
+        return false;
+    }
+    rng.random_bool(chance)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -370,6 +401,86 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(1);
         for _ in 0..32 {
             assert!(!trust_shock_roll(20, 20, &mut rng));
+        }
+    }
+
+    // ---- Phase 6: try_form_alliance integration helper -------------------
+
+    #[test]
+    fn try_form_alliance_returns_false_when_gate_blocks() {
+        // LoneWolf vs Friendly fails passes_gate; helper must short-circuit.
+        let mut rng = StdRng::seed_from_u64(313);
+        let formed = try_form_alliance(
+            &[Trait::LoneWolf],
+            &[Trait::Friendly],
+            true,
+            0,
+            0,
+            &mut rng,
+        );
+        assert!(!formed);
+    }
+
+    #[test]
+    fn try_form_alliance_returns_false_when_either_at_cap() {
+        let mut rng = StdRng::seed_from_u64(419);
+        let r1 = try_form_alliance(
+            &[Trait::Friendly],
+            &[Trait::Friendly],
+            true,
+            MAX_ALLIES,
+            0,
+            &mut rng,
+        );
+        assert!(!r1, "self at cap blocks");
+        let r2 = try_form_alliance(
+            &[Trait::Friendly],
+            &[Trait::Friendly],
+            true,
+            0,
+            MAX_ALLIES,
+            &mut rng,
+        );
+        assert!(!r2, "target at cap blocks");
+    }
+
+    #[test]
+    fn try_form_alliance_can_succeed_for_high_chance_pair() {
+        // Friendly + same district + 0 allies → ~0.675 chance. Sample many
+        // trials and assert at least some succeed.
+        let mut rng = StdRng::seed_from_u64(547);
+        let mut successes = 0;
+        for _ in 0..200 {
+            if try_form_alliance(
+                &[Trait::Friendly],
+                &[Trait::Friendly],
+                true,
+                0,
+                0,
+                &mut rng,
+            ) {
+                successes += 1;
+            }
+        }
+        assert!(
+            successes > 100,
+            "expected majority success at p≈0.675, got {successes}"
+        );
+    }
+
+    #[test]
+    fn try_form_alliance_zero_chance_never_forms() {
+        // Both at cap → roll_chance = 0.0 → never forms.
+        let mut rng = StdRng::seed_from_u64(101);
+        for _ in 0..32 {
+            assert!(!try_form_alliance(
+                &[],
+                &[],
+                false,
+                MAX_ALLIES,
+                MAX_ALLIES,
+                &mut rng
+            ));
         }
     }
 }

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -115,9 +115,29 @@ pub fn deciding_factor(
     candidates.into_iter().next().map(|(_, df)| df)
 }
 
+/// Per-ally sanity-break roll (spec §7.3a). Returns `true` if the
+/// symmetric pair should be removed. Probability scales linearly with
+/// the deficit below `low_sanity_limit`; at or above the limit the
+/// function always returns `false`.
+pub fn sanity_break_roll(
+    current_sanity: u32,
+    low_sanity_limit: u32,
+    rng: &mut impl rand::Rng,
+) -> bool {
+    if current_sanity >= low_sanity_limit {
+        return false;
+    }
+    let deficit_ratio = (low_sanity_limit.saturating_sub(current_sanity) as f64)
+        / (low_sanity_limit.max(1) as f64);
+    let p = deficit_ratio.clamp(0.0, 1.0);
+    rng.random_bool(p)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     #[test]
     fn alliance_event_variants_distinct() {
@@ -283,5 +303,39 @@ mod tests {
         // No trait > 1.0, but same_district adds 1.5 → SameDistrict wins.
         let f = deciding_factor(&[Trait::Tough], &[Trait::Tough], true);
         assert_eq!(f, Some(DecidingFactor::SameDistrict));
+    }
+
+    // ---- Task 2.5: sanity_break_roll -------------------------------------
+
+    #[test]
+    fn sanity_break_above_limit_no_break() {
+        let mut rng = StdRng::seed_from_u64(1);
+        for _ in 0..32 {
+            assert!(!sanity_break_roll(50, 20, &mut rng));
+        }
+    }
+
+    #[test]
+    fn sanity_break_far_below_always_breaks() {
+        let mut rng = StdRng::seed_from_u64(1);
+        // Sanity 0 vs limit 20: deficit ratio 1.0 → p=1.0 → always breaks.
+        for _ in 0..32 {
+            assert!(sanity_break_roll(0, 20, &mut rng));
+        }
+    }
+
+    #[test]
+    fn sanity_break_at_limit_no_break() {
+        let mut rng = StdRng::seed_from_u64(1);
+        for _ in 0..32 {
+            assert!(!sanity_break_roll(20, 20, &mut rng));
+        }
+    }
+
+    #[test]
+    fn sanity_break_zero_limit_safe() {
+        let mut rng = StdRng::seed_from_u64(1);
+        // Degenerate limit must not panic and must not break (sanity >= 0).
+        assert!(!sanity_break_roll(0, 0, &mut rng));
     }
 }

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -65,6 +65,56 @@ pub fn roll_chance(
     raw.clamp(0.0, 0.95)
 }
 
+/// Human-readable deciding factor for a successful alliance roll.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecidingFactor {
+    SameDistrict,
+    TraitOnSelf(Trait),
+    TraitOnTarget(Trait),
+}
+
+impl DecidingFactor {
+    pub fn label(&self) -> &'static str {
+        match self {
+            DecidingFactor::SameDistrict => "same district",
+            DecidingFactor::TraitOnSelf(t) | DecidingFactor::TraitOnTarget(t) => t.label(),
+        }
+    }
+}
+
+/// Returns the deciding factor for a successful alliance roll, or `None`
+/// if no factor exceeded 1.0. Same-district contributes a 1.5 weight; each
+/// trait contributes its `alliance_affinity`. Ties break by label sort to
+/// keep test output deterministic.
+pub fn deciding_factor(
+    self_traits: &[Trait],
+    target_traits: &[Trait],
+    same_district: bool,
+) -> Option<DecidingFactor> {
+    let mut candidates: Vec<(f64, DecidingFactor)> = Vec::new();
+    if same_district {
+        candidates.push((1.5, DecidingFactor::SameDistrict));
+    }
+    for t in self_traits {
+        let a = t.alliance_affinity();
+        if a > 1.0 {
+            candidates.push((a, DecidingFactor::TraitOnSelf(*t)));
+        }
+    }
+    for t in target_traits {
+        let a = t.alliance_affinity();
+        if a > 1.0 {
+            candidates.push((a, DecidingFactor::TraitOnTarget(*t)));
+        }
+    }
+    candidates.sort_by(|(a, df_a), (b, df_b)| {
+        b.partial_cmp(a)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| df_a.label().cmp(df_b.label()))
+    });
+    candidates.into_iter().next().map(|(_, df)| df)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,5 +251,37 @@ mod tests {
         let a = roll_chance(&[Trait::Friendly], &[Trait::Loyal], true, 0, 0);
         let b = roll_chance(&[Trait::Loyal], &[Trait::Friendly], true, 0, 0);
         assert!((a - b).abs() < 1e-9);
+    }
+
+    // ---- Task 2.4: deciding_factor ---------------------------------------
+
+    #[test]
+    fn deciding_factor_picks_largest_above_one() {
+        let f = deciding_factor(&[Trait::Friendly], &[Trait::Loyal], true);
+        assert!(f.is_some());
+    }
+
+    #[test]
+    fn deciding_factor_none_when_nothing_exceeds_one() {
+        let f = deciding_factor(&[], &[], false);
+        assert!(f.is_none());
+    }
+
+    #[test]
+    fn deciding_factor_friendly_beats_loyal() {
+        // Friendly 1.5 > Loyal 1.4. Without same_district, only the trait
+        // candidates are in play; Friendly wins.
+        let f = deciding_factor(&[Trait::Friendly], &[Trait::Loyal], false);
+        match f {
+            Some(DecidingFactor::TraitOnSelf(Trait::Friendly)) => {}
+            other => panic!("expected TraitOnSelf(Friendly), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deciding_factor_neutral_only_loses_to_district() {
+        // No trait > 1.0, but same_district adds 1.5 → SameDistrict wins.
+        let f = deciding_factor(&[Trait::Tough], &[Trait::Tough], true);
+        assert_eq!(f, Some(DecidingFactor::SameDistrict));
     }
 }

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -7,6 +7,8 @@
 
 use uuid::Uuid;
 
+use crate::tributes::traits::{REFUSERS, Trait};
+
 /// Per-tribute hard cap on direct alliances.
 pub const MAX_ALLIES: usize = 5;
 /// Base chance per encounter that two tributes form an alliance.
@@ -25,6 +27,16 @@ pub enum AllianceEvent {
         deceased: Uuid,
         killer: Option<Uuid>,
     },
+}
+
+/// Refuser gate per spec §6.1. Two tributes pass the gate if either both
+/// have at least one positive-affinity trait, or neither has any refuser
+/// trait. Empty trait sets pass (no refusers).
+pub fn passes_gate(self_traits: &[Trait], target_traits: &[Trait]) -> bool {
+    let has_positive = |ts: &[Trait]| ts.iter().any(|x| x.alliance_affinity() >= 1.0);
+    let has_refuser = |ts: &[Trait]| ts.iter().any(|x| REFUSERS.contains(x));
+    (has_positive(self_traits) && has_positive(target_traits))
+        || (!has_refuser(self_traits) && !has_refuser(target_traits))
 }
 
 #[cfg(test)]
@@ -70,5 +82,39 @@ mod tests {
         assert_eq!(MAX_ALLIES, 5);
         assert!((BASE_ALLIANCE_CHANCE - 0.20).abs() < f64::EPSILON);
         assert_eq!(TREACHEROUS_BETRAYAL_INTERVAL, 5);
+    }
+
+    #[test]
+    fn paranoid_vs_paranoid_blocked() {
+        assert!(!passes_gate(&[Trait::Paranoid], &[Trait::Paranoid]));
+    }
+
+    #[test]
+    fn lonewolf_vs_friendly_blocked() {
+        // LoneWolf affinity 0.6 (no positive) and is a refuser; Friendly is
+        // 1.5. (positive AND positive) is false; (no_refuser AND no_refuser)
+        // is false because LoneWolf is a refuser. Gate blocks.
+        assert!(!passes_gate(&[Trait::LoneWolf], &[Trait::Friendly]));
+    }
+
+    #[test]
+    fn snake_in_grass_passes_gate() {
+        // [Friendly, Paranoid] paired with [Loyal]: both sides have a
+        // positive-affinity trait, so the first clause holds.
+        assert!(passes_gate(
+            &[Trait::Friendly, Trait::Paranoid],
+            &[Trait::Loyal],
+        ));
+    }
+
+    #[test]
+    fn empty_traits_pass_gate() {
+        assert!(passes_gate(&[], &[]));
+    }
+
+    #[test]
+    fn neutral_pair_passes_gate() {
+        // Tough has affinity 1.0 and is not a refuser; both clauses hold.
+        assert!(passes_gate(&[Trait::Tough], &[Trait::Tough]));
     }
 }

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -9,15 +9,6 @@ use serde::{Deserialize, Serialize};
 const LOW_ENEMY_LIMIT: u32 = 6;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum BrainPersonality {
-    Aggressive,
-    Defensive,
-    Balanced,
-    Cautious,
-    Reckless,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum PsychoticBreakType {
     Berserk,         // Attack anyone nearby
     Paranoid,        // Flee and hide constantly
@@ -103,166 +94,8 @@ impl PersonalityThresholds {
     }
 }
 
-impl BrainPersonality {
-    pub fn random(rng: &mut impl Rng) -> Self {
-        match rng.random_range(0..5) {
-            0 => BrainPersonality::Aggressive,
-            1 => BrainPersonality::Defensive,
-            2 => BrainPersonality::Balanced,
-            3 => BrainPersonality::Cautious,
-            _ => BrainPersonality::Reckless,
-        }
-    }
-
-    /// Generate thresholds with ±20% variance for individual differences
-    pub fn generate_thresholds(&self, rng: &mut impl Rng) -> PersonalityThresholds {
-        fn apply_variance(base: u32, rng: &mut impl Rng) -> u32 {
-            let variance = rng.random_range(-0.2..=0.2);
-            ((base as f32) * (1.0 + variance)).max(1.0) as u32
-        }
-
-        // Base values per personality
-        let (base_low_health, base_mid_health) = match self {
-            BrainPersonality::Aggressive => (15, 30),
-            BrainPersonality::Defensive => (30, 50),
-            BrainPersonality::Balanced => (20, 40),
-            BrainPersonality::Cautious => (35, 55),
-            BrainPersonality::Reckless => (10, 25),
-        };
-
-        let (base_extreme_low_sanity, base_low_sanity, base_mid_sanity) = match self {
-            BrainPersonality::Aggressive => (8, 15, 25),
-            BrainPersonality::Defensive => (15, 25, 45),
-            BrainPersonality::Balanced => (10, 20, 35),
-            BrainPersonality::Cautious => (18, 30, 50),
-            BrainPersonality::Reckless => (5, 10, 20),
-        };
-
-        let base_low_movement = match self {
-            BrainPersonality::Aggressive => 8,
-            BrainPersonality::Defensive => 15,
-            BrainPersonality::Balanced => 10,
-            BrainPersonality::Cautious => 18,
-            BrainPersonality::Reckless => 5,
-        };
-
-        let (base_high_intelligence, base_low_intelligence) = match self {
-            BrainPersonality::Aggressive => (30, 75),
-            BrainPersonality::Defensive => (40, 85),
-            BrainPersonality::Balanced => (35, 80),
-            BrainPersonality::Cautious => (45, 90),
-            BrainPersonality::Reckless => (25, 70),
-        };
-
-        // Psychotic break threshold varies by personality
-        // Reckless/Aggressive more prone (higher threshold = breaks sooner)
-        // Cautious/Defensive more resilient (lower threshold = breaks later)
-        let base_break_threshold = match self {
-            BrainPersonality::Reckless => 12, // Breaks easily
-            BrainPersonality::Aggressive => 10,
-            BrainPersonality::Balanced => 8,
-            BrainPersonality::Defensive => 6,
-            BrainPersonality::Cautious => 5, // Very resilient
-        };
-
-        PersonalityThresholds {
-            low_health: apply_variance(base_low_health, rng),
-            mid_health: apply_variance(base_mid_health, rng),
-            extreme_low_sanity: apply_variance(base_extreme_low_sanity, rng),
-            low_sanity: apply_variance(base_low_sanity, rng),
-            mid_sanity: apply_variance(base_mid_sanity, rng),
-            low_movement: apply_variance(base_low_movement, rng),
-            high_intelligence: apply_variance(base_high_intelligence, rng),
-            low_intelligence: apply_variance(base_low_intelligence, rng),
-            psychotic_break_threshold: apply_variance(base_break_threshold, rng),
-        }
-    }
-
-    // Keep original methods for backward compatibility/reference
-    pub fn low_health_limit(&self) -> u32 {
-        match self {
-            BrainPersonality::Aggressive => 15,
-            BrainPersonality::Defensive => 30,
-            BrainPersonality::Balanced => 20,
-            BrainPersonality::Cautious => 35,
-            BrainPersonality::Reckless => 10,
-        }
-    }
-
-    pub fn mid_health_limit(&self) -> u32 {
-        match self {
-            BrainPersonality::Aggressive => 30,
-            BrainPersonality::Defensive => 50,
-            BrainPersonality::Balanced => 40,
-            BrainPersonality::Cautious => 55,
-            BrainPersonality::Reckless => 25,
-        }
-    }
-
-    pub fn extreme_low_sanity_limit(&self) -> u32 {
-        match self {
-            BrainPersonality::Aggressive => 8,
-            BrainPersonality::Defensive => 15,
-            BrainPersonality::Balanced => 10,
-            BrainPersonality::Cautious => 18,
-            BrainPersonality::Reckless => 5,
-        }
-    }
-
-    pub fn low_sanity_limit(&self) -> u32 {
-        match self {
-            BrainPersonality::Aggressive => 15,
-            BrainPersonality::Defensive => 25,
-            BrainPersonality::Balanced => 20,
-            BrainPersonality::Cautious => 30,
-            BrainPersonality::Reckless => 10,
-        }
-    }
-
-    pub fn mid_sanity_limit(&self) -> u32 {
-        match self {
-            BrainPersonality::Aggressive => 25,
-            BrainPersonality::Defensive => 45,
-            BrainPersonality::Balanced => 35,
-            BrainPersonality::Cautious => 50,
-            BrainPersonality::Reckless => 20,
-        }
-    }
-
-    pub fn low_movement_limit(&self) -> u32 {
-        match self {
-            BrainPersonality::Aggressive => 8,
-            BrainPersonality::Defensive => 15,
-            BrainPersonality::Balanced => 10,
-            BrainPersonality::Cautious => 18,
-            BrainPersonality::Reckless => 5,
-        }
-    }
-
-    pub fn high_intelligence_limit(&self) -> u32 {
-        match self {
-            BrainPersonality::Aggressive => 30,
-            BrainPersonality::Defensive => 40,
-            BrainPersonality::Balanced => 35,
-            BrainPersonality::Cautious => 45,
-            BrainPersonality::Reckless => 25,
-        }
-    }
-
-    pub fn low_intelligence_limit(&self) -> u32 {
-        match self {
-            BrainPersonality::Aggressive => 75,
-            BrainPersonality::Defensive => 85,
-            BrainPersonality::Balanced => 80,
-            BrainPersonality::Cautious => 90,
-            BrainPersonality::Reckless => 70,
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Brain {
-    pub personality: BrainPersonality,
     pub thresholds: PersonalityThresholds,
     pub psychotic_break: Option<PsychoticBreakType>,
     pub preferred_action: Option<Action>,
@@ -274,8 +107,7 @@ impl Default for Brain {
         use rand::SeedableRng;
         let mut rng = rand::rngs::SmallRng::seed_from_u64(0); // Deterministic default
         Self {
-            personality: BrainPersonality::Balanced,
-            thresholds: BrainPersonality::Balanced.generate_thresholds(&mut rng),
+            thresholds: PersonalityThresholds::from_traits(&[], &mut rng),
             psychotic_break: None,
             preferred_action: None,
             preferred_action_percentage: 0.0,
@@ -284,24 +116,9 @@ impl Default for Brain {
 }
 
 impl Brain {
-    pub fn new_with_random_personality(rng: &mut impl Rng) -> Self {
-        let personality = BrainPersonality::random(rng);
-        let thresholds = personality.generate_thresholds(rng);
-        Self {
-            personality,
-            thresholds,
-            psychotic_break: None,
-            preferred_action: None,
-            preferred_action_percentage: 0.0,
-        }
-    }
-
     /// Build a brain whose thresholds are derived from a tribute's traits.
-    /// `personality` is set to `Balanced` as a placeholder until the
-    /// `BrainPersonality` enum is removed; thresholds are the load-bearing field.
     pub fn from_traits(traits: &[Trait], rng: &mut impl Rng) -> Self {
         Self {
-            personality: BrainPersonality::Balanced,
             thresholds: PersonalityThresholds::from_traits(traits, rng),
             psychotic_break: None,
             preferred_action: None,
@@ -968,113 +785,6 @@ mod tests {
         tribute.attributes.sanity = 0;
         let action = tribute.brain.act(&tribute.clone(), 6, &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
-    }
-
-    #[test]
-    fn test_personality_thresholds_aggressive() {
-        let personality = BrainPersonality::Aggressive;
-        assert_eq!(personality.low_health_limit(), 15);
-        assert_eq!(personality.mid_health_limit(), 30);
-        assert!(personality.low_health_limit() < BrainPersonality::Balanced.low_health_limit());
-    }
-
-    #[test]
-    fn test_personality_thresholds_defensive() {
-        let personality = BrainPersonality::Defensive;
-        assert_eq!(personality.low_health_limit(), 30);
-        assert_eq!(personality.mid_health_limit(), 50);
-        assert!(personality.low_health_limit() > BrainPersonality::Balanced.low_health_limit());
-    }
-
-    #[test]
-    fn test_personality_thresholds_reckless() {
-        let personality = BrainPersonality::Reckless;
-        assert_eq!(personality.low_health_limit(), 10);
-        assert!(personality.low_health_limit() < BrainPersonality::Aggressive.low_health_limit());
-    }
-
-    #[test]
-    fn test_personality_thresholds_cautious() {
-        let personality = BrainPersonality::Cautious;
-        assert_eq!(personality.low_health_limit(), 35);
-        assert!(personality.low_health_limit() > BrainPersonality::Defensive.low_health_limit());
-    }
-
-    #[test]
-    fn test_personality_random_distribution() {
-        let mut rng = SmallRng::seed_from_u64(42);
-        let mut counts = std::collections::HashMap::new();
-
-        for _ in 0..100 {
-            let personality = BrainPersonality::random(&mut rng);
-            *counts.entry(format!("{:?}", personality)).or_insert(0) += 1;
-        }
-
-        // Should have all 5 personality types
-        assert_eq!(counts.len(), 5);
-        // Each should appear at least once (with high probability)
-        for count in counts.values() {
-            assert!(*count > 0);
-        }
-    }
-
-    #[rstest]
-    fn test_aggressive_fights_at_lower_health(mut small_rng: SmallRng) {
-        let mut tribute = Tribute::default();
-        tribute.brain.personality = BrainPersonality::Aggressive;
-        tribute.attributes.health = 18; // Between aggressive (15) and balanced (20)
-        tribute.attributes.sanity = 40;
-
-        let action = tribute.brain.act(&tribute.clone(), 1, &[], &mut small_rng);
-        // Aggressive should still attack/move at this health
-        assert!(matches!(action, Action::Attack | Action::Move(_)));
-    }
-
-    #[rstest]
-    fn test_defensive_retreats_earlier(_small_rng: SmallRng) {
-        let mut tribute = Tribute::default();
-        tribute.brain.personality = BrainPersonality::Defensive;
-        // Regenerate thresholds for the new personality (otherwise stale
-        // thresholds from random construction are used). Seed=0 gives
-        // Defensive low_health ~28-32, mid_health ~45-55.
-        tribute.brain.thresholds =
-            BrainPersonality::Defensive.generate_thresholds(&mut SmallRng::seed_from_u64(0));
-        tribute.attributes.health = 25; // Below defensive low_health
-        // Sanity must be safely above Defensive mid_sanity (base 45, +20%
-        // variance ceiling = 54) so the visible/ok-sanity arm of
-        // decide_action_few_enemies_low_health returns Move, not Attack.
-        tribute.attributes.sanity = 60;
-
-        let action = tribute.brain.decide_action_few_enemies(&tribute);
-        // Defensive should prefer moving/hiding at this health
-        assert!(matches!(action, Action::Move(_) | Action::Hide));
-    }
-
-    #[rstest]
-    fn test_threshold_variance_within_range(mut small_rng: SmallRng) {
-        let personality = BrainPersonality::Balanced;
-        let thresholds = personality.generate_thresholds(&mut small_rng);
-
-        // Base value for Balanced is 20, variance is ±20% = 16-24
-        assert!(thresholds.low_health >= 16 && thresholds.low_health <= 24);
-        // Base value for Balanced is 40, variance is ±20% = 32-48
-        assert!(thresholds.mid_health >= 32 && thresholds.mid_health <= 48);
-    }
-
-    #[rstest]
-    fn test_threshold_variance_differs_between_tributes(mut small_rng: SmallRng) {
-        let personality = BrainPersonality::Balanced;
-        let thresholds1 = personality.generate_thresholds(&mut small_rng);
-        let thresholds2 = personality.generate_thresholds(&mut small_rng);
-
-        // With high probability, at least one threshold should differ
-        // (not guaranteed due to randomness, but very likely)
-        let differs = thresholds1.low_health != thresholds2.low_health
-            || thresholds1.mid_health != thresholds2.mid_health
-            || thresholds1.low_sanity != thresholds2.low_sanity;
-
-        // This test may occasionally fail due to random chance, but is very unlikely
-        assert!(differs);
     }
 
     #[rstest]

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -2,6 +2,7 @@ use crate::areas::{Area, AreaDetails};
 use crate::terrain::{BaseTerrain, Harshness, TerrainType, Visibility};
 use crate::tributes::Tribute;
 use crate::tributes::actions::Action;
+use crate::tributes::traits::{ThresholdDelta, Trait};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -36,6 +37,70 @@ pub struct PersonalityThresholds {
     pub high_intelligence: u32,
     pub low_intelligence: u32,
     pub psychotic_break_threshold: u32, // Sanity level that triggers break
+}
+
+impl PersonalityThresholds {
+    /// Derive thresholds from a tribute's traits. Sums each trait's
+    /// `ThresholdDelta`, applies it to baseline values, then applies ±20%
+    /// individual variance. Each field is clamped to at least 1.
+    ///
+    /// Field mapping from `ThresholdDelta` to `PersonalityThresholds`:
+    /// - `low_health_limit`        → `low_health`
+    /// - `mid_health_limit`        → `mid_health`
+    /// - `low_sanity_limit`        → `extreme_low_sanity`
+    /// - `mid_sanity_limit`        → `low_sanity`
+    /// - `high_sanity_limit`       → `mid_sanity`
+    /// - `movement_limit`          → `low_movement`
+    /// - `high_intelligence_limit` → `high_intelligence`
+    /// - `low_intelligence_limit`  → `low_intelligence`
+    /// - `psychotic_break_threshold` → `psychotic_break_threshold`
+    pub fn from_traits(traits: &[Trait], rng: &mut impl Rng) -> Self {
+        fn apply_variance(base: i32, rng: &mut impl Rng) -> u32 {
+            let variance = rng.random_range(-0.2_f32..=0.2_f32);
+            ((base as f32) * (1.0 + variance)).max(1.0) as u32
+        }
+
+        fn apply_delta(base: i32, delta: i32) -> i32 {
+            (base + delta).max(1)
+        }
+
+        // Baseline values match the original `Balanced` personality.
+        let base_low_health: i32 = 20;
+        let base_mid_health: i32 = 40;
+        let base_extreme_low_sanity: i32 = 10;
+        let base_low_sanity: i32 = 20;
+        let base_mid_sanity: i32 = 35;
+        let base_low_movement: i32 = 10;
+        let base_high_intelligence: i32 = 35;
+        let base_low_intelligence: i32 = 80;
+        let base_break_threshold: i32 = 8;
+
+        let delta: ThresholdDelta = traits.iter().map(|t| t.threshold_modifiers()).sum();
+
+        PersonalityThresholds {
+            low_health: apply_variance(apply_delta(base_low_health, delta.low_health_limit), rng),
+            mid_health: apply_variance(apply_delta(base_mid_health, delta.mid_health_limit), rng),
+            extreme_low_sanity: apply_variance(
+                apply_delta(base_extreme_low_sanity, delta.low_sanity_limit),
+                rng,
+            ),
+            low_sanity: apply_variance(apply_delta(base_low_sanity, delta.mid_sanity_limit), rng),
+            mid_sanity: apply_variance(apply_delta(base_mid_sanity, delta.high_sanity_limit), rng),
+            low_movement: apply_variance(apply_delta(base_low_movement, delta.movement_limit), rng),
+            high_intelligence: apply_variance(
+                apply_delta(base_high_intelligence, delta.high_intelligence_limit),
+                rng,
+            ),
+            low_intelligence: apply_variance(
+                apply_delta(base_low_intelligence, delta.low_intelligence_limit),
+                rng,
+            ),
+            psychotic_break_threshold: apply_variance(
+                apply_delta(base_break_threshold, delta.psychotic_break_threshold),
+                rng,
+            ),
+        }
+    }
 }
 
 impl BrainPersonality {
@@ -1106,5 +1171,57 @@ mod tests {
         let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
         // Self-destructive ignores health and attacks
         assert_eq!(action, Action::Attack);
+    }
+
+    #[rstest]
+    fn from_traits_empty_uses_balanced_baseline() {
+        // With no traits and zero variance, thresholds collapse to the
+        // documented baseline values (the original `Balanced` numbers).
+        let mut rng = SmallRng::seed_from_u64(101);
+        let thresholds = PersonalityThresholds::from_traits(&[], &mut rng);
+        // Each base ±20% — assert each lies in the expected window.
+        assert!(
+            (16..=24).contains(&thresholds.low_health),
+            "low_health={}",
+            thresholds.low_health
+        );
+        assert!((32..=48).contains(&thresholds.mid_health));
+        assert!((8..=12).contains(&thresholds.extreme_low_sanity));
+        assert!((16..=24).contains(&thresholds.low_sanity));
+        assert!((28..=42).contains(&thresholds.mid_sanity));
+        assert!((8..=12).contains(&thresholds.low_movement));
+        assert!((28..=42).contains(&thresholds.high_intelligence));
+        assert!((64..=96).contains(&thresholds.low_intelligence));
+        assert!((6..=10).contains(&thresholds.psychotic_break_threshold));
+    }
+
+    #[rstest]
+    fn from_traits_aggressive_lowers_health_thresholds() {
+        // Aggressive: low_health -5 (→15), mid_health -10 (→30) before variance.
+        // Use many seeds and check the mean is shifted below baseline.
+        let aggressive = vec![Trait::Aggressive];
+        let mut total_low: u32 = 0;
+        let mut total_mid: u32 = 0;
+        for seed in 0..50 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let t = PersonalityThresholds::from_traits(&aggressive, &mut rng);
+            total_low += t.low_health;
+            total_mid += t.mid_health;
+        }
+        // Mean low_health ≈ 15, mean mid_health ≈ 30.
+        let mean_low = total_low / 50;
+        let mean_mid = total_mid / 50;
+        assert!((12..=18).contains(&mean_low), "mean_low={}", mean_low);
+        assert!((25..=35).contains(&mean_mid), "mean_mid={}", mean_mid);
+    }
+
+    #[rstest]
+    fn from_traits_clamps_to_minimum_one() {
+        // Stack many sanity-lowering traits to push past the clamp boundary.
+        let traits = vec![Trait::Reckless, Trait::Aggressive];
+        let mut rng = SmallRng::seed_from_u64(17);
+        let t = PersonalityThresholds::from_traits(&traits, &mut rng);
+        assert!(t.extreme_low_sanity >= 1);
+        assert!(t.low_health >= 1);
     }
 }

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -296,6 +296,19 @@ impl Brain {
         }
     }
 
+    /// Build a brain whose thresholds are derived from a tribute's traits.
+    /// `personality` is set to `Balanced` as a placeholder until the
+    /// `BrainPersonality` enum is removed; thresholds are the load-bearing field.
+    pub fn from_traits(traits: &[Trait], rng: &mut impl Rng) -> Self {
+        Self {
+            personality: BrainPersonality::Balanced,
+            thresholds: PersonalityThresholds::from_traits(traits, rng),
+            psychotic_break: None,
+            preferred_action: None,
+            preferred_action_percentage: 0.0,
+        }
+    }
+
     /// Check if tribute should have a psychotic break
     ///
     /// Break type is randomly determined, not tied to personality.

--- a/game/src/tributes/codemap.md
+++ b/game/src/tributes/codemap.md
@@ -339,7 +339,7 @@ Brain::act()
 - `calculate_violence_stress()`: Stress from combat (lines 1079-1109)
 - `travels()`: Movement logic with area validation (lines 457-548)
 - `process_status()`: Apply status effect damage (lines 552-616)
-- `pick_target()`: Target selection with loyalty/betrayal (lines 949-1018)
+- `pick_target()`: Target selection with alliance filter (lines 416-450)
 - 26 damage/reduction constants (lines 24-57)
 - 12 max attribute values (lines 60-71)
 - 60+ test functions

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -30,7 +30,6 @@ use uuid::Uuid;
 
 /// Consts
 const SANITY_BREAK_LEVEL: u32 = 9;
-const LOYALTY_BREAK_LEVEL: f64 = 0.25;
 
 #[derive(Clone, Debug)]
 pub struct ActionSuggestion {
@@ -478,8 +477,6 @@ pub struct Attributes {
     pub defense: u32,
     /// Will they jump into dangerous situations?
     pub bravery: u32,
-    /// Are they a backstabber?
-    pub loyalty: u32,
     /// How well do they avoid traps?
     pub intelligence: u32,
     /// Can they talk their way out of, or into, things?
@@ -500,7 +497,6 @@ impl Default for Attributes {
             strength: 50,
             defense: 50,
             bravery: 100,
-            loyalty: 100,
             intelligence: 100,
             persuasion: 100,
             luck: 100,
@@ -522,7 +518,6 @@ impl Attributes {
             strength: rng.random_range(1..=config.max_strength),
             defense: rng.random_range(1..=config.max_defense),
             bravery: rng.random_range(1..=config.max_bravery),
-            loyalty: rng.random_range(1..=config.max_loyalty),
             intelligence: rng.random_range(1..=config.max_intelligence),
             persuasion: rng.random_range(1..=config.max_persuasion),
             luck: rng.random_range(1..=config.max_luck),

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -352,14 +352,17 @@ impl Tribute {
     }
 
     /// Pick an appropriate target from nearby tributes prioritizing targets as follows:
-    /// (for this function, "nearby" means in the same area and "ally" means
-    /// from the same district)
-    /// 1. If there are enemy tributes nearby, target them.
-    /// 2. If there are no enemies and the tribute is feeling suicidal, target self.
-    /// 3. If there are no enemies nearby, but they exist elsewhere, target no one.
-    /// 4. If there are no enemies nearby and no enemies left in the game:
-    ///    a. If loyalty is low, target ally.
-    ///    b. Otherwise, target no one.
+    /// Pick a target tribute from `targets` to attack, given the number of
+    /// living tributes in the game.
+    ///
+    /// Selection rules:
+    /// 1. If there are no targets and the tribute is suicidal (very low sanity),
+    ///    target self.
+    /// 2. Otherwise, filter out current allies — they are off-limits regardless
+    ///    of district.
+    /// 3. If any non-allies remain, pick one at random.
+    /// 4. If only allies are nearby (and we're not the last two alive), pick no
+    ///    target. Final confrontation (only two alive) overrides alliance.
     fn pick_target(
         &self,
         mut targets: Vec<Tribute>,
@@ -368,48 +371,32 @@ impl Tribute {
     ) -> Option<Tribute> {
         // If there are no targets, check if the tribute is feeling suicidal.
         if targets.is_empty() {
-            match self.attributes.sanity {
+            return match self.attributes.sanity {
                 0..=SANITY_BREAK_LEVEL => {
                     // attempt suicide
                     events.push(GameOutput::TributeSuicide(self.name.as_str()).to_string());
                     Some(self.clone())
                 }
                 _ => None, // Attack no one
-            }
-        } else {
-            let enemies: Vec<Tribute> = targets
-                .iter()
-                .filter(|t| t.district != self.district)
-                .cloned()
-                .collect();
-
-            match enemies.len() {
-                0 => {
-                    // No enemies, check for a "friend"
-                    // If there are two of us in the area
-                    if targets.len() == 1 {
-                        let target = targets.pop().unwrap();
-                        // And we're the only two left in the game
-                        if living_tributes_count == 2 {
-                            // Kill the other tribute (final confrontation)
-                            Some(target)
-                        } else if (self.attributes.loyalty as f64 / 100.0) < LOYALTY_BREAK_LEVEL {
-                            // ...or they're unloyal (betrayal)
-                            Some(target)
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                }
-                _ => {
-                    // If there are enemies
-                    let mut rng = SmallRng::from_rng(&mut rand::rng());
-                    Some(enemies.choose(&mut rng).unwrap().clone())
-                }
-            }
+            };
         }
+
+        let enemies: Vec<Tribute> = targets
+            .iter()
+            .filter(|t| !self.allies.contains(&t.id))
+            .cloned()
+            .collect();
+
+        if enemies.is_empty() {
+            // Only allies in range. Final confrontation overrides loyalty.
+            if targets.len() == 1 && living_tributes_count == 2 {
+                return Some(targets.pop().unwrap());
+            }
+            return None;
+        }
+
+        let mut rng = SmallRng::from_rng(&mut rand::rng());
+        Some(enemies.choose(&mut rng).unwrap().clone())
     }
 }
 
@@ -607,5 +594,45 @@ mod tests {
         let tribute = Tribute::new("Katniss".to_string(), Some(12), None);
         // generate_traits rolls 2..=6 traits from the district pool.
         assert!((2..=6).contains(&tribute.traits.len()));
+    }
+
+    #[rstest]
+    fn pick_target_skips_allies() {
+        // An ally is in the same area but must not be picked as a target.
+        let mut me = Tribute::new("Katniss".to_string(), Some(12), None);
+        me.attributes.sanity = 100; // not suicidal
+        let ally = Tribute::new("Peeta".to_string(), Some(12), None);
+        me.allies.push(ally.id);
+
+        let mut events: Vec<String> = vec![];
+        let target = me.pick_target(vec![ally.clone()], 5, &mut events);
+        // Only candidate was an ally and we're not in final confrontation.
+        assert!(target.is_none());
+    }
+
+    #[rstest]
+    fn pick_target_allows_same_district_when_not_ally() {
+        // Same-district tributes can now be targeted unless they're allies.
+        let me = Tribute::new("Katniss".to_string(), Some(12), None);
+        let same_district = Tribute::new("Peeta".to_string(), Some(12), None);
+
+        let mut events: Vec<String> = vec![];
+        let target = me.pick_target(vec![same_district.clone()], 5, &mut events);
+        assert!(target.is_some());
+        assert_eq!(target.unwrap().id, same_district.id);
+    }
+
+    #[rstest]
+    fn pick_target_final_confrontation_overrides_alliance() {
+        // When only two tributes remain alive, even an ally is a valid target.
+        let mut me = Tribute::new("Katniss".to_string(), Some(12), None);
+        me.attributes.sanity = 100;
+        let ally = Tribute::new("Peeta".to_string(), Some(12), None);
+        me.allies.push(ally.id);
+
+        let mut events: Vec<String> = vec![];
+        let target = me.pick_target(vec![ally.clone()], 2, &mut events);
+        assert!(target.is_some());
+        assert_eq!(target.unwrap().id, ally.id);
     }
 }

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -208,6 +208,11 @@ impl Tribute {
             return;
         }
 
+        // Advance per-tribute alliance timers (spec §7.4). Ticks
+        // turns_since_last_betrayal so Treacherous tributes can betray on
+        // cadence. Skipped for dead tributes via `is_alive` guard above.
+        self.tick_alliance_timers();
+
         // Consume any pending trust-shock from a betrayal recorded last turn
         // (spec §7.3c1). Rolls per ally; broken allies are removed locally.
         self.consume_pending_trust_shock(rng, events);
@@ -420,6 +425,20 @@ impl Tribute {
     /// tribute acts. See spec §7.5.
     pub fn drain_alliance_events(&mut self) -> Vec<alliances::AllianceEvent> {
         std::mem::take(&mut self.alliance_events)
+    }
+
+    /// Advance per-tribute alliance bookkeeping for one turn (spec §7.4).
+    ///
+    /// Ticks `turns_since_last_betrayal`, which gates Treacherous-trait
+    /// betrayals to fire at most every
+    /// [`alliances::TREACHEROUS_BETRAYAL_INTERVAL`] turns. Saturates at
+    /// `u8::MAX` so a long-lived tribute never overflows or wraps back
+    /// through the betrayal trigger. Dead tributes are skipped.
+    pub fn tick_alliance_timers(&mut self) {
+        if !self.is_alive() {
+            return;
+        }
+        self.turns_since_last_betrayal = self.turns_since_last_betrayal.saturating_add(1);
     }
 
     /// Consume a pending trust-shock flag (set when this tribute was the
@@ -818,5 +837,35 @@ mod tests {
         let target = me.pick_target(vec![ally.clone()], 2, &mut events);
         assert!(target.is_some());
         assert_eq!(target.unwrap().id, ally.id);
+    }
+
+    #[rstest]
+    fn tick_alliance_timers_increments_betrayal_counter() {
+        // Living tribute: counter increments by exactly one per tick.
+        let mut tribute = Tribute::new("Cinna".to_string(), Some(1), None);
+        assert_eq!(tribute.turns_since_last_betrayal, 0);
+        tribute.tick_alliance_timers();
+        assert_eq!(tribute.turns_since_last_betrayal, 1);
+        tribute.tick_alliance_timers();
+        assert_eq!(tribute.turns_since_last_betrayal, 2);
+    }
+
+    #[rstest]
+    fn tick_alliance_timers_saturates_does_not_overflow() {
+        // u8 saturating add: never panics, never wraps to zero.
+        let mut tribute = Tribute::new("Cinna".to_string(), Some(1), None);
+        tribute.turns_since_last_betrayal = u8::MAX;
+        tribute.tick_alliance_timers();
+        assert_eq!(tribute.turns_since_last_betrayal, u8::MAX);
+    }
+
+    #[rstest]
+    fn tick_alliance_timers_skips_dead_tributes() {
+        // Dead tributes don't accumulate betrayal cooldown.
+        let mut tribute = Tribute::new("Cinna".to_string(), Some(1), None);
+        tribute.attributes.health = 0;
+        tribute.status = crate::tributes::TributeStatus::RecentlyDead;
+        tribute.tick_alliance_timers();
+        assert_eq!(tribute.turns_since_last_betrayal, 0);
     }
 }

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -57,6 +57,10 @@ pub struct EncounterContext {
 pub struct Tribute {
     /// Identifier
     pub identifier: String,
+    /// Stable typed UUID. Mirrors `identifier` for callers that want a
+    /// non-stringly-typed key (alliance graph, betrayal events).
+    #[serde(default = "Uuid::new_v4")]
+    pub id: Uuid,
     /// Where are they?
     pub area: Area,
     /// What is their current status?
@@ -92,6 +96,17 @@ pub struct Tribute {
     pub stamina: u32,
     /// Maximum stamina capacity
     pub max_stamina: u32,
+    /// Personality/behavior trait set. Replaces `BrainPersonality`.
+    /// A tribute with zero traits behaves as the old `Balanced` baseline.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub traits: Vec<traits::Trait>,
+    /// Pair-wise alliance graph. Symmetric: when A allies with B, both
+    /// `allies` lists gain the other. Capped at `MAX_ALLIES`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allies: Vec<Uuid>,
+    /// Turn counter for the Treacherous betrayal cadence. Reset on betrayal.
+    #[serde(default)]
+    pub turns_since_last_betrayal: u8,
 }
 
 impl Default for Tribute {
@@ -107,7 +122,8 @@ impl Tribute {
         let attributes = Attributes::new();
         let statistics = Statistics::default();
 
-        let id: String = Uuid::new_v4().to_string();
+        let id_uuid: Uuid = Uuid::new_v4();
+        let id: String = id_uuid.to_string();
 
         // Assign terrain affinity and personality based on district
         let mut rng = SmallRng::from_rng(&mut rand::rng());
@@ -120,6 +136,7 @@ impl Tribute {
 
         Self {
             identifier: id,
+            id: id_uuid,
             area: Area::Cornucopia,
             name: name.clone(),
             district,
@@ -135,6 +152,9 @@ impl Tribute {
             terrain_affinity,
             stamina: 100,
             max_stamina: 100,
+            traits: Vec::new(),
+            allies: Vec::new(),
+            turns_since_last_betrayal: 0,
         }
     }
 
@@ -570,5 +590,14 @@ mod tests {
         let tribute = Tribute::random();
         assert!(!tribute.name.is_empty());
         assert!(tribute.district >= 1 && tribute.district <= 12);
+    }
+
+    #[rstest]
+    fn new_tribute_has_empty_alliance_state() {
+        let tribute = Tribute::new("Cinna".to_string(), Some(1), None);
+        assert!(tribute.allies.is_empty());
+        assert_eq!(tribute.turns_since_last_betrayal, 0);
+        // `id` mirrors `identifier`.
+        assert_eq!(tribute.id.to_string(), tribute.identifier);
     }
 }

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -7,6 +7,7 @@ pub mod lifecycle;
 pub mod movement;
 pub mod statuses;
 pub mod traits;
+pub mod alliances;
 
 // Re-export key items from sub-modules
 pub use combat::{attack_contest, update_stats};

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -208,6 +208,10 @@ impl Tribute {
             return;
         }
 
+        // Consume any pending trust-shock from a betrayal recorded last turn
+        // (spec §7.3c1). Rolls per ally; broken allies are removed locally.
+        self.consume_pending_trust_shock(rng, events);
+
         let area_details = &mut environment_details.area_details;
 
         // Update the tribute based on the period's events.
@@ -417,6 +421,42 @@ impl Tribute {
     pub fn drain_alliance_events(&mut self) -> Vec<alliances::AllianceEvent> {
         std::mem::take(&mut self.alliance_events)
     }
+
+    /// Consume a pending trust-shock flag (set when this tribute was the
+    /// victim of a betrayal). For each current ally, roll
+    /// [`alliances::trust_shock_roll`]; on success drop that ally from this
+    /// tribute's `allies` list and emit a message. The flag is reset
+    /// unconditionally so it never carries past the turn it fires.
+    ///
+    /// Note: this only mutates `self`. The symmetric back-edge on the broken
+    /// ally's side is left to the next cycle's processing or to subsequent
+    /// alliance events; per Phase 4 of the implementation plan, full
+    /// symmetric cleanup is deferred. See spec §7.3c1.
+    pub fn consume_pending_trust_shock(
+        &mut self,
+        rng: &mut impl rand::Rng,
+        events: &mut Vec<String>,
+    ) {
+        if !self.pending_trust_shock {
+            return;
+        }
+        let limit = self.brain.thresholds.extreme_low_sanity;
+        let sanity = self.attributes.sanity;
+        let mut broken: Vec<Uuid> = Vec::new();
+        for ally_id in &self.allies {
+            if alliances::trust_shock_roll(sanity, limit, rng) {
+                broken.push(*ally_id);
+            }
+        }
+        for ally_id in &broken {
+            self.allies.retain(|x| x != ally_id);
+            events.push(format!(
+                "{} loses faith and breaks ties with ally {}.",
+                self.name, ally_id
+            ));
+        }
+        self.pending_trust_shock = false;
+    }
 }
 
 /// Calculates the stamina cost for a tribute action based on:
@@ -623,6 +663,61 @@ mod tests {
         let drained = tribute.drain_alliance_events();
         assert_eq!(drained.len(), 1);
         assert!(tribute.alliance_events.is_empty());
+    }
+
+    #[rstest]
+    fn consume_pending_trust_shock_resets_flag_when_not_set() {
+        // No flag → no rolls, flag stays false, allies untouched.
+        let mut tribute = Tribute::new("Cinna".to_string(), Some(1), None);
+        let ally = uuid::Uuid::new_v4();
+        tribute.allies.push(ally);
+        let mut events: Vec<String> = vec![];
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(53);
+        tribute.consume_pending_trust_shock(&mut rng, &mut events);
+        assert!(!tribute.pending_trust_shock);
+        assert_eq!(tribute.allies, vec![ally]);
+        assert!(events.is_empty());
+    }
+
+    #[rstest]
+    fn consume_pending_trust_shock_breaks_allies_on_success_and_clears_flag() {
+        // Force trust_shock to fire deterministically: sanity=0, threshold>0
+        // gives p = 0.5 + 0.5 * 1.0 = 1.0 → always true.
+        let mut tribute = Tribute::new("Cinna".to_string(), Some(1), None);
+        tribute.attributes.sanity = 0;
+        tribute.brain.thresholds.extreme_low_sanity = 50;
+        let ally1 = uuid::Uuid::new_v4();
+        let ally2 = uuid::Uuid::new_v4();
+        tribute.allies.push(ally1);
+        tribute.allies.push(ally2);
+        tribute.pending_trust_shock = true;
+
+        let mut events: Vec<String> = vec![];
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(211);
+        tribute.consume_pending_trust_shock(&mut rng, &mut events);
+
+        assert!(!tribute.pending_trust_shock, "flag must reset");
+        assert!(tribute.allies.is_empty(), "all allies broken on guaranteed success");
+        assert_eq!(events.len(), 2, "one message per broken ally");
+    }
+
+    #[rstest]
+    fn consume_pending_trust_shock_no_break_when_sanity_above_threshold() {
+        // Sanity at/above threshold → trust_shock_roll returns false → no break.
+        let mut tribute = Tribute::new("Cinna".to_string(), Some(1), None);
+        tribute.attributes.sanity = 100;
+        tribute.brain.thresholds.extreme_low_sanity = 50;
+        let ally = uuid::Uuid::new_v4();
+        tribute.allies.push(ally);
+        tribute.pending_trust_shock = true;
+
+        let mut events: Vec<String> = vec![];
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(89);
+        tribute.consume_pending_trust_shock(&mut rng, &mut events);
+
+        assert!(!tribute.pending_trust_shock, "flag must reset");
+        assert_eq!(tribute.allies, vec![ally], "ally retained");
+        assert!(events.is_empty());
     }
 
     #[rstest]

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -1,4 +1,5 @@
 pub mod actions;
+pub mod alliances;
 pub mod brains;
 pub mod combat;
 pub mod events;
@@ -7,7 +8,6 @@ pub mod lifecycle;
 pub mod movement;
 pub mod statuses;
 pub mod traits;
-pub mod alliances;
 
 // Re-export key items from sub-modules
 pub use combat::{attack_contest, update_stats};

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -402,7 +402,6 @@ impl Tribute {
         }
     }
 
-    /// Pick an appropriate target from nearby tributes prioritizing targets as follows:
     /// Pick a target tribute from `targets` to attack, given the number of
     /// living tributes in the game.
     ///

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -6,6 +6,7 @@ pub mod inventory;
 pub mod lifecycle;
 pub mod movement;
 pub mod statuses;
+pub mod traits;
 
 // Re-export key items from sub-modules
 pub use combat::{attack_contest, update_stats};

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -228,6 +228,37 @@ impl Tribute {
             return;
         }
 
+        // Treacherous active betrayal (spec §7.4(b)). When the timer has
+        // elapsed and the tribute carries the Treacherous trait, attempt to
+        // betray a same-area ally. On success, drop the symmetric pair
+        // locally, enqueue BetrayalRecorded so the victim's `allies` is
+        // cleaned and `pending_trust_shock` flips on the next drain. The
+        // timer resets unconditionally so a missed opportunity does not
+        // stack (one chance per cadence).
+        if self.traits.contains(&traits::Trait::Treacherous)
+            && self.turns_since_last_betrayal >= alliances::TREACHEROUS_BETRAYAL_INTERVAL
+        {
+            let same_area_ally = encounter_context
+                .potential_targets
+                .iter()
+                .find(|t| self.allies.contains(&t.id) && t.is_alive())
+                .cloned();
+            if let Some(victim) = same_area_ally {
+                self.allies.retain(|id| id != &victim.id);
+                self.alliance_events
+                    .push(alliances::AllianceEvent::BetrayalRecorded {
+                        betrayer: self.id,
+                        victim: victim.id,
+                    });
+                events.push(format!(
+                    "{} betrays {} — true to their treacherous nature.",
+                    self.name, victim.name
+                ));
+            }
+            // Reset the timer whether or not an ally was available.
+            self.turns_since_last_betrayal = 0;
+        }
+
         // Any generous patrons this round?
         if let Some(gift) = self.receive_patron_gift(&mut *rng) {
             events.push(GameOutput::SponsorGift(self.name.as_str(), &gift).to_string());

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -616,6 +616,54 @@ mod tests {
     }
 
     #[rstest]
+    fn serde_roundtrip_alliance_fields() {
+        use crate::tributes::traits::Trait;
+        use uuid::Uuid;
+
+        let mut tribute = Tribute::new("Rue".to_string(), None, None);
+        let ally = Uuid::new_v4();
+        tribute.allies.push(ally);
+        tribute.traits.clear();
+        tribute.traits.push(Trait::Loyal);
+        tribute.traits.push(Trait::Treacherous);
+        tribute.turns_since_last_betrayal = 7;
+        tribute.pending_trust_shock = true;
+
+        let json = serde_json::to_string(&tribute).expect("serialize");
+        assert!(json.contains("\"allies\""));
+        assert!(json.contains("\"traits\""));
+        assert!(json.contains("\"Loyal\""));
+        assert!(json.contains("\"turns_since_last_betrayal\":7"));
+        assert!(json.contains("\"pending_trust_shock\":true"));
+
+        let restored: Tribute = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(restored.allies, vec![ally]);
+        assert_eq!(restored.traits, vec![Trait::Loyal, Trait::Treacherous]);
+        assert_eq!(restored.turns_since_last_betrayal, 7);
+        assert!(restored.pending_trust_shock);
+    }
+
+    #[rstest]
+    fn serde_defaults_for_missing_alliance_fields() {
+        // Persisted tribute records written before the alliance fields existed
+        // must still deserialize. Simulate this by serialising a fresh tribute,
+        // stripping the new fields, then round-tripping.
+        let baseline = Tribute::new("Legacy".to_string(), None, None);
+        let mut value: serde_json::Value = serde_json::to_value(&baseline).expect("to_value");
+        let obj = value.as_object_mut().expect("object");
+        obj.remove("allies");
+        obj.remove("traits");
+        obj.remove("turns_since_last_betrayal");
+        obj.remove("pending_trust_shock");
+
+        let restored: Tribute = serde_json::from_value(value).expect("legacy deserialize");
+        assert!(restored.allies.is_empty());
+        assert!(restored.traits.is_empty());
+        assert_eq!(restored.turns_since_last_betrayal, 0);
+        assert!(!restored.pending_trust_shock);
+    }
+
+    #[rstest]
     fn new() {
         let tribute = Tribute::new("Katniss".to_string(), Some(12), None);
         assert_eq!(tribute.name, "Katniss");

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -106,6 +106,11 @@ pub struct Tribute {
     /// Turn counter for the Treacherous betrayal cadence. Reset on betrayal.
     #[serde(default)]
     pub turns_since_last_betrayal: u8,
+    /// Set to `true` by the cycle drain when this tribute is the victim of a
+    /// betrayal. Consumed at the top of `process_turn_phase` on the victim's
+    /// next turn to drive the trust-shock cascade (spec §7.3c1).
+    #[serde(default)]
+    pub pending_trust_shock: bool,
 }
 
 impl Default for Tribute {
@@ -155,6 +160,7 @@ impl Tribute {
             traits,
             allies: Vec::new(),
             turns_since_last_betrayal: 0,
+            pending_trust_shock: false,
         }
     }
 
@@ -582,6 +588,12 @@ mod tests {
         assert_eq!(tribute.turns_since_last_betrayal, 0);
         // `id` mirrors `identifier`.
         assert_eq!(tribute.id.to_string(), tribute.identifier);
+    }
+
+    #[rstest]
+    fn new_tribute_has_no_pending_trust_shock() {
+        let tribute = Tribute::new("Cinna".to_string(), Some(1), None);
+        assert!(!tribute.pending_trust_shock);
     }
 
     #[rstest]

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -899,4 +899,65 @@ mod tests {
         tribute.tick_alliance_timers();
         assert_eq!(tribute.turns_since_last_betrayal, 0);
     }
+
+    #[rstest]
+    fn pick_target_picks_ex_ally_after_trust_shock_breaks_bond() {
+        // End-to-end break-then-attack (spec §7.3c1 + §7.5):
+        // Once a trust shock fires and removes the betrayer from the
+        // victim's `allies`, the victim's next `pick_target` call must
+        // consider that ex-ally a valid target.
+        let mut victim = Tribute::new("Glimmer".to_string(), Some(1), None);
+        victim.attributes.sanity = 100; // not suicidal
+        let ex_ally = Tribute::new("Cato".to_string(), Some(2), None);
+        // Pre-condition: bonded.
+        victim.allies.push(ex_ally.id);
+
+        // Simulate the bond breaking (what process_alliance_events does
+        // for BetrayalRecorded, plus what consume_pending_trust_shock
+        // does on the victim's side: drop the ex-ally locally).
+        victim.allies.retain(|id| *id != ex_ally.id);
+
+        let mut events: Vec<String> = vec![];
+        let target = victim.pick_target(vec![ex_ally.clone()], 5, &mut events);
+        assert!(
+            target.is_some(),
+            "ex-ally must be targetable after the bond breaks"
+        );
+        assert_eq!(target.unwrap().id, ex_ally.id);
+    }
+
+    #[rstest]
+    fn consume_pending_trust_shock_leaves_asymmetric_back_edge() {
+        // Spec §7.3c1 explicitly defers the symmetric back-edge cleanup
+        // for trust-shock breaks: only `self` is mutated. This regression
+        // test pins that contract so any future tightening is intentional.
+        let mut victim = Tribute::new("Glimmer".to_string(), Some(1), None);
+        victim.attributes.sanity = 0; // force a break
+        victim.brain.thresholds.extreme_low_sanity = 100;
+        let betrayer_id = uuid::Uuid::new_v4();
+        victim.allies.push(betrayer_id);
+        victim.pending_trust_shock = true;
+
+        let mut rng = SmallRng::seed_from_u64(419);
+        let mut events: Vec<String> = vec![];
+        victim.consume_pending_trust_shock(&mut rng, &mut events);
+
+        // Victim's side cleaned.
+        assert!(
+            !victim.allies.contains(&betrayer_id),
+            "victim must drop the broken ally"
+        );
+        // The flag is consumed regardless of roll outcome.
+        assert!(
+            !victim.pending_trust_shock,
+            "pending flag is reset after the call"
+        );
+        // Asymmetric back-edge stays — `consume_pending_trust_shock` only
+        // touches `self`. The next cycle's event drain (or follow-up
+        // events) is responsible for the betrayer's side.
+        // We can't observe the betrayer here (different tribute instance);
+        // the documented contract is what matters and is asserted by the
+        // single-side mutation: the function signature takes `&mut self`
+        // and returns nothing, with no reference to the broken ally.
+    }
 }

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -111,6 +111,11 @@ pub struct Tribute {
     /// next turn to drive the trust-shock cascade (spec §7.3c1).
     #[serde(default)]
     pub pending_trust_shock: bool,
+    /// Per-tribute alliance event buffer, populated during `process_turn_phase`
+    /// (e.g. on Treacherous betrayal) and drained by the game cycle into
+    /// `Game.alliance_events` between turns. Transient; never persisted.
+    #[serde(default, skip)]
+    pub alliance_events: Vec<alliances::AllianceEvent>,
 }
 
 impl Default for Tribute {
@@ -161,6 +166,7 @@ impl Tribute {
             allies: Vec::new(),
             turns_since_last_betrayal: 0,
             pending_trust_shock: false,
+            alliance_events: Vec::new(),
         }
     }
 
@@ -403,6 +409,14 @@ impl Tribute {
         let mut rng = SmallRng::from_rng(&mut rand::rng());
         Some(enemies.choose(&mut rng).unwrap().clone())
     }
+
+    /// Drain this tribute's per-turn alliance event buffer. Called by
+    /// `Game::run_tribute_cycle` after each tribute's turn so the events
+    /// are appended to the game's queue and processed before the next
+    /// tribute acts. See spec §7.5.
+    pub fn drain_alliance_events(&mut self) -> Vec<alliances::AllianceEvent> {
+        std::mem::take(&mut self.alliance_events)
+    }
 }
 
 /// Calculates the stamina cost for a tribute action based on:
@@ -594,6 +608,21 @@ mod tests {
     fn new_tribute_has_no_pending_trust_shock() {
         let tribute = Tribute::new("Cinna".to_string(), Some(1), None);
         assert!(!tribute.pending_trust_shock);
+    }
+
+    #[rstest]
+    fn tribute_drain_alliance_events_returns_and_clears_buffer() {
+        use crate::tributes::alliances::AllianceEvent;
+        use uuid::Uuid;
+        let mut tribute = Tribute::new("Cinna".to_string(), Some(1), None);
+        let other = Uuid::new_v4();
+        tribute.alliance_events.push(AllianceEvent::BetrayalRecorded {
+            betrayer: tribute.id,
+            victim: other,
+        });
+        let drained = tribute.drain_alliance_events();
+        assert_eq!(drained.len(), 1);
+        assert!(tribute.alliance_events.is_empty());
     }
 
     #[rstest]

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -127,13 +127,13 @@ impl Tribute {
 
         // Assign terrain affinity, traits, and personality based on district
         let mut rng = SmallRng::from_rng(&mut rand::rng());
-        let brain = Brain::new_with_random_personality(&mut rng);
         let terrain_affinity = if (1..=12).contains(&district) {
             crate::districts::assign_terrain_affinity(district as u8, &mut rng)
         } else {
             vec![]
         };
         let traits = traits::generate_traits(district as u8, &mut rng);
+        let brain = Brain::from_traits(&traits, &mut rng);
 
         Self {
             identifier: id,

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -656,10 +656,12 @@ mod tests {
         use uuid::Uuid;
         let mut tribute = Tribute::new("Cinna".to_string(), Some(1), None);
         let other = Uuid::new_v4();
-        tribute.alliance_events.push(AllianceEvent::BetrayalRecorded {
-            betrayer: tribute.id,
-            victim: other,
-        });
+        tribute
+            .alliance_events
+            .push(AllianceEvent::BetrayalRecorded {
+                betrayer: tribute.id,
+                victim: other,
+            });
         let drained = tribute.drain_alliance_events();
         assert_eq!(drained.len(), 1);
         assert!(tribute.alliance_events.is_empty());
@@ -697,7 +699,10 @@ mod tests {
         tribute.consume_pending_trust_shock(&mut rng, &mut events);
 
         assert!(!tribute.pending_trust_shock, "flag must reset");
-        assert!(tribute.allies.is_empty(), "all allies broken on guaranteed success");
+        assert!(
+            tribute.allies.is_empty(),
+            "all allies broken on guaranteed success"
+        );
         assert_eq!(events.len(), 2, "one message per broken ally");
     }
 

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -125,7 +125,7 @@ impl Tribute {
         let id_uuid: Uuid = Uuid::new_v4();
         let id: String = id_uuid.to_string();
 
-        // Assign terrain affinity and personality based on district
+        // Assign terrain affinity, traits, and personality based on district
         let mut rng = SmallRng::from_rng(&mut rand::rng());
         let brain = Brain::new_with_random_personality(&mut rng);
         let terrain_affinity = if (1..=12).contains(&district) {
@@ -133,6 +133,7 @@ impl Tribute {
         } else {
             vec![]
         };
+        let traits = traits::generate_traits(district as u8, &mut rng);
 
         Self {
             identifier: id,
@@ -152,7 +153,7 @@ impl Tribute {
             terrain_affinity,
             stamina: 100,
             max_stamina: 100,
-            traits: Vec::new(),
+            traits,
             allies: Vec::new(),
             turns_since_last_betrayal: 0,
         }
@@ -599,5 +600,12 @@ mod tests {
         assert_eq!(tribute.turns_since_last_betrayal, 0);
         // `id` mirrors `identifier`.
         assert_eq!(tribute.id.to_string(), tribute.identifier);
+    }
+
+    #[rstest]
+    fn new_tribute_has_traits_for_valid_district() {
+        let tribute = Tribute::new("Katniss".to_string(), Some(12), None);
+        // generate_traits rolls 2..=6 traits from the district pool.
+        assert!((2..=6).contains(&tribute.traits.len()));
     }
 }

--- a/game/src/tributes/traits.rs
+++ b/game/src/tributes/traits.rs
@@ -63,6 +63,16 @@ impl Trait {
 
 pub const REFUSERS: &[Trait] = &[Trait::Paranoid, Trait::LoneWolf];
 
+/// Geometric mean of trait affinity values. Returns 1.0 for empty input.
+pub fn geometric_mean_affinity(traits: &[Trait]) -> f64 {
+    if traits.is_empty() {
+        return 1.0;
+    }
+    let n = traits.len() as f64;
+    let product: f64 = traits.iter().map(|t| t.alliance_affinity()).product();
+    product.powf(1.0 / n)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -83,5 +93,22 @@ mod tests {
         assert!(REFUSERS.contains(&Trait::Paranoid));
         assert!(REFUSERS.contains(&Trait::LoneWolf));
         assert!(!REFUSERS.contains(&Trait::Friendly));
+    }
+
+    #[test]
+    fn geometric_mean_empty_is_one() {
+        assert_eq!(geometric_mean_affinity(&[]), 1.0);
+    }
+
+    #[test]
+    fn geometric_mean_single_is_identity() {
+        assert!((geometric_mean_affinity(&[Trait::Friendly]) - 1.5).abs() < f64::EPSILON * 10.0);
+    }
+
+    #[test]
+    fn geometric_mean_two_friendly_one_lonewolf() {
+        let g = geometric_mean_affinity(&[Trait::Friendly, Trait::Friendly, Trait::LoneWolf]);
+        let expected = (1.5_f64 * 1.5 * 0.6).powf(1.0 / 3.0);
+        assert!((g - expected).abs() < f64::EPSILON * 10.0);
     }
 }

--- a/game/src/tributes/traits.rs
+++ b/game/src/tributes/traits.rs
@@ -73,6 +73,23 @@ pub fn geometric_mean_affinity(traits: &[Trait]) -> f64 {
     product.powf(1.0 / n)
 }
 
+pub const CONFLICTS: &[(Trait, Trait)] = &[
+    (Trait::Friendly, Trait::Paranoid),
+    (Trait::Loyal, Trait::Treacherous),
+    (Trait::Loyal, Trait::LoneWolf),
+    (Trait::Aggressive, Trait::Cautious),
+    (Trait::Aggressive, Trait::Defensive),
+    (Trait::Reckless, Trait::Cautious),
+    (Trait::Resilient, Trait::Fragile),
+    (Trait::Cunning, Trait::Dim),
+];
+
+pub fn conflicts_with(a: Trait, b: Trait) -> bool {
+    CONFLICTS
+        .iter()
+        .any(|(x, y)| (*x == a && *y == b) || (*x == b && *y == a))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,5 +127,32 @@ mod tests {
         let g = geometric_mean_affinity(&[Trait::Friendly, Trait::Friendly, Trait::LoneWolf]);
         let expected = (1.5_f64 * 1.5 * 0.6).powf(1.0 / 3.0);
         assert!((g - expected).abs() < f64::EPSILON * 10.0);
+    }
+
+    #[test]
+    fn conflict_symmetry() {
+        let pairs = [
+            (Trait::Friendly, Trait::Paranoid),
+            (Trait::Loyal, Trait::Treacherous),
+            (Trait::Loyal, Trait::LoneWolf),
+            (Trait::Aggressive, Trait::Cautious),
+            (Trait::Aggressive, Trait::Defensive),
+            (Trait::Reckless, Trait::Cautious),
+            (Trait::Resilient, Trait::Fragile),
+            (Trait::Cunning, Trait::Dim),
+        ];
+        for (a, b) in pairs {
+            assert!(conflicts_with(a, b), "{a:?} should conflict with {b:?}");
+            assert!(
+                conflicts_with(b, a),
+                "{b:?} should conflict with {a:?} (symmetry)"
+            );
+        }
+    }
+
+    #[test]
+    fn conflict_allowed_combos_do_not_conflict() {
+        assert!(!conflicts_with(Trait::Friendly, Trait::Treacherous));
+        assert!(!conflicts_with(Trait::Paranoid, Trait::LoneWolf));
     }
 }

--- a/game/src/tributes/traits.rs
+++ b/game/src/tributes/traits.rs
@@ -215,6 +215,101 @@ pub fn generate_traits(district: u8, rng: &mut impl Rng) -> Vec<Trait> {
     chosen
 }
 
+/// Additive deltas applied to `PersonalityThresholds`. `i32` so deltas can be
+/// signed; final values clamp to u32 ranges in `compute_thresholds`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ThresholdDelta {
+    pub low_health_limit: i32,
+    pub mid_health_limit: i32,
+    pub low_sanity_limit: i32,
+    pub mid_sanity_limit: i32,
+    pub high_sanity_limit: i32,
+    pub movement_limit: i32,
+    pub low_intelligence_limit: i32,
+    pub high_intelligence_limit: i32,
+    pub psychotic_break_threshold: i32,
+}
+
+impl std::ops::Add for ThresholdDelta {
+    type Output = ThresholdDelta;
+    fn add(self, rhs: Self) -> Self {
+        ThresholdDelta {
+            low_health_limit: self.low_health_limit + rhs.low_health_limit,
+            mid_health_limit: self.mid_health_limit + rhs.mid_health_limit,
+            low_sanity_limit: self.low_sanity_limit + rhs.low_sanity_limit,
+            mid_sanity_limit: self.mid_sanity_limit + rhs.mid_sanity_limit,
+            high_sanity_limit: self.high_sanity_limit + rhs.high_sanity_limit,
+            movement_limit: self.movement_limit + rhs.movement_limit,
+            low_intelligence_limit: self.low_intelligence_limit + rhs.low_intelligence_limit,
+            high_intelligence_limit: self.high_intelligence_limit + rhs.high_intelligence_limit,
+            psychotic_break_threshold: self.psychotic_break_threshold
+                + rhs.psychotic_break_threshold,
+        }
+    }
+}
+
+impl std::iter::Sum for ThresholdDelta {
+    fn sum<I: Iterator<Item = ThresholdDelta>>(iter: I) -> Self {
+        iter.fold(ThresholdDelta::default(), |a, b| a + b)
+    }
+}
+
+impl Trait {
+    pub fn threshold_modifiers(&self) -> ThresholdDelta {
+        match self {
+            Trait::Aggressive => ThresholdDelta {
+                low_health_limit: -5,
+                mid_health_limit: -10,
+                low_sanity_limit: -2,
+                psychotic_break_threshold: 2,
+                ..Default::default()
+            },
+            Trait::Defensive => ThresholdDelta {
+                low_health_limit: 10,
+                mid_health_limit: 10,
+                psychotic_break_threshold: -2,
+                ..Default::default()
+            },
+            Trait::Cautious => ThresholdDelta {
+                low_health_limit: 15,
+                mid_health_limit: 15,
+                low_sanity_limit: 10,
+                mid_sanity_limit: 10,
+                psychotic_break_threshold: -3,
+                ..Default::default()
+            },
+            Trait::Reckless => ThresholdDelta {
+                low_health_limit: -10,
+                low_sanity_limit: -10,
+                psychotic_break_threshold: 4,
+                ..Default::default()
+            },
+            Trait::Resilient => ThresholdDelta {
+                psychotic_break_threshold: -3,
+                low_sanity_limit: -3,
+                ..Default::default()
+            },
+            Trait::Fragile => ThresholdDelta {
+                psychotic_break_threshold: 3,
+                low_sanity_limit: 5,
+                ..Default::default()
+            },
+            Trait::Cunning => ThresholdDelta {
+                low_intelligence_limit: -5,
+                high_intelligence_limit: -5,
+                ..Default::default()
+            },
+            Trait::Dim => ThresholdDelta {
+                low_intelligence_limit: 10,
+                high_intelligence_limit: 5,
+                ..Default::default()
+            },
+            // Social and physical traits leave thresholds untouched.
+            _ => ThresholdDelta::default(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,5 +412,17 @@ mod tests {
         sorted.sort_by_key(|t| *t as u8);
         sorted.dedup();
         assert_eq!(sorted.len(), traits.len());
+    }
+
+    #[test]
+    fn threshold_delta_aggressive_lowers_health_threshold() {
+        let d = Trait::Aggressive.threshold_modifiers();
+        assert!(d.low_health_limit < 0);
+    }
+
+    #[test]
+    fn threshold_delta_zero_traits_is_identity() {
+        let total: ThresholdDelta = [].iter().map(|t: &Trait| t.threshold_modifiers()).sum();
+        assert_eq!(total, ThresholdDelta::default());
     }
 }

--- a/game/src/tributes/traits.rs
+++ b/game/src/tributes/traits.rs
@@ -1,6 +1,7 @@
 //! Tribute trait system. Replaces `BrainPersonality`. See spec
 //! `docs/superpowers/specs/2026-04-25-tribute-alliances-design.md` §5.
 
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -178,9 +179,47 @@ pub fn pool_for(district: u8) -> &'static [(Trait, u8)] {
     }
 }
 
+/// Generate a trait set for a tribute in `district`. Rolls 2–6 uniformly,
+/// then draws weighted picks from the district pool, rejecting conflicts and
+/// duplicates. Stops early if the pool cannot satisfy the count; never spins.
+pub fn generate_traits(district: u8, rng: &mut impl Rng) -> Vec<Trait> {
+    let pool = pool_for(district);
+    let target_count = rng.random_range(2..=6);
+    let mut chosen: Vec<Trait> = Vec::with_capacity(target_count);
+
+    let mut remaining: Vec<(Trait, u8)> = pool.to_vec();
+
+    while chosen.len() < target_count && !remaining.is_empty() {
+        let total: u32 = remaining.iter().map(|(_, w)| *w as u32).sum();
+        if total == 0 {
+            break;
+        }
+        let mut roll = rng.random_range(0..total);
+        let mut picked_idx: Option<usize> = None;
+        for (i, (_, w)) in remaining.iter().enumerate() {
+            if roll < *w as u32 {
+                picked_idx = Some(i);
+                break;
+            }
+            roll -= *w as u32;
+        }
+        let idx = picked_idx.expect("weighted pick must succeed when total > 0");
+        let (candidate, _) = remaining.remove(idx);
+
+        if chosen.iter().any(|t| conflicts_with(*t, candidate)) {
+            continue;
+        }
+        chosen.push(candidate);
+    }
+
+    chosen
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     #[test]
     fn affinity_known_values() {
@@ -256,5 +295,27 @@ mod tests {
     fn pool_for_unknown_district_falls_back() {
         // Districts outside 1..=12 fall back to district 1's pool; assert non-panic.
         let _ = pool_for(99);
+    }
+
+    #[test]
+    fn generate_respects_count_when_pool_supports() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let traits = generate_traits(1, &mut rng);
+        assert!(traits.len() >= 2 && traits.len() <= 6);
+        for i in 0..traits.len() {
+            for j in (i + 1)..traits.len() {
+                assert!(!conflicts_with(traits[i], traits[j]));
+            }
+        }
+    }
+
+    #[test]
+    fn generate_no_duplicates() {
+        let mut rng = StdRng::seed_from_u64(7);
+        let traits = generate_traits(2, &mut rng);
+        let mut sorted: Vec<_> = traits.clone();
+        sorted.sort_by_key(|t| *t as u8);
+        sorted.dedup();
+        assert_eq!(sorted.len(), traits.len());
     }
 }

--- a/game/src/tributes/traits.rs
+++ b/game/src/tributes/traits.rs
@@ -48,4 +48,40 @@ impl Trait {
             Trait::Tough => "tough",
         }
     }
+
+    pub fn alliance_affinity(&self) -> f64 {
+        match self {
+            Trait::Friendly => 1.5,
+            Trait::Loyal => 1.4,
+            Trait::Treacherous => 1.2,
+            Trait::LoneWolf => 0.6,
+            Trait::Paranoid => 0.5,
+            _ => 1.0,
+        }
+    }
+}
+
+pub const REFUSERS: &[Trait] = &[Trait::Paranoid, Trait::LoneWolf];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn affinity_known_values() {
+        assert_eq!(Trait::Friendly.alliance_affinity(), 1.5);
+        assert_eq!(Trait::Loyal.alliance_affinity(), 1.4);
+        assert_eq!(Trait::Treacherous.alliance_affinity(), 1.2);
+        assert_eq!(Trait::Aggressive.alliance_affinity(), 1.0);
+        assert_eq!(Trait::Tough.alliance_affinity(), 1.0);
+        assert_eq!(Trait::LoneWolf.alliance_affinity(), 0.6);
+        assert_eq!(Trait::Paranoid.alliance_affinity(), 0.5);
+    }
+
+    #[test]
+    fn refusers_membership() {
+        assert!(REFUSERS.contains(&Trait::Paranoid));
+        assert!(REFUSERS.contains(&Trait::LoneWolf));
+        assert!(!REFUSERS.contains(&Trait::Friendly));
+    }
 }

--- a/game/src/tributes/traits.rs
+++ b/game/src/tributes/traits.rs
@@ -1,0 +1,51 @@
+//! Tribute trait system. Replaces `BrainPersonality`. See spec
+//! `docs/superpowers/specs/2026-04-25-tribute-alliances-design.md` §5.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Trait {
+    // Combat stance
+    Aggressive,
+    Defensive,
+    Cautious,
+    Reckless,
+    // Social
+    Friendly,
+    Loyal,
+    Paranoid,
+    LoneWolf,
+    Treacherous,
+    // Mental
+    Resilient,
+    Fragile,
+    Cunning,
+    Dim,
+    // Physical
+    Asthmatic,
+    Nearsighted,
+    Tough,
+}
+
+impl Trait {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Trait::Aggressive => "aggressive",
+            Trait::Defensive => "defensive",
+            Trait::Cautious => "cautious",
+            Trait::Reckless => "reckless",
+            Trait::Friendly => "friendly",
+            Trait::Loyal => "loyal",
+            Trait::Paranoid => "paranoid",
+            Trait::LoneWolf => "a lone wolf",
+            Trait::Treacherous => "treacherous",
+            Trait::Resilient => "resilient",
+            Trait::Fragile => "fragile",
+            Trait::Cunning => "cunning",
+            Trait::Dim => "dim",
+            Trait::Asthmatic => "asthmatic",
+            Trait::Nearsighted => "nearsighted",
+            Trait::Tough => "tough",
+        }
+    }
+}

--- a/game/src/tributes/traits.rs
+++ b/game/src/tributes/traits.rs
@@ -90,6 +90,94 @@ pub fn conflicts_with(a: Trait, b: Trait) -> bool {
         .any(|(x, y)| (*x == a && *y == b) || (*x == b && *y == a))
 }
 
+pub const DISTRICT_1_POOL: &[(Trait, u8)] = &[
+    (Trait::Loyal, 4),
+    (Trait::Aggressive, 4),
+    (Trait::Paranoid, 3),
+    (Trait::Tough, 2),
+];
+pub const DISTRICT_2_POOL: &[(Trait, u8)] = &[
+    (Trait::Aggressive, 4),
+    (Trait::Defensive, 4),
+    (Trait::Loyal, 3),
+    (Trait::Tough, 2),
+];
+pub const DISTRICT_3_POOL: &[(Trait, u8)] = &[
+    (Trait::Cunning, 4),
+    (Trait::Cautious, 3),
+    (Trait::Dim, 2),
+    (Trait::Nearsighted, 2),
+    (Trait::Asthmatic, 1),
+];
+pub const DISTRICT_4_POOL: &[(Trait, u8)] = &[
+    (Trait::Resilient, 4),
+    (Trait::Aggressive, 3),
+    (Trait::Loyal, 3),
+    (Trait::Tough, 2),
+];
+pub const DISTRICT_5_POOL: &[(Trait, u8)] = &[
+    (Trait::Cunning, 4),
+    (Trait::Cautious, 3),
+    (Trait::Treacherous, 2),
+];
+pub const DISTRICT_6_POOL: &[(Trait, u8)] = &[
+    (Trait::Fragile, 3),
+    (Trait::Friendly, 3),
+    (Trait::Asthmatic, 2),
+    (Trait::Nearsighted, 2),
+];
+pub const DISTRICT_7_POOL: &[(Trait, u8)] = &[
+    (Trait::Resilient, 4),
+    (Trait::Defensive, 3),
+    (Trait::Tough, 3),
+];
+pub const DISTRICT_8_POOL: &[(Trait, u8)] = &[
+    (Trait::Fragile, 2),
+    (Trait::Friendly, 4),
+    (Trait::Loyal, 3),
+    (Trait::Asthmatic, 2),
+];
+pub const DISTRICT_9_POOL: &[(Trait, u8)] = &[
+    (Trait::Cautious, 3),
+    (Trait::Friendly, 3),
+    (Trait::Asthmatic, 2),
+];
+pub const DISTRICT_10_POOL: &[(Trait, u8)] = &[
+    (Trait::Resilient, 4),
+    (Trait::Defensive, 3),
+    (Trait::Tough, 3),
+];
+pub const DISTRICT_11_POOL: &[(Trait, u8)] = &[
+    (Trait::Loyal, 3),
+    (Trait::Friendly, 4),
+    (Trait::Resilient, 3),
+    (Trait::Tough, 2),
+];
+pub const DISTRICT_12_POOL: &[(Trait, u8)] = &[
+    (Trait::Resilient, 3),
+    (Trait::LoneWolf, 3),
+    (Trait::Cunning, 3),
+    (Trait::Asthmatic, 2),
+];
+
+pub fn pool_for(district: u8) -> &'static [(Trait, u8)] {
+    match district {
+        1 => DISTRICT_1_POOL,
+        2 => DISTRICT_2_POOL,
+        3 => DISTRICT_3_POOL,
+        4 => DISTRICT_4_POOL,
+        5 => DISTRICT_5_POOL,
+        6 => DISTRICT_6_POOL,
+        7 => DISTRICT_7_POOL,
+        8 => DISTRICT_8_POOL,
+        9 => DISTRICT_9_POOL,
+        10 => DISTRICT_10_POOL,
+        11 => DISTRICT_11_POOL,
+        12 => DISTRICT_12_POOL,
+        _ => DISTRICT_1_POOL,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -154,5 +242,19 @@ mod tests {
     fn conflict_allowed_combos_do_not_conflict() {
         assert!(!conflicts_with(Trait::Friendly, Trait::Treacherous));
         assert!(!conflicts_with(Trait::Paranoid, Trait::LoneWolf));
+    }
+
+    #[test]
+    fn pool_for_returns_correct_pool_per_district() {
+        let p1 = pool_for(1);
+        assert!(p1.iter().any(|(t, _)| *t == Trait::Loyal));
+        let p12 = pool_for(12);
+        assert!(p12.iter().any(|(t, _)| *t == Trait::LoneWolf));
+    }
+
+    #[test]
+    fn pool_for_unknown_district_falls_back() {
+        // Districts outside 1..=12 fall back to district 1's pool; assert non-panic.
+        let _ = pool_for(99);
     }
 }

--- a/migrations/20260426_120000_TributeAlliances.surql
+++ b/migrations/20260426_120000_TributeAlliances.surql
@@ -1,0 +1,6 @@
+-- Tribute alliances v1: traits replace BrainPersonality;
+-- allies + traits + turns_since_last_betrayal added on tribute.
+-- Existing tribute rows are not migrated. Reset your dev DB.
+DELETE owns;
+DELETE playing_in;
+DELETE tribute;

--- a/schemas/tribute.surql
+++ b/schemas/tribute.surql
@@ -15,6 +15,9 @@ DEFINE FIELD OVERWRITE attributes ON tribute;
 DEFINE FIELD OVERWRITE stamina ON tribute;
 DEFINE FIELD OVERWRITE max_stamina ON tribute;
 DEFINE FIELD OVERWRITE terrain_affinity ON tribute;
+DEFINE FIELD OVERWRITE allies ON tribute TYPE array<uuid> DEFAULT [];
+DEFINE FIELD OVERWRITE traits ON tribute TYPE array<string> DEFAULT [];
+DEFINE FIELD OVERWRITE turns_since_last_betrayal ON tribute TYPE int DEFAULT 0;
 DEFINE FIELD OVERWRITE created_by ON tribute VALUE $auth READONLY;
 
 DEFINE INDEX OVERWRITE tribute_identifier ON tribute FIELDS identifier UNIQUE;

--- a/web/src/components/tribute_detail.rs
+++ b/web/src/components/tribute_detail.rs
@@ -312,8 +312,6 @@ fn TributeAttributes(attributes: Attributes) -> Element {
             dd { "{attributes.defense}"}
             dt { "Bravery" }
             dd { "{attributes.bravery}"}
-            dt { "Loyalty" }
-            dd { "{attributes.loyalty}"}
             dt { "Intelligence" }
             dd { "{attributes.intelligence}"}
             dt { "Persuasion" }


### PR DESCRIPTION
## Summary

Replaces the old `BrainPersonality` enum + `loyalty` attribute with a richer per-tribute trait + alliance graph system. Tributes now carry `traits: Vec<Trait>` (drawn from district pools with conflict resolution) and a symmetric `allies: Vec<Uuid>` graph. Alliances form via geometric-mean affinity gates, can break via betrayal or trust shock, and propagate death/betrayal events through a per-game `alliance_events` queue drained each cycle.

Closes `hangrier_games-0ug` (root) plus phase beads `yy1`, `cbx`, `0ao`, `43v`, `il7`, `rbq`.

Spec: `docs/superpowers/specs/2026-04-25-tribute-alliances-design.md` (status: Implemented 2026-04-26).
Plan: `docs/superpowers/plans/2026-04-25-tribute-alliances-implementation.md`.

## Changes

**game/ (engine, ~30 commits, TDD per step):**
- New `tributes/traits.rs`: `Trait` enum, `ThresholdDelta`, district-keyed trait pools, conflict table, REFUSERS set, `geometric_mean_affinity`, `generate_traits`.
- New `tributes/alliances.rs`: `passes_gate`, `roll_chance`, `DecidingFactor`, `sanity_break_roll`, `trust_shock_roll`, `AllianceEvent` (BetrayalRecorded / DeathRecorded), `try_form_alliance`. Constants: `MAX_ALLIES=5`, `BASE_ALLIANCE_CHANCE=0.20`, `TREACHEROUS_BETRAYAL_INTERVAL=5`.
- `Tribute`: new `id`, `traits`, `allies`, `turns_since_last_betrayal`, `pending_trust_shock`, `alliance_events`. `Brain::from_traits` and `PersonalityThresholds::from_traits` derive behavior from traits. `pick_target` filters allies. `BrainPersonality` enum and `loyalty` attribute removed.
- `Game`: new `alliance_events` queue. `run_tribute_cycle` performs an alliance-formation pass, drains per-tribute alliance events, processes betrayal/death cascades, and enqueues `DeathRecorded` for newly-dead tributes. Treacherous tributes trigger betrayals at cadence (`TREACHEROUS_BETRAYAL_INTERVAL`).
- `config`: `loyalty_break_level` and `max_loyalty` removed.

**schema / persistence:**
- `schemas/tribute.surql`: `allies array<uuid>`, `traits array<string>`, `turns_since_last_betrayal int`.
- `migrations/20260426_120000_TributeAlliances.surql`: destructive tribute wipe (authorized by spec — dev-only hard cutover, no production data).
- `api/src/games.rs`: include `alliance_events` when constructing `Game`.

**web/:**
- `tribute_detail.rs`: removed loyalty stat row. Trait/ally UI and alliance-event timeline tracked as follow-ups (`hangrier_games-4sh`, `5yr`).

## Verification

- `cargo test -p game`: **451 lib tests pass** (up from ~360, +90 new tests across 6 phases).
- `cargo test -p api --test '*' -- --test-threads=1`: **178 integration tests pass**.
- `cargo fmt --all -- --check`: clean (custom edition=2024, fn_single_line=true).
- `cargo clippy -p game --no-deps -- -D warnings`: clean.
- `cargo check -p shared -p api`: clean.
- `RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"' cargo check -p web --target wasm32-unknown-unknown`: clean.

## Follow-ups

Tracked as discovered-from `hangrier_games-0ug`:
- `hangrier_games-4sh` (P3) — frontend traits/allies display.
- `hangrier_games-5yr` (P3) — alliance-event timeline UI.
- `hangrier_games-5ed` (P3) — killer attribution on `DeathRecorded`.
- `hangrier_games-q1q` (P4) — document migration warning / dev-DB-reset requirement.
- `hangrier_games-zaa` (P4) — decide whether asymmetric trust-shock back-edge should become symmetric (currently pinned by regression test per spec §7.3c1).