### PR TITLE
feat(web): alliance event timeline categorized rendering

### DIFF
--- a/web/src/components/game_day_log.rs
+++ b/web/src/components/game_day_log.rs
@@ -3,8 +3,20 @@ use crate::env::APP_API_HOST;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
-use game::messages::GameMessage;
+use game::messages::{GameMessage, MessageKind};
 use shared::DisplayGame;
+
+/// Returns (container_classes, leading_glyph) for a categorised message.
+/// `None` keeps the legacy plain rendering.
+fn kind_styles(kind: &MessageKind) -> (&'static str, &'static str) {
+    match kind {
+        MessageKind::AllianceFormed => {
+            ("border-l-4 border-emerald-500 pl-2 bg-emerald-500/10", "🤝")
+        }
+        MessageKind::BetrayalTriggered => ("border-l-4 border-rose-500 pl-2 bg-rose-500/10", "🗡️"),
+        MessageKind::TrustShockBreak => ("border-l-4 border-amber-500 pl-2 bg-amber-500/10", "💔"),
+    }
+}
 
 async fn fetch_game_day_log(
     keys: Vec<QueryKey>,
@@ -61,8 +73,22 @@ pub fn GameDayLog(game: DisplayGame, day: u32) -> Element {
                     theme3:text-stone-800
                     "#,
                     for log in logs {
-                        li {
-                            "{log.content}"
+                        {
+                            match log.kind.as_ref() {
+                                Some(kind) => {
+                                    let (classes, glyph) = kind_styles(kind);
+                                    rsx! {
+                                        li {
+                                            class: "{classes}",
+                                            span { class: "mr-2", "{glyph}" }
+                                            "{log.content}"
+                                        }
+                                    }
+                                }
+                                _ => rsx! {
+                                    li { "{log.content}" }
+                                },
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Players can now visually distinguish alliance lifecycle events in the game-day log. Categorized `GameMessage` entries (introduced engine-side in #125) get an icon + colored left border so alliances forming, betrayals firing, and trust shocks breaking stand out from the rest of the play-by-play stream.

## Changes

- `web/src/components/game_day_log.rs`
  - Import `MessageKind` from `game::messages`.
  - Add `kind_styles(&MessageKind)` helper returning `(Tailwind classes, leading glyph)`.
  - Per-log rendering: match on `log.kind`. Categorized messages render with `border-l-4`, tinted `bg-*-500/10`, and a leading glyph (`mr-2`). Uncategorized messages keep the existing plain `<li>` rendering. Wildcard arm keeps the component future-proof against new variants.

Visual mapping:
- `AllianceFormed` → emerald + 🤝
- `BetrayalTriggered` → rose + 🗡️
- `TrustShockBreak` → amber + 💔

## Verification

- `cargo fmt --all` — clean
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check -p web --target wasm32-unknown-unknown` — pass
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo clippy -p web --target wasm32-unknown-unknown -- -D warnings` — pass
- `cargo check -p game` — pass (sanity, no game changes)
- `just build-css` — pass

## Closes

Closes hangrier_games-5yr (engine half landed in #125; this completes the bead).

## Follow-ups

None. The new color utilities (`emerald-500`, `rose-500`, `amber-500` and their `/10` slash-opacity variants) follow the same Tailwind v4 utility patterns used elsewhere in the codebase and will be picked up by `dx serve` / `dx build`'s CSS pipeline.