### PR TITLE
feat(web): render tribute traits and allies on detail view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7125,6 +7125,7 @@ dependencies = [
  "serde_json",
  "shared",
  "tracing",
+ "uuid",
  "web-sys",
 ]
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -18,6 +18,7 @@ shared = { path = "../shared" }
 reqwest = { version = "0.12.9", features = ["json", "multipart"] }
 serde_json = "1.0.140"
 tracing = "0.1"
+uuid = { version = "1.13.2", features = ["v4", "js", "serde"] }
 web-sys = { version = "0.3", features = ["console"] }
 
 [build-dependencies]

--- a/web/src/components/tribute_detail.rs
+++ b/web/src/components/tribute_detail.rs
@@ -1,4 +1,5 @@
 use crate::cache::{QueryError, QueryKey, QueryValue};
+use crate::components::game_tributes::PaginatedTributesResponse;
 use crate::components::icons::uturn::UTurnIcon;
 use crate::components::info_detail::InfoDetail;
 use crate::components::item_icon::ItemIcon;
@@ -9,6 +10,8 @@ use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
 use dioxus_query::prelude::{QueryResult, QueryState, use_get_query};
 use game::messages::GameMessage;
+use game::tributes::statuses::TributeStatus;
+use game::tributes::traits::Trait;
 use game::tributes::{Attributes, Tribute};
 
 async fn fetch_tribute(keys: Vec<QueryKey>, token: String) -> QueryResult<QueryValue, QueryError> {
@@ -50,6 +53,65 @@ async fn fetch_tribute(keys: Vec<QueryKey>, token: String) -> QueryResult<QueryV
         }
     } else {
         QueryResult::Err(QueryError::Unknown)
+    }
+}
+
+/// Fetch the paginated tribute roster for a game (used to resolve ally UUIDs
+/// to names client-side without a new endpoint). Standard rosters are exactly
+/// 24 tributes (12 districts × 2), matching the API's default page size.
+async fn fetch_tribute_roster(
+    keys: Vec<QueryKey>,
+    token: String,
+) -> QueryResult<QueryValue, QueryError> {
+    if let Some(QueryKey::Tributes(game_identifier)) = keys.first() {
+        let client = reqwest::Client::new();
+        let request = client
+            .request(
+                reqwest::Method::GET,
+                format!(
+                    "{}/api/games/{}/tributes?limit=24&offset=0",
+                    APP_API_HOST, game_identifier
+                ),
+            )
+            .bearer_auth(token);
+        match request.send().await {
+            Ok(response) => match response.json::<PaginatedTributesResponse>().await {
+                Ok(tributes) => Ok(QueryValue::PaginatedTributes(tributes)),
+                Err(_) => Err(QueryError::BadJson),
+            },
+            Err(_) => Err(QueryError::GameNotFound(game_identifier.to_string())),
+        }
+    } else {
+        Err(QueryError::Unknown)
+    }
+}
+
+/// Tailwind utility classes for a trait chip. Mapping is semantic: combat
+/// stance traits get warm/cool tones, social traits map to trust/danger
+/// signals, mental/physical traits get neutral-ish accents. Keep contrast
+/// readable across all three themes (dark amber, dark green, light stone).
+fn trait_chip_classes(t: &Trait) -> &'static str {
+    match t {
+        // Social: trust signals
+        Trait::Loyal => "bg-green-700/40 text-green-100 border border-green-500/60",
+        Trait::Friendly => "bg-emerald-700/40 text-emerald-100 border border-emerald-500/60",
+        Trait::Treacherous => "bg-red-700/40 text-red-100 border border-red-500/60",
+        Trait::Paranoid => "bg-yellow-700/40 text-yellow-100 border border-yellow-500/60",
+        Trait::LoneWolf => "bg-slate-700/40 text-slate-100 border border-slate-400/60",
+        // Combat stance
+        Trait::Aggressive => "bg-orange-700/40 text-orange-100 border border-orange-500/60",
+        Trait::Reckless => "bg-rose-700/40 text-rose-100 border border-rose-500/60",
+        Trait::Defensive => "bg-sky-700/40 text-sky-100 border border-sky-500/60",
+        Trait::Cautious => "bg-cyan-700/40 text-cyan-100 border border-cyan-500/60",
+        // Mental
+        Trait::Cunning => "bg-purple-700/40 text-purple-100 border border-purple-500/60",
+        Trait::Dim => "bg-stone-700/40 text-stone-100 border border-stone-500/60",
+        Trait::Resilient => "bg-teal-700/40 text-teal-100 border border-teal-500/60",
+        Trait::Fragile => "bg-pink-700/40 text-pink-100 border border-pink-500/60",
+        // Physical
+        Trait::Tough => "bg-amber-700/40 text-amber-100 border border-amber-500/60",
+        Trait::Asthmatic => "bg-indigo-700/40 text-indigo-100 border border-indigo-500/60",
+        Trait::Nearsighted => "bg-fuchsia-700/40 text-fuchsia-100 border border-fuchsia-500/60",
     }
 }
 
@@ -228,6 +290,26 @@ pub fn TributeDetail(game_identifier: String, tribute_identifier: String) -> Ele
                         TributeAttributes { attributes: tribute.attributes.clone() }
                     }
 
+                    if !tribute.traits.is_empty() {
+                        InfoDetail {
+                            title: "Traits",
+                            open: false,
+                            TributeTraits {
+                                traits: tribute.traits.clone(),
+                                turns_since_last_betrayal: tribute.turns_since_last_betrayal,
+                            }
+                        }
+                    }
+
+                    InfoDetail {
+                        title: "Allies",
+                        open: false,
+                        TributeAllies {
+                            game_identifier: game_identifier.clone(),
+                            ally_ids: tribute.allies.clone(),
+                        }
+                    }
+
                     if !tribute.clone().editable {
                         InfoDetail {
                             title: "Log",
@@ -319,5 +401,118 @@ fn TributeAttributes(attributes: Attributes) -> Element {
             dt { "Luck" }
             dd { "{attributes.luck}"}
         }
+    }
+}
+
+#[component]
+fn TributeTraits(traits: Vec<Trait>, turns_since_last_betrayal: u8) -> Element {
+    let has_treacherous = traits.contains(&Trait::Treacherous);
+    rsx! {
+        ul {
+            class: "flex flex-row gap-2 flex-wrap",
+            for t in traits.iter() {
+                li {
+                    class: format!(
+                        "px-2 py-1 rounded-full text-xs font-semibold capitalize {}",
+                        trait_chip_classes(t),
+                    ),
+                    "{t.label()}"
+                }
+            }
+        }
+        if has_treacherous {
+            p {
+                class: "text-xs mt-2 italic opacity-75",
+                "Turns since last betrayal: {turns_since_last_betrayal}"
+            }
+        }
+    }
+}
+
+#[component]
+fn TributeAllies(game_identifier: String, ally_ids: Vec<uuid::Uuid>) -> Element {
+    if ally_ids.is_empty() {
+        return rsx! {
+            p {
+                class: "text-sm italic opacity-75",
+                "No allies."
+            }
+        };
+    }
+
+    let storage = use_persistent("hangry-games", AppState::default);
+    let token = storage.get().jwt.expect("No JWT found");
+
+    let roster_query = use_get_query(
+        [
+            QueryKey::Tributes(game_identifier.clone()),
+            QueryKey::DisplayGame(game_identifier.clone()),
+        ],
+        move |keys: Vec<QueryKey>| fetch_tribute_roster(keys, token.clone()),
+    );
+
+    match roster_query.result().value() {
+        QueryState::Settled(Ok(QueryValue::PaginatedTributes(response))) => {
+            let roster = response.tributes.clone();
+            rsx! {
+                ul {
+                    class: "flex flex-col gap-1",
+                    for ally_id in ally_ids.iter() {
+                        li {
+                            class: "flex flex-row gap-2 items-center text-sm",
+                            {
+                                let ally = roster.iter().find(|t| &t.id == ally_id);
+                                match ally {
+                                    Some(t) => {
+                                        let dead = matches!(
+                                            t.status,
+                                            TributeStatus::Dead | TributeStatus::RecentlyDead,
+                                        );
+                                        let link_class = if dead {
+                                            "line-through opacity-60 hover:opacity-100 underline decoration-dotted"
+                                        } else {
+                                            "hover:underline decoration-2"
+                                        };
+                                        rsx! {
+                                            TributeStatusIcon {
+                                                status: t.status.clone(),
+                                                css_class: "size-4 theme1:fill-amber-500 theme2:fill-green-200".to_string(),
+                                            }
+                                            Link {
+                                                class: "{link_class}",
+                                                to: Routes::TributeDetail {
+                                                    game_identifier: game_identifier.clone(),
+                                                    tribute_identifier: t.identifier.clone(),
+                                                },
+                                                "{t.name}"
+                                            }
+                                        }
+                                    }
+                                    None => rsx! {
+                                        span {
+                                            class: "italic opacity-50",
+                                            "Unknown"
+                                        }
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        QueryState::Settled(Err(_)) => rsx! {
+            p {
+                class: "text-sm italic opacity-75",
+                "Failed to load allies."
+            }
+        },
+        QueryState::Loading(_) => rsx! {
+            p {
+                class: "text-sm italic opacity-75",
+                "Loading allies..."
+            }
+        },
+        _ => rsx! {},
     }
 }


### PR DESCRIPTION
## Summary

Closes hangrier_games-4sh.

Adds two new sections to the tribute detail page (replacing the now-removed `loyalty` UI surface):

- **Traits**: colored chip row, one chip per `Trait` enum variant. Section is hidden entirely when the tribute has no traits. Treacherous tributes additionally surface `turns_since_last_betrayal` as small italic text below the chip row.
- **Allies**: linked list of ally tribute names. Each item gets a `TributeStatusIcon` and a `Link` to that tribute's detail page. Dead / RecentlyDead allies render struck-through and muted. Unresolved UUIDs (ally not in roster, defensive) render as muted "Unknown" with no link. Empty list renders "No allies."

## Changes

- `web/src/components/tribute_detail.rs`
  - New `fetch_tribute_roster` async fn — paginated tributes endpoint (`limit=24`, matching the standard 12 districts × 2 tributes roster) used to resolve `Vec<Uuid>` → tribute `name` + `identifier` client-side. No new API endpoint.
  - New `trait_chip_classes` helper mapping each `Trait` variant to a Tailwind chip palette. Semantic mapping documented inline:
    - Loyal → green, Friendly → emerald, Treacherous → red, Paranoid → yellow, LoneWolf → slate
    - Aggressive → orange, Reckless → rose, Defensive → sky, Cautious → cyan
    - Cunning → purple, Dim → stone, Resilient → teal, Fragile → pink
    - Tough → amber, Asthmatic → indigo, Nearsighted → fuchsia
  - New `TributeTraits` and `TributeAllies` components, wrapped in `InfoDetail` to match the visual rhythm of existing sections (Overview, Inventory, Attributes, Log).
- `web/Cargo.toml` — adds `uuid` direct dep (was already transitive via `game`); needed for the `Vec<Uuid>` prop on `TributeAllies`.

## Verification

```
cargo fmt --all
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check -p web --target wasm32-unknown-unknown   # clean
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo clippy -p web --target wasm32-unknown-unknown -- -D warnings   # clean
cargo check -p game   # clean
just build-css   # clean
```

## Notes

- This PR only touches the `web/` crate plus a `Cargo.lock` bump. The working tree contains unrelated wip game-crate changes from a prior session; those are intentionally excluded.
- Roster query reuses the existing paginated endpoint at `limit=24`. If a future game allows more than 24 tributes, ally resolution would silently fall back to "Unknown" for the overflow — should be a separate follow-up if needed.

## Follow-ups

None for this issue.