### PR TITLE
feat(game): structured alliance event messages with MessageKind

### DIFF
--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -218,6 +218,26 @@ impl Game {
         self.log(source, subject, output.to_string());
     }
 
+    /// Log a structured game output and tag the resulting `GameMessage` with a typed
+    /// [`MessageKind`]. Used by the alliance event sites so consumers (UI, announcers)
+    /// can filter by category without parsing strings.
+    pub fn log_output_kind<D: std::fmt::Display>(
+        &mut self,
+        source: crate::messages::MessageSource,
+        subject: String,
+        output: D,
+        kind: crate::messages::MessageKind,
+    ) {
+        let game_day = self.day.unwrap_or(0);
+        self.messages.push(crate::messages::GameMessage::with_kind(
+            source,
+            game_day,
+            subject,
+            output.to_string(),
+            kind,
+        ));
+    }
+
     fn check_for_winner(&mut self) -> Result<(), GameError> {
         if let Some(winner) = self.winner() {
             self.log(
@@ -716,7 +736,12 @@ impl Game {
 
         // Collected (actor_identifier, line) pairs from all tributes this cycle.
         // Drained into self.messages after the mutable borrow of self.tributes ends.
-        let mut collected_events: Vec<(String, String, String)> = Vec::new();
+        let mut collected_events: Vec<(
+            String,
+            String,
+            String,
+            Option<crate::messages::MessageKind>,
+        )> = Vec::new();
 
         // Alliance formation rolls (spec §6). For every pair of living
         // tributes sharing an area where neither already lists the other as
@@ -758,15 +783,13 @@ impl Game {
                             .as_ref()
                             .map(|f| f.label())
                             .unwrap_or("mutual circumstance");
-                        new_alliances.push((
-                            a.id,
-                            b.id,
-                            a.name.clone(),
-                            format!(
-                                "{} and {} form an alliance ({}).",
-                                a.name, b.name, factor_label
-                            ),
-                        ));
+                        let message = crate::output::GameOutput::AllianceFormed(
+                            &a.name,
+                            &b.name,
+                            factor_label,
+                        )
+                        .to_string();
+                        new_alliances.push((a.id, b.id, a.name.clone(), message));
                     }
                 }
             }
@@ -815,6 +838,7 @@ impl Game {
                 self.tributes[ia].identifier.clone(),
                 name_a.clone(),
                 message.clone(),
+                Some(crate::messages::MessageKind::AllianceFormed),
             ));
         }
 
@@ -917,18 +941,31 @@ impl Game {
                 &mut tribute_events,
             );
             for line in tribute_events {
-                collected_events.push((tribute.identifier.clone(), tribute.name.clone(), line));
+                collected_events.push((
+                    tribute.identifier.clone(),
+                    tribute.name.clone(),
+                    line,
+                    None,
+                ));
             }
             drained_alliance_events.append(&mut tribute.drain_alliance_events());
         }
 
         // Drain collected events into game messages now that the mutable borrow ends.
-        for (identifier, name, line) in collected_events {
-            self.log_output(
-                crate::messages::MessageSource::Tribute(identifier),
-                name,
-                line,
-            );
+        for (identifier, name, line, kind) in collected_events {
+            match kind {
+                Some(k) => self.log_output_kind(
+                    crate::messages::MessageSource::Tribute(identifier),
+                    name,
+                    line,
+                    k,
+                ),
+                None => self.log_output(
+                    crate::messages::MessageSource::Tribute(identifier),
+                    name,
+                    line,
+                ),
+            }
         }
 
         // Promote drained alliance events into the game queue and process them
@@ -1036,11 +1073,33 @@ impl Game {
         for ev in drained {
             match ev {
                 AllianceEvent::BetrayalRecorded { betrayer, victim } => {
+                    // Snapshot names before the mutable borrow on `victim` so
+                    // we can emit the message after victim mutation completes.
+                    let betrayer_name = self
+                        .tributes
+                        .iter()
+                        .find(|t| t.id == betrayer)
+                        .map(|t| t.name.clone());
+                    let victim_info = self
+                        .tributes
+                        .iter()
+                        .find(|t| t.id == victim)
+                        .map(|t| (t.identifier.clone(), t.name.clone()));
                     if let Some(v) = self.tributes.iter_mut().find(|t| t.id == victim) {
                         v.allies.retain(|x| *x != betrayer);
                         v.pending_trust_shock = true;
                     }
                     // Spec §7.5: betrayer is never enqueued for trust-shock.
+                    if let (Some(b_name), Some((v_id, v_name))) = (betrayer_name, victim_info) {
+                        let line = crate::output::GameOutput::BetrayalTriggered(&b_name, &v_name)
+                            .to_string();
+                        self.log_output_kind(
+                            crate::messages::MessageSource::Tribute(v_id),
+                            v_name,
+                            line,
+                            crate::messages::MessageKind::BetrayalTriggered,
+                        );
+                    }
                 }
                 AllianceEvent::DeathRecorded {
                     deceased,
@@ -1063,13 +1122,16 @@ impl Game {
                             let sanity = ally.attributes.sanity;
                             if sanity_break_roll(sanity, limit, rng) {
                                 ally.allies.retain(|x| *x != deceased);
-                                let line = format!(
-                                    "{} is shaken by their ally's death and breaks the bond.",
-                                    ally.name
-                                );
                                 let aid = ally.identifier.clone();
                                 let aname = ally.name.clone();
-                                self.log(crate::messages::MessageSource::Tribute(aid), aname, line);
+                                let line =
+                                    crate::output::GameOutput::TrustShockBreak(&aname).to_string();
+                                self.log_output_kind(
+                                    crate::messages::MessageSource::Tribute(aid),
+                                    aname,
+                                    line,
+                                    crate::messages::MessageKind::TrustShockBreak,
+                                );
                             }
                         }
                     }
@@ -1962,5 +2024,102 @@ mod tests {
         );
         let s = game.tributes.iter().find(|t| t.id == sid).unwrap();
         assert!(!s.allies.contains(&did));
+    }
+
+    #[test]
+    fn alliance_formation_emits_message_with_alliance_formed_kind() {
+        // Friendly + same district guarantees a high formation chance; loop
+        // a few seeds until at least one cycle forms an alliance and assert
+        // the resulting message carries kind = AllianceFormed and the exact
+        // display string from `GameOutput::AllianceFormed`.
+        use crate::messages::MessageKind;
+        use crate::tributes::traits::Trait;
+
+        let mut t1 = create_tribute("Cinna", true);
+        let mut t2 = create_tribute("Portia", true);
+        t1.district = 1;
+        t2.district = 1;
+        t1.traits = vec![Trait::Friendly];
+        t2.traits = vec![Trait::Friendly];
+        t1.area = Area::Cornucopia;
+        t2.area = Area::Cornucopia;
+
+        let base = create_test_game_with_tributes(vec![t1.clone(), t2.clone()]);
+        let mut game_with_area = base.clone();
+        game_with_area
+            .areas
+            .push(AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia));
+        let closed_areas: Vec<Area> = vec![];
+
+        let mut hit: Option<crate::messages::GameMessage> = None;
+        for seed in [313u64, 419, 547, 23, 89, 211, 7, 11] {
+            let mut g = game_with_area.clone();
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let _ = g.run_tribute_cycle(
+                true,
+                &mut rng,
+                closed_areas.clone(),
+                vec![t1.clone(), t2.clone()],
+                2,
+            );
+            if let Some(m) = g
+                .messages
+                .iter()
+                .find(|m| m.kind == Some(MessageKind::AllianceFormed))
+            {
+                hit = Some(m.clone());
+                break;
+            }
+        }
+        let m = hit.expect("at least one cycle must emit AllianceFormed");
+        assert_eq!(m.kind, Some(MessageKind::AllianceFormed));
+        assert!(
+            m.content.contains("form an alliance"),
+            "content should match GameOutput::AllianceFormed display, got: {}",
+            m.content
+        );
+    }
+
+    #[test]
+    fn betrayal_emits_message_with_betrayal_triggered_kind() {
+        use crate::messages::MessageKind;
+        use crate::tributes::alliances::TREACHEROUS_BETRAYAL_INTERVAL;
+        use crate::tributes::traits::Trait;
+
+        let mut betrayer = create_tribute("Cato", true);
+        let mut victim = create_tribute("Glimmer", true);
+        betrayer.traits = vec![Trait::Treacherous];
+        victim.traits = vec![Trait::Tough];
+        betrayer.allies.push(victim.id);
+        victim.allies.push(betrayer.id);
+        betrayer.turns_since_last_betrayal = TREACHEROUS_BETRAYAL_INTERVAL;
+        betrayer.area = Area::Cornucopia;
+        victim.area = Area::Cornucopia;
+        betrayer.district = 1;
+        victim.district = 2;
+
+        let mut game = create_test_game_with_tributes(vec![betrayer.clone(), victim.clone()]);
+        game.areas
+            .push(AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia));
+        let closed_areas: Vec<Area> = vec![];
+
+        let mut rng = SmallRng::seed_from_u64(313);
+        let _ = game.run_tribute_cycle(
+            true,
+            &mut rng,
+            closed_areas,
+            vec![betrayer.clone(), victim.clone()],
+            2,
+        );
+
+        let m = game
+            .messages
+            .iter()
+            .find(|m| m.kind == Some(MessageKind::BetrayalTriggered))
+            .expect("betrayal cycle must emit BetrayalTriggered message");
+        assert_eq!(
+            m.content,
+            "Cato betrays Glimmer — true to their treacherous nature."
+        );
     }
 }

--- a/game/src/messages.rs
+++ b/game/src/messages.rs
@@ -15,6 +15,17 @@ pub enum MessageSource {
     Tribute(String), // Tribute identifier
 }
 
+/// Typed category for a `GameMessage`. Initial set covers alliance lifecycle
+/// events; future categories (combat, area, sponsor) will be added as those
+/// emit sites get refactored. `None` on `GameMessage.kind` means the message
+/// has not yet been categorised.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum MessageKind {
+    AllianceFormed,
+    BetrayalTriggered,
+    TrustShockBreak,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GameMessage {
     pub identifier: String,
@@ -24,10 +35,15 @@ pub struct GameMessage {
     #[serde(with = "chrono::serde::ts_nanoseconds")]
     pub timestamp: DateTime<Utc>,
     pub content: String,
+    /// Optional typed category. `None` for legacy/uncategorised messages so
+    /// existing serialized rows hydrate cleanly. Skipped on serialize when
+    /// absent to keep JSON compact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<MessageKind>,
 }
 
 impl GameMessage {
-    /// Create a new game message
+    /// Create a new game message without a typed kind.
     pub fn new(source: MessageSource, game_day: u32, subject: String, content: String) -> Self {
         GameMessage {
             identifier: Uuid::new_v4().to_string(),
@@ -36,6 +52,26 @@ impl GameMessage {
             subject,
             timestamp: Utc::now(),
             content,
+            kind: None,
+        }
+    }
+
+    /// Create a new game message with a typed `MessageKind`.
+    pub fn with_kind(
+        source: MessageSource,
+        game_day: u32,
+        subject: String,
+        content: String,
+        kind: MessageKind,
+    ) -> Self {
+        GameMessage {
+            identifier: Uuid::new_v4().to_string(),
+            source,
+            game_day,
+            subject,
+            timestamp: Utc::now(),
+            content,
+            kind: Some(kind),
         }
     }
 }
@@ -351,5 +387,76 @@ fn terrain_name(terrain: BaseTerrain) -> &'static str {
         BaseTerrain::Badlands => "badland",
         BaseTerrain::Highlands => "highland",
         BaseTerrain::Geothermal => "geothermal",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use serde_json::json;
+
+    #[test]
+    fn message_kind_serde_roundtrip() {
+        for kind in [
+            MessageKind::AllianceFormed,
+            MessageKind::BetrayalTriggered,
+            MessageKind::TrustShockBreak,
+        ] {
+            let s = serde_json::to_string(&kind).expect("serialize MessageKind");
+            let back: MessageKind = serde_json::from_str(&s).expect("deserialize MessageKind");
+            assert_eq!(kind, back);
+        }
+    }
+
+    #[test]
+    fn game_message_kind_optional_field_default() {
+        // Legacy row: no `kind` field present.
+        let ts = Utc.timestamp_nanos(0);
+        let raw = json!({
+            "identifier": "abc",
+            "source": { "type": "Game", "value": "g1" },
+            "game_day": 1,
+            "subject": "game:g1",
+            "timestamp": ts.timestamp_nanos_opt().unwrap(),
+            "content": "hello",
+        });
+        let msg: GameMessage = serde_json::from_value(raw).expect("deserialize without kind");
+        assert!(msg.kind.is_none());
+    }
+
+    #[test]
+    fn game_message_with_kind_constructor_sets_kind() {
+        let msg = GameMessage::with_kind(
+            MessageSource::Game("g".into()),
+            2,
+            "game:g".into(),
+            "content".into(),
+            MessageKind::AllianceFormed,
+        );
+        assert_eq!(msg.kind, Some(MessageKind::AllianceFormed));
+    }
+
+    #[test]
+    fn game_message_default_constructor_has_no_kind() {
+        let msg = GameMessage::new(
+            MessageSource::Game("g".into()),
+            2,
+            "game:g".into(),
+            "content".into(),
+        );
+        assert!(msg.kind.is_none());
+    }
+
+    #[test]
+    fn game_message_skips_kind_when_none() {
+        let msg = GameMessage::new(
+            MessageSource::Game("g".into()),
+            1,
+            "subj".into(),
+            "c".into(),
+        );
+        let s = serde_json::to_string(&msg).expect("serialize");
+        assert!(!s.contains("\"kind\""), "kind field should be skipped: {s}");
     }
 }

--- a/game/src/output.rs
+++ b/game/src/output.rs
@@ -82,6 +82,9 @@ pub enum GameOutput<'a> {
     TributeForcedBetrayal(&'a str, &'a str),
     NoOneToAttack(&'a str),
     AllAlone(&'a str),
+    AllianceFormed(&'a str, &'a str, &'a str), // tribute_a, tribute_b, deciding factor
+    BetrayalTriggered(&'a str, &'a str),       // betrayer, victim
+    TrustShockBreak(&'a str),                  // shaken tribute
 }
 
 impl<'a> Display for GameOutput<'a> {
@@ -380,6 +383,52 @@ impl<'a> Display for GameOutput<'a> {
             GameOutput::AllAlone(tribute) => {
                 write!(f, "😢 {} is all alone!", tribute)
             }
+            GameOutput::AllianceFormed(a, b, factor) => {
+                write!(f, "{} and {} form an alliance ({}).", a, b, factor)
+            }
+            GameOutput::BetrayalTriggered(betrayer, victim) => {
+                write!(
+                    f,
+                    "{} betrays {} — true to their treacherous nature.",
+                    betrayer, victim
+                )
+            }
+            GameOutput::TrustShockBreak(shaken) => {
+                write!(
+                    f,
+                    "{} is shaken by their ally's death and breaks the bond.",
+                    shaken
+                )
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_alliance_formed_unchanged() {
+        let s = GameOutput::AllianceFormed("Alice", "Bob", "trust").to_string();
+        assert_eq!(s, "Alice and Bob form an alliance (trust).");
+    }
+
+    #[test]
+    fn display_betrayal_triggered_unchanged() {
+        let s = GameOutput::BetrayalTriggered("Cato", "Glimmer").to_string();
+        assert_eq!(
+            s,
+            "Cato betrays Glimmer — true to their treacherous nature."
+        );
+    }
+
+    #[test]
+    fn display_trust_shock_break_unchanged() {
+        let s = GameOutput::TrustShockBreak("Rue").to_string();
+        assert_eq!(
+            s,
+            "Rue is shaken by their ally's death and breaks the bond."
+        );
     }
 }

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -258,10 +258,9 @@ impl Tribute {
                         betrayer: self.id,
                         victim: victim.id,
                     });
-                events.push(format!(
-                    "{} betrays {} — true to their treacherous nature.",
-                    self.name, victim.name
-                ));
+                // The human-readable betrayal line is emitted at the game
+                // level inside `process_alliance_events` so it can be tagged
+                // with `MessageKind::BetrayalTriggered`. See games.rs.
             }
             // Reset the timer whether or not an ally was available.
             self.turns_since_last_betrayal = 0;

--- a/migrations/20260426_180000_MessageKind.surql
+++ b/migrations/20260426_180000_MessageKind.surql
@@ -1,0 +1,6 @@
+-- Add optional `kind` field to message rows so engine-emitted alliance
+-- events can be tagged with a typed `MessageKind` (see
+-- `game::messages::MessageKind`). Existing rows have no `kind` and remain
+-- valid because the field is optional.
+DEFINE FIELD OVERWRITE kind ON message TYPE option<string>;
+DEFINE INDEX OVERWRITE message_kind ON message FIELDS kind;

--- a/schemas/logs.surql
+++ b/schemas/logs.surql
@@ -12,12 +12,16 @@ DEFINE FIELD OVERWRITE game_day ON message TYPE number;
 DEFINE FIELD OVERWRITE subject ON message TYPE string;
 DEFINE FIELD OVERWRITE timestamp ON message TYPE number;
 DEFINE FIELD OVERWRITE content ON message TYPE string;
+-- Optional typed category for engine-emitted events. See
+-- `game::messages::MessageKind`. Legacy rows leave this unset.
+DEFINE FIELD OVERWRITE kind ON message TYPE option<string>;
 
 -- Define indexes for querying
 DEFINE INDEX OVERWRITE message_timestamp ON message FIELDS timestamp;
 DEFINE INDEX OVERWRITE message_game_day ON message FIELDS game_day;
 DEFINE INDEX OVERWRITE message_source_type ON message FIELDS source.type;
 DEFINE INDEX OVERWRITE message_game_id ON message FIELDS source.value;
+DEFINE INDEX OVERWRITE message_kind ON message FIELDS kind;
 
 -- Helper functions for common queries
 DEFINE FUNCTION OVERWRITE fn::get_messages_by_day($day: number) {


### PR DESCRIPTION
## Summary

Engine half of bead \`hangrier_games-5yr\` (alliance event timeline). Promotes 3 alliance-related log lines to structured \`GameOutput\` variants and tags every emitted \`GameMessage\` with an optional typed \`kind\` so the web UI can filter the alliance timeline. Web UI half ships separately.

## Changes

- \`game/src/output.rs\` — 3 new \`GameOutput\` variants (\`AllianceFormed\`, \`BetrayalTriggered\`, \`TrustShockBreak\`) with byte-identical Display strings; tests cover Display unchanged.
- \`game/src/messages.rs\` — \`MessageKind\` enum + optional \`kind\` field on \`GameMessage\` (\`#[serde(default, skip_serializing_if = \"Option::is_none\")]\`), plus \`GameMessage::with_kind\` constructor and serde tests.
- \`game/src/games.rs\` — new \`log_output_kind\` helper; alliance-formation, trust-shock, and betrayal emission sites now emit structured \`GameOutput\` + \`MessageKind\`. Two new integration tests assert kinds are attached.
- \`game/src/tributes/mod.rs\` — removed string push for betrayal line; emission moved up to \`process_alliance_events\` (BetrayalRecorded already carries betrayer + victim UUIDs).
- \`schemas/logs.surql\` — optional \`kind\` field + index (SCHEMAFULL).
- \`migrations/20260426_180000_MessageKind.surql\` — new migration adding the field.

## Verification

\`\`\`
cargo fmt --all                                                  # clean
cargo test -p game                                               # 652 passed
cargo clippy -p game -- -D warnings                              # clean
cargo check -p api                                               # ok
RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"' \\
  cargo check -p web --target wasm32-unknown-unknown             # ok
\`\`\`

Player-facing log strings unchanged byte-for-byte. No new MessageKind variants beyond the 3 listed. Web crate untouched.

## Follow-ups

- Bead \`hangrier_games-5yr\` stays \`in_progress\` — web UI half (filter alliance timeline by \`MessageKind\`) ships in a separate PR.
- \`Tribute.brain\` \`#[serde(skip)]\` deferred to bead \`szl\` (out of scope here).