### PR TITLE
feat(game): introduce structured GameEvent enum

### DIFF
--- a/docs/superpowers/specs/2026-04-26-game-event-enum.md
+++ b/docs/superpowers/specs/2026-04-26-game-event-enum.md
@@ -1,0 +1,139 @@
+# GameEvent enum — structured replacement for GameOutput
+
+**Date:** 2026-04-26
+**Bead:** [hangrier_games-mqi.1](../../../.beads) — first child of the **mqi** epic ("Migrate event log from stringly-typed GameOutput to structured GameEvent")
+**Status:** Implemented (this PR introduces the type; no emission sites switched yet)
+**Author:** rust-engineer agent
+
+## Rationale
+
+`GameOutput` (in `game/src/output.rs`) is the engine's only event vocabulary today. It has two jobs jammed into one type:
+
+1. **Render** the player-facing log line (what the `Display` impl produces).
+2. **Identify** what happened so consumers (DB, websocket clients, announcers, future analytics) can react.
+
+Job 1 it does well. Job 2 it does badly:
+
+- Variants borrow `&'a str`, so events cannot be stored, queued, or sent across threads.
+- Names appear in payloads but UUIDs do not — a downstream consumer has no stable handle for the tribute, area, or item involved.
+- Some variants (`TributeMauled`) accept stringly-typed enum members (`animal: &str`) and `FromStr` them inside `Display`, so a malformed string panics at render time.
+- Adding any new field to a tuple variant is a breaking call-site change.
+
+Downstream code (announcers in particular, plus the Game.messages buffer landed in mqi precursor PR #125) is forced to either pre-stringify everything before the engine touches it or re-parse the rendered sentence. Both options are fragile.
+
+`GameEvent` solves this by carrying **typed, owned, serde-friendly** fields. The engine's render path stays identical (Display still produces the same bytes), so this is a *purely additive* change in this bead. Subsequent beads (mqi.2–6) will migrate emission sites and persistence layers off `GameOutput`.
+
+## Scope of this bead (mqi.1)
+
+-  Introduce `game::events::GameEvent` enum.
+-  One variant per existing `GameOutput` variant (77 total).
+-  `Display` impl producing **byte-identical** strings.
+-  `Debug, Clone, PartialEq, Serialize, Deserialize` derives.
+-  Parity tests asserting Display equality across all 77 variants.
+-  Serde roundtrip tests covering every distinct payload shape.
+-  No emission sites changed (mqi.2).
+-  No persistence wiring (mqi.3).
+-  No announcer integration (mqi.4+).
+
+## Variant inventory
+
+All 77 `GameOutput` variants have a 1:1 `GameEvent` counterpart with the same name. The parity table in `game/src/events.rs::tests::parity_table` is the authoritative mapping; `parity_table_covers_every_variant` enforces the count via assertion.
+
+Categories (for readability — the enum itself is flat):
+
+| Category | Variant count | Examples |
+|---|---:|---|
+| Day/night cycle | 11 | `GameDayStart`, `FirstDayStart`, `TributesLeft`, `TributeWins` |
+| Rest/hide/movement | 12 | `TributeRest`, `TributeTravel`, `TributeTakeItem`, `TributeUseItem` |
+| Status effects (single tribute) | 19 | `TributeBleeds`, `TributeMauled`, `TributeHorrified`, `TributeSuicide` |
+| Combat | 12 | `TributeAttackWin`, `TributeCriticalHit`, `TributePerfectBlock` |
+| Death | 6 | `TributeDiesFromStatus`, `TributeAlreadyDead`, `TributeDeath` |
+| Items / equipment | 5 | `WeaponBreak`, `ShieldWear`, `SponsorGift` |
+| Area events | 5 | `AreaEvent`, `AreaClose`, `TrappedInArea`, `DiedInArea` |
+| Social / alliance | 7 | `AllianceFormed`, `BetrayalTriggered`, `TrustShockBreak` |
+
+(Bead description estimated 75 variants; actual count is 77 because two alliance variants — `TributeBetrayal` and `TributeForcedBetrayal` — and the `TributeTravelNoOptions` variant slipped in after the bead was written. All are included.)
+
+## Design decisions
+
+### 1. Named struct variants everywhere
+
+`GameOutput` uses positional tuple variants (`AllianceFormed(&str, &str, &str)`). `GameEvent` uses named struct variants (`AllianceFormed { tribute_a_id, tribute_a_name, tribute_b_id, tribute_b_name, factor }`).
+
+**Why:** future fields can be added without breaking call sites, JSON output is self-describing, and pattern-match arms read like documentation. Cost is verbosity, which is acceptable for a type defined once and consumed many times.
+
+### 2. Carry both UUID and name
+
+Where `GameOutput` carries only a name (`TributeRest("Alice")`), `GameEvent` carries `tribute_id: Uuid` **and** `tribute_name: String`.
+
+**Why:**
+- The UUID is the only stable cross-system reference. Names can collide (two "Cato"s in different games), names can be edited, names embed in URLs poorly.
+- The name is needed verbatim for `Display` to reproduce the legacy log line. We refuse to make `Display` perform a name lookup against external state — the event must be self-contained.
+- Storing both is a few bytes per event. We are not in a memory-constrained environment.
+
+### 3. Embed full `Item`, not just name
+
+`TributeUseItem` and `SponsorGift` carry the entire `Item` struct. `Item` is already `Clone + Serialize + Deserialize + PartialEq`, and the rendered string needs `item.name`, `item.effect`, `item.attribute`, `item.current_durability`, `item.max_durability`. Embedding the whole struct is simpler than fanning fields out and keeps the event a faithful record of what happened.
+
+### 4. Animal as enum, not string
+
+`GameOutput::TributeMauled` carries `animal: &str` and parses it via `Animal::from_str` inside `Display` (a `.unwrap()` that would panic on a typo). `GameEvent::TributeMauled` carries `animal: Animal` directly. The parity test passes the discriminant name (`"Wolf"`) to `GameOutput` and `Animal::Wolf` to `GameEvent`, and both render `"wolves"` via `Animal::plural()`.
+
+### 5. Serde shape: externally-tagged (default)
+
+```json
+{"GameDayStart": {"day_number": 4}}
+{"AllianceFormed": {"tribute_a_id": "11111111-…", "tribute_a_name": "Alice", …}}
+{"FirstDayStart": null}    // unit variant
+```
+
+**Alternatives considered:**
+
+| Shape | Pros | Cons |
+|---|---|---|
+| **Externally-tagged** (chosen) | Default, no attribute noise, unambiguous, plays nicely with unit variants and named-struct variants alike, every serde adapter on every wire format already handles it. | Slightly verbose JSON; the variant name is a JSON object key (not a field). |
+| Internally-tagged `#[serde(tag = "type")]` | Flatter JSON: `{"type": "GameDayStart", "day_number": 4}`. Reads nicely in DB browsers. | **Cannot represent unit variants** (`FirstDayStart`) without workaround; cannot represent newtype-of-non-struct variants. Would require splitting the enum or per-variant remediation. |
+| Adjacently-tagged `#[serde(tag = "type", content = "data")]` | Round-trips every variant shape, structurally explicit. | Doubly-nested JSON for the common case; harder to query in SurrealDB without `data.*` paths everywhere. |
+| Untagged | Cleanest JSON when payloads are distinguishable. | Payload shapes overlap heavily here (many variants are `{tribute_id, tribute_name}`), so deserialization would be ambiguous. Non-starter. |
+
+Externally-tagged is the only shape that handles all 77 variants uniformly with zero attribute noise and zero ambiguity. The JSON-key-is-variant-name aspect is the cost we pay for that uniformity, and downstream consumers (SurrealDB JSON, websocket frames, announcer prompts) can handle it.
+
+### 6. Selective `Eq + Hash`
+
+The bead acceptance criteria suggested adding `Eq + Hash` only to UUID-only variants. After implementation, almost every variant carries a `String` (the rendered name), and `String` is `Eq + Hash`, so the discriminator could in principle apply broadly. However, two variants embed `Item`, and `Item` does not currently derive `Hash`. Rather than thread `Hash` through `Item` purely for this enum, **`GameEvent` derives `Debug + Clone + PartialEq + Serialize + Deserialize` only.** Consumers that need `Hash` should hash a stable identifier (e.g. a future `event_id: Uuid` field added in mqi.3) rather than the entire payload.
+
+If `Eq + Hash` becomes load-bearing later, a sibling `#[derive(Hash)]` on `Item` is the right fix.
+
+### 7. No I/O, no DB, no announcer plumbing
+
+This bead is type design. The engine still emits `GameOutput` exclusively. The next bead (mqi.2) will switch emission sites one cluster at a time (alliance first, then combat, then status effects, etc.) and run both paths in parallel until parity is verified end-to-end.
+
+## Migration plan
+
+| Bead | Scope |
+|---|---|
+| **mqi.1** (this PR) | Introduce `GameEvent` + parity tests. |
+| mqi.2 | Switch emission sites to also emit `GameEvent` alongside `GameOutput`; add `Game.event_log: Vec<GameEvent>` buffer in `game::games`. |
+| mqi.3 | Persist `GameEvent` in SurrealDB; add migration; expose via API read endpoints. |
+| mqi.4 | Announcer (`announcers/`) consumes structured events instead of parsing rendered sentences. |
+| mqi.5 | Frontend (`web/`) consumes structured events for live tickers. |
+| mqi.6 | Remove `GameOutput` and the parallel emission path. |
+
+Each step is independently shippable; if any step regresses, the parallel `GameOutput` path remains intact until mqi.6.
+
+## Open questions
+
+1. **Event identity.** Should `GameEvent` carry an `event_id: Uuid` and a `timestamp: DateTime<Utc>` of its own, mirroring `GameMessage`? Likely yes, but added in mqi.3 when persistence lands so the schema is final.
+2. **Severity.** PR #122 introduced event severity for messages (Info / Warning / Critical). Should `GameEvent` expose a `fn severity(&self) -> Severity` method? Probably yes, again deferred to mqi.3.
+3. **`AreaEvent` typing.** Currently `area_event: String`. Long-term this should be an `AreaEventKind` enum mirroring the `MessageKind` precedent. Captured as a follow-up — not in scope for mqi.1.
+4. **Removing `GameOutput`.** After mqi.6, `GameOutput` is dead code. Removal is a breaking change for any external consumer that re-exports it (none today), so it can land in mqi.6 itself.
+
+## Verification
+
+- `cargo test -p game --lib events::` — 7 new tests pass.
+- `cargo test -p game --lib` — 475 total tests pass (was 468; delta +7).
+- `cargo clippy -p game --all-targets -- -D warnings` — clean.
+- `cargo check -p api` — clean.
+- WASM check on `web` — clean.
+- `display_matches_game_output_for_every_variant` asserts byte-identical Display output across all 77 variants.
+- `parity_table_covers_every_variant` ensures the table grows in lockstep with the enum.

--- a/game/src/events.rs
+++ b/game/src/events.rs
@@ -1,0 +1,1615 @@
+//! Structured `GameEvent` enum — the typed counterpart to [`crate::output::GameOutput`].
+//!
+//! `GameOutput` is a borrowed, stringly-typed enum used purely to render
+//! player-facing log lines. `GameEvent` is owned, serde-friendly, and carries
+//! the original typed fields (UUIDs, numbers, names, items) so downstream
+//! consumers (DB, websockets, analytics, announcers) can react to *what
+//! happened* rather than re-parsing a localized sentence.
+//!
+//! This module is introduced in mqi.1. No emission sites have switched yet —
+//! the engine still emits `GameOutput`. Parity tests below guarantee that
+//! every `GameEvent` variant renders to a byte-identical string when fed the
+//! same data as the matching `GameOutput` variant, so future emission-site
+//! migration (mqi.2) and persistence (mqi.3) can proceed in lockstep without
+//! changing player-visible log output.
+//!
+//! Design decisions documented in
+//! `docs/superpowers/specs/2026-04-26-game-event-enum.md`.
+
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::items::Item;
+use crate::threats::animals::Animal;
+use indefinite::{indefinite, indefinite_capitalized};
+
+/// Structured, owned, serde-friendly counterpart to [`crate::output::GameOutput`].
+///
+/// Every variant of `GameOutput` has a matching variant here. Fields use
+/// owned types so the event can outlive the borrowed sources that produced
+/// it, and named struct variants are used throughout so future fields can be
+/// added without breaking call sites.
+///
+/// Where `GameOutput` only carries names (e.g. tribute display names),
+/// `GameEvent` carries both a UUID (`*_id`) for stable cross-system reference
+/// **and** the rendered name (`*_name`) so [`Display`] can reproduce the
+/// exact log line without a name-lookup round-trip.
+///
+/// Serialization uses serde's default externally-tagged representation, which
+/// gives unambiguous JSON shapes for every variant and round-trips cleanly
+/// without bespoke deserialization logic.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum GameEvent {
+    // ---- Day / night cycle markers ----
+    GameDayStart {
+        day_number: u32,
+    },
+    GameDayEnd {
+        day_number: u32,
+    },
+    FirstDayStart,
+    FeastDayStart,
+    TributesLeft {
+        tribute_count: u32,
+    },
+    GameNightStart {
+        day_number: u32,
+    },
+    GameNightEnd {
+        day_number: u32,
+    },
+    DailyDeathAnnouncement {
+        death_count: u32,
+    },
+    DeathAnnouncement {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    NoOneWins,
+    TributeWins {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+
+    // ---- Rest / hide / movement ----
+    TributeRest {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeLongRest {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeHide {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeTravel {
+        tribute_id: Uuid,
+        tribute_name: String,
+        from_area: String,
+        to_area: String,
+    },
+    TributeTakeItem {
+        tribute_id: Uuid,
+        tribute_name: String,
+        item_name: String,
+    },
+    TributeCannotUseItem {
+        tribute_id: Uuid,
+        tribute_name: String,
+        item_name: String,
+    },
+    TributeUseItem {
+        tribute_id: Uuid,
+        tribute_name: String,
+        item: Item,
+    },
+    TributeTravelTooTired {
+        tribute_id: Uuid,
+        tribute_name: String,
+        area: String,
+    },
+    TributeTravelExhausted {
+        tribute_id: Uuid,
+        tribute_name: String,
+        area: String,
+    },
+    TributeTravelAlreadyThere {
+        tribute_id: Uuid,
+        tribute_name: String,
+        area: String,
+    },
+    TributeTravelFollow {
+        tribute_id: Uuid,
+        tribute_name: String,
+        area: String,
+    },
+    TributeTravelStay {
+        tribute_id: Uuid,
+        tribute_name: String,
+        area: String,
+    },
+    TributeTravelNoOptions {
+        tribute_id: Uuid,
+        tribute_name: String,
+        area: String,
+    },
+
+    // ---- Status effects (single-tribute) ----
+    TributeBleeds {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeSick {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeElectrocuted {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeFrozen {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeOverheated {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeDehydrated {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeStarving {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributePoisoned {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeBrokenArm {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeBrokenLeg {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeInfected {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeDrowned {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeMauled {
+        tribute_id: Uuid,
+        tribute_name: String,
+        animal_count: u32,
+        animal: Animal,
+        damage: u32,
+    },
+    TributeBurned {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeHorrified {
+        tribute_id: Uuid,
+        tribute_name: String,
+        sanity_damage: u32,
+    },
+    TributeSuffer {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeSelfHarm {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeSuicide {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+
+    // ---- Combat ----
+    TributeAttackWin {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    TributeAttackWinExtra {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    TributeAttackWound {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    TributeAttackLose {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    TributeAttackLoseExtra {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    TributeAttackMiss {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    TributeAttackDied {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    TributeAttackSuccessKill {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    TributeAttackHidden {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    /// Natural 20 on attack roll.
+    TributeCriticalHit {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    /// Natural 1 on attack roll.
+    TributeCriticalFumble {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    /// Natural 20 on defense roll.
+    TributePerfectBlock {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+
+    // ---- Death ----
+    TributeDiesFromStatus {
+        tribute_id: Uuid,
+        tribute_name: String,
+        status: String,
+    },
+    TributeDiesFromAreaEvent {
+        tribute_id: Uuid,
+        tribute_name: String,
+        area_event: String,
+    },
+    TributeDiesFromTributeEvent {
+        tribute_id: Uuid,
+        tribute_name: String,
+        tribute_event: String,
+    },
+    TributeAlreadyDead {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeDead {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    TributeDeath {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+
+    // ---- Items / equipment ----
+    WeaponBreak {
+        tribute_id: Uuid,
+        tribute_name: String,
+        weapon_name: String,
+    },
+    WeaponWear {
+        tribute_id: Uuid,
+        tribute_name: String,
+        weapon_name: String,
+    },
+    ShieldBreak {
+        tribute_id: Uuid,
+        tribute_name: String,
+        shield_name: String,
+    },
+    ShieldWear {
+        tribute_id: Uuid,
+        tribute_name: String,
+        shield_name: String,
+    },
+    SponsorGift {
+        tribute_id: Uuid,
+        tribute_name: String,
+        item: Item,
+    },
+
+    // ---- Area events ----
+    AreaEvent {
+        area_event: String,
+        area_name: String,
+    },
+    AreaClose {
+        area_name: String,
+    },
+    AreaOpen {
+        area_name: String,
+    },
+    TrappedInArea {
+        tribute_id: Uuid,
+        tribute_name: String,
+        area_name: String,
+    },
+    DiedInArea {
+        tribute_id: Uuid,
+        tribute_name: String,
+        area_name: String,
+    },
+
+    // ---- Social / alliance ----
+    TributeBetrayal {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    TributeForcedBetrayal {
+        tribute_id: Uuid,
+        tribute_name: String,
+        target_id: Uuid,
+        target_name: String,
+    },
+    NoOneToAttack {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    AllAlone {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+    AllianceFormed {
+        tribute_a_id: Uuid,
+        tribute_a_name: String,
+        tribute_b_id: Uuid,
+        tribute_b_name: String,
+        factor: String,
+    },
+    BetrayalTriggered {
+        betrayer_id: Uuid,
+        betrayer_name: String,
+        victim_id: Uuid,
+        victim_name: String,
+    },
+    TrustShockBreak {
+        tribute_id: Uuid,
+        tribute_name: String,
+    },
+}
+
+impl Display for GameEvent {
+    #[allow(clippy::too_many_lines)]
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GameEvent::GameDayStart { day_number } => {
+                write!(f, "=== ☀️ Day {} begins! ===", day_number)
+            }
+            GameEvent::GameDayEnd { day_number } => {
+                write!(f, "=== ☀️ Day {} ends! ===", day_number)
+            }
+            GameEvent::FirstDayStart => {
+                write!(f, "=== 🎉 The Hangry Games begin! 🎉 ===")
+            }
+            GameEvent::FeastDayStart => {
+                write!(f, "=== 😋 Day 3: Feast Day ===")
+            }
+            GameEvent::TributesLeft { tribute_count } => {
+                write!(f, "=== 📌 Tributes alive: {} ===", tribute_count)
+            }
+            GameEvent::GameNightStart { day_number } => {
+                write!(f, "=== 🌙 Night {} begins ===", day_number)
+            }
+            GameEvent::GameNightEnd { day_number } => {
+                write!(f, "=== 🌙 Night {} ends ===", day_number)
+            }
+            GameEvent::DailyDeathAnnouncement { death_count } => {
+                write!(f, "=== 💀 Tributes dead: {} ===", death_count)
+            }
+            GameEvent::DeathAnnouncement { tribute_name, .. } => {
+                write!(f, "=== 🪦 {} has died ===", tribute_name)
+            }
+            GameEvent::NoOneWins => {
+                write!(f, "=== 🎭 No one wins! ===")
+            }
+            GameEvent::TributeWins { tribute_name, .. } => {
+                write!(f, "=== 🏆 The winner is {} ===", tribute_name)
+            }
+            GameEvent::TributeRest { tribute_name, .. } => {
+                write!(f, "😪 {} rests", tribute_name)
+            }
+            GameEvent::TributeLongRest { tribute_name, .. } => {
+                write!(
+                    f,
+                    "💤 {} rests and recovers a little health and sanity",
+                    tribute_name
+                )
+            }
+            GameEvent::TributeHide { tribute_name, .. } => {
+                write!(f, "🫥 {} tries to hide", tribute_name)
+            }
+            GameEvent::TributeTravel {
+                tribute_name,
+                from_area,
+                to_area,
+                ..
+            } => {
+                write!(
+                    f,
+                    "🚶 {} moves from {} to {}",
+                    tribute_name, from_area, to_area
+                )
+            }
+            GameEvent::TributeTakeItem {
+                tribute_name,
+                item_name,
+                ..
+            } => {
+                let object = indefinite(item_name);
+                write!(f, "🔨 {} takes {}", tribute_name, object)
+            }
+            GameEvent::TributeCannotUseItem {
+                tribute_name,
+                item_name,
+                ..
+            } => {
+                let object = indefinite(item_name);
+                write!(f, "❌ {} cannot use {}", tribute_name, object)
+            }
+            GameEvent::TributeUseItem {
+                tribute_name, item, ..
+            } => {
+                let object = indefinite(&item.name);
+                write!(
+                    f,
+                    "💊 {} uses {}, gains {} {}",
+                    tribute_name, object, item.effect, item.attribute
+                )
+            }
+            GameEvent::TributeTravelTooTired {
+                tribute_name, area, ..
+            } => {
+                write!(
+                    f,
+                    "😴 {} is too tired to move from {}, rests instead",
+                    tribute_name, area
+                )
+            }
+            GameEvent::TributeTravelExhausted {
+                tribute_name, area, ..
+            } => {
+                write!(
+                    f,
+                    "🥵 {} is too exhausted to move from {}, lacks stamina",
+                    tribute_name, area
+                )
+            }
+            GameEvent::TributeTravelAlreadyThere {
+                tribute_name, area, ..
+            } => {
+                write!(
+                    f,
+                    "🤔 {} is already in the {}, stays put",
+                    tribute_name, area
+                )
+            }
+            GameEvent::TributeTravelFollow {
+                tribute_name, area, ..
+            } => {
+                write!(
+                    f,
+                    "🫡 {} follows their district mate to {}",
+                    tribute_name, area
+                )
+            }
+            GameEvent::TributeTravelStay {
+                tribute_name, area, ..
+            } => {
+                write!(f, "🪑 {} stays in {}", tribute_name, area)
+            }
+            GameEvent::TributeTravelNoOptions {
+                tribute_name, area, ..
+            } => {
+                write!(
+                    f,
+                    "📍 {} has nowhere to go, stays in {}",
+                    tribute_name, area
+                )
+            }
+            GameEvent::TributeBleeds { tribute_name, .. } => {
+                write!(f, "🩸 {} bleeds from their wounds.", tribute_name)
+            }
+            GameEvent::TributeSick { tribute_name, .. } => {
+                write!(
+                    f,
+                    "🤒 {} contracts dysentery, loses strength and speed",
+                    tribute_name
+                )
+            }
+            GameEvent::TributeElectrocuted { tribute_name, .. } => {
+                write!(
+                    f,
+                    "🌩️ {} is struck by lightning, loses health",
+                    tribute_name
+                )
+            }
+            GameEvent::TributeFrozen { tribute_name, .. } => {
+                write!(
+                    f,
+                    "🥶 {} suffers from hypothermia, loses speed.",
+                    tribute_name
+                )
+            }
+            GameEvent::TributeOverheated { tribute_name, .. } => {
+                write!(
+                    f,
+                    "🥵 {} suffers from heat stroke, loses speed.",
+                    tribute_name
+                )
+            }
+            GameEvent::TributeDehydrated { tribute_name, .. } => {
+                write!(
+                    f,
+                    "🌵 {} is severely dehydrated, loses strength",
+                    tribute_name
+                )
+            }
+            GameEvent::TributeStarving { tribute_name, .. } => {
+                write!(
+                    f,
+                    "🍴 {} is ravenously hungry, loses strength",
+                    tribute_name
+                )
+            }
+            GameEvent::TributePoisoned { tribute_name, .. } => {
+                write!(
+                    f,
+                    "🧪 {} eats something poisonous, loses sanity",
+                    tribute_name
+                )
+            }
+            GameEvent::TributeBrokenArm { tribute_name, .. } => {
+                write!(f, "🦴 {} injures their arm, loses strength.", tribute_name)
+            }
+            GameEvent::TributeBrokenLeg { tribute_name, .. } => {
+                write!(f, "🦴 {} injures their leg, loses speed.", tribute_name)
+            }
+            GameEvent::TributeInfected { tribute_name, .. } => {
+                write!(
+                    f,
+                    "🤢 {} gets an infection, loses health and sanity",
+                    tribute_name
+                )
+            }
+            GameEvent::TributeDrowned { tribute_name, .. } => {
+                write!(
+                    f,
+                    "🏊 {} partially drowns, loses health and sanity",
+                    tribute_name
+                )
+            }
+            GameEvent::TributeMauled {
+                tribute_name,
+                animal_count,
+                animal,
+                damage,
+                ..
+            } => {
+                write!(
+                    f,
+                    "🐾 {} is attacked by {} {}, takes {} damage!",
+                    tribute_name,
+                    animal_count,
+                    animal.plural(),
+                    damage
+                )
+            }
+            GameEvent::TributeBurned { tribute_name, .. } => {
+                write!(f, "🔥 {} gets burned, loses health", tribute_name)
+            }
+            GameEvent::TributeHorrified {
+                tribute_name,
+                sanity_damage,
+                ..
+            } => {
+                write!(
+                    f,
+                    "😱 {} is horrified by the violence, loses {} sanity.",
+                    tribute_name, sanity_damage
+                )
+            }
+            GameEvent::TributeSuffer { tribute_name, .. } => {
+                write!(f, "😭 {} suffers from loneliness and terror.", tribute_name)
+            }
+            GameEvent::TributeSelfHarm { tribute_name, .. } => {
+                write!(f, "🤦 {} tries to attack themself!", tribute_name)
+            }
+            GameEvent::TributeSuicide { tribute_name, .. } => {
+                write!(f, "🪒 {} attempts suicide.", tribute_name)
+            }
+            GameEvent::TributeAttackWin {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(f, "🔪 {} attacks {}, and wins!", tribute_name, target_name)
+            }
+            GameEvent::TributeAttackWinExtra {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "🔪 {} attacks {}, and wins decisively!",
+                    tribute_name, target_name
+                )
+            }
+            GameEvent::TributeAttackWound {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(f, "🤕 {} wounds {}", tribute_name, target_name)
+            }
+            GameEvent::TributeAttackLose {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(f, "🤣 {} attacks {}, but loses!", tribute_name, target_name)
+            }
+            GameEvent::TributeAttackLoseExtra {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "🤣 {} attacks {}, but loses decisively!",
+                    tribute_name, target_name
+                )
+            }
+            GameEvent::TributeAttackMiss {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "😰 {} attacks {}, but misses!",
+                    tribute_name, target_name
+                )
+            }
+            GameEvent::TributeAttackDied {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(f, "☠️ {} is killed by {}", tribute_name, target_name)
+            }
+            GameEvent::TributeAttackSuccessKill {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(f, "☠️ {} successfully kills {}", tribute_name, target_name)
+            }
+            GameEvent::TributeAttackHidden {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "🤔 {} can't attack {}, they're hidden",
+                    tribute_name, target_name
+                )
+            }
+            GameEvent::TributeCriticalHit {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "💥 {} lands a CRITICAL HIT on {}!",
+                    tribute_name, target_name
+                )
+            }
+            GameEvent::TributeCriticalFumble { tribute_name, .. } => {
+                write!(
+                    f,
+                    "😵 {} fumbles their attack badly and hurts themself!",
+                    tribute_name
+                )
+            }
+            GameEvent::TributePerfectBlock {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "🛡️ {} perfectly blocks {}'s attack and counters!",
+                    tribute_name, target_name
+                )
+            }
+            GameEvent::TributeDiesFromStatus {
+                tribute_name,
+                status,
+                ..
+            } => {
+                write!(f, "💀 {} dies from {}", tribute_name, status)
+            }
+            GameEvent::TributeDiesFromAreaEvent {
+                tribute_name,
+                area_event,
+                ..
+            } => {
+                write!(f, "🪦 {} died in the {}.", tribute_name, area_event)
+            }
+            GameEvent::TributeDiesFromTributeEvent {
+                tribute_name,
+                tribute_event,
+                ..
+            } => {
+                write!(f, "💀 {} dies by {}", tribute_name, tribute_event)
+            }
+            GameEvent::TributeAlreadyDead { tribute_name, .. } => {
+                write!(f, "‼️ {} is already dead!", tribute_name)
+            }
+            GameEvent::TributeDead { tribute_name, .. } => {
+                write!(f, "❗️ {} is dead!", tribute_name)
+            }
+            GameEvent::WeaponBreak {
+                tribute_name,
+                weapon_name,
+                ..
+            } => {
+                write!(f, "🗡️ {} breaks their {}", tribute_name, weapon_name)
+            }
+            GameEvent::WeaponWear {
+                tribute_name,
+                weapon_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "🗡️ {}'s {} is showing signs of wear",
+                    tribute_name, weapon_name
+                )
+            }
+            GameEvent::ShieldBreak {
+                tribute_name,
+                shield_name,
+                ..
+            } => {
+                write!(f, "🛡️ {} breaks their {}", tribute_name, shield_name)
+            }
+            GameEvent::ShieldWear {
+                tribute_name,
+                shield_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "🛡️ {}'s {} is showing signs of wear",
+                    tribute_name, shield_name
+                )
+            }
+            GameEvent::SponsorGift {
+                tribute_name, item, ..
+            } => {
+                let object = indefinite(&item.name);
+                write!(
+                    f,
+                    "🎁 {} receives {} (durability {}/{} {} +{})",
+                    tribute_name,
+                    object,
+                    item.current_durability,
+                    item.max_durability,
+                    item.attribute,
+                    item.effect
+                )
+            }
+            GameEvent::AreaEvent {
+                area_event,
+                area_name,
+            } => {
+                let area_short = area_name.replace("The ", "");
+                let event = indefinite_capitalized(area_event);
+                write!(f, "=== ⚠️ {} has occurred in the {} ===", event, area_short)
+            }
+            GameEvent::AreaClose { area_name } => {
+                let area_short = area_name.replace("The ", "");
+                write!(f, "=== 🔔 The {} is uninhabitable ===", area_short)
+            }
+            GameEvent::AreaOpen { area_name } => {
+                let area_short = area_name.replace("The ", "");
+                write!(f, "=== 🔔 The {} is habitable again ===", area_short)
+            }
+            GameEvent::TrappedInArea {
+                tribute_name,
+                area_name,
+                ..
+            } => {
+                let area_short = area_name.replace("The ", "");
+                write!(f, "💥 {} is trapped in the {}.", tribute_name, area_short)
+            }
+            GameEvent::DiedInArea {
+                tribute_name,
+                area_name,
+                ..
+            } => {
+                let area_short = area_name.replace("The ", "");
+                write!(f, "💥 {} died in the {}.", tribute_name, area_short)
+            }
+            GameEvent::TributeDeath { tribute_name, .. } => {
+                write!(f, "⚰️ {} has died.", tribute_name)
+            }
+            GameEvent::TributeBetrayal {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(f, "💔 {} betrays {}!", tribute_name, target_name)
+            }
+            GameEvent::TributeForcedBetrayal {
+                tribute_name,
+                target_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "💔💔 {} is forced to betray {}!",
+                    tribute_name, target_name
+                )
+            }
+            GameEvent::NoOneToAttack { tribute_name, .. } => {
+                write!(f, "🤷 {} has no one to attack!", tribute_name)
+            }
+            GameEvent::AllAlone { tribute_name, .. } => {
+                write!(f, "😢 {} is all alone!", tribute_name)
+            }
+            GameEvent::AllianceFormed {
+                tribute_a_name,
+                tribute_b_name,
+                factor,
+                ..
+            } => {
+                write!(
+                    f,
+                    "{} and {} form an alliance ({}).",
+                    tribute_a_name, tribute_b_name, factor
+                )
+            }
+            GameEvent::BetrayalTriggered {
+                betrayer_name,
+                victim_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "{} betrays {} — true to their treacherous nature.",
+                    betrayer_name, victim_name
+                )
+            }
+            GameEvent::TrustShockBreak { tribute_name, .. } => {
+                write!(
+                    f,
+                    "{} is shaken by their ally's death and breaks the bond.",
+                    tribute_name
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::items::{Attribute, Item, ItemRarity, ItemType};
+    use crate::output::GameOutput;
+
+    /// Stable UUIDs so test failures are easy to reason about.
+    fn uid_a() -> Uuid {
+        Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap()
+    }
+    fn uid_b() -> Uuid {
+        Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap()
+    }
+
+    fn sample_item() -> Item {
+        Item {
+            identifier: "33333333-3333-3333-3333-333333333333".to_string(),
+            name: "elixir".to_string(),
+            item_type: ItemType::Consumable,
+            rarity: ItemRarity::Common,
+            current_durability: 3,
+            max_durability: 5,
+            attribute: Attribute::Health,
+            effect: 7,
+        }
+    }
+
+    /// Single source of truth for the parity table. Each row pairs a
+    /// constructed `GameEvent` with a `GameOutput` carrying the same data;
+    /// the rendered strings must be byte-identical.
+    fn parity_table() -> Vec<(GameEvent, GameOutput<'static>)> {
+        let item = sample_item();
+        // SAFETY: `Item` is owned, but `GameOutput` borrows. We leak the
+        // sample item once for the test table so its references are 'static.
+        // This is test-only code; the leak is bounded and intentional.
+        let item_ref: &'static Item = Box::leak(Box::new(item.clone()));
+
+        vec![
+            (
+                GameEvent::GameDayStart { day_number: 4 },
+                GameOutput::GameDayStart(4),
+            ),
+            (
+                GameEvent::GameDayEnd { day_number: 4 },
+                GameOutput::GameDayEnd(4),
+            ),
+            (GameEvent::FirstDayStart, GameOutput::FirstDayStart),
+            (GameEvent::FeastDayStart, GameOutput::FeastDayStart),
+            (
+                GameEvent::TributesLeft { tribute_count: 12 },
+                GameOutput::TributesLeft(12),
+            ),
+            (
+                GameEvent::GameNightStart { day_number: 2 },
+                GameOutput::GameNightStart(2),
+            ),
+            (
+                GameEvent::GameNightEnd { day_number: 2 },
+                GameOutput::GameNightEnd(2),
+            ),
+            (
+                GameEvent::DailyDeathAnnouncement { death_count: 3 },
+                GameOutput::DailyDeathAnnouncement(3),
+            ),
+            (
+                GameEvent::DeathAnnouncement {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::DeathAnnouncement("Alice"),
+            ),
+            (GameEvent::NoOneWins, GameOutput::NoOneWins),
+            (
+                GameEvent::TributeWins {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeWins("Alice"),
+            ),
+            (
+                GameEvent::TributeRest {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeRest("Alice"),
+            ),
+            (
+                GameEvent::TributeLongRest {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeLongRest("Alice"),
+            ),
+            (
+                GameEvent::TributeHide {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeHide("Alice"),
+            ),
+            (
+                GameEvent::TributeTravel {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    from_area: "Cornucopia".into(),
+                    to_area: "North".into(),
+                },
+                GameOutput::TributeTravel("Alice", "Cornucopia", "North"),
+            ),
+            (
+                GameEvent::TributeTakeItem {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    item_name: "elixir".into(),
+                },
+                GameOutput::TributeTakeItem("Alice", "elixir"),
+            ),
+            (
+                GameEvent::TributeCannotUseItem {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    item_name: "elixir".into(),
+                },
+                GameOutput::TributeCannotUseItem("Alice", "elixir"),
+            ),
+            (
+                GameEvent::TributeUseItem {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    item: item.clone(),
+                },
+                GameOutput::TributeUseItem("Alice", item_ref),
+            ),
+            (
+                GameEvent::TributeTravelTooTired {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    area: "Forest".into(),
+                },
+                GameOutput::TributeTravelTooTired("Alice", "Forest"),
+            ),
+            (
+                GameEvent::TributeTravelExhausted {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    area: "Forest".into(),
+                },
+                GameOutput::TributeTravelExhausted("Alice", "Forest"),
+            ),
+            (
+                GameEvent::TributeTravelAlreadyThere {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    area: "Forest".into(),
+                },
+                GameOutput::TributeTravelAlreadyThere("Alice", "Forest"),
+            ),
+            (
+                GameEvent::TributeTravelFollow {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    area: "Forest".into(),
+                },
+                GameOutput::TributeTravelFollow("Alice", "Forest"),
+            ),
+            (
+                GameEvent::TributeTravelStay {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    area: "Forest".into(),
+                },
+                GameOutput::TributeTravelStay("Alice", "Forest"),
+            ),
+            (
+                GameEvent::TributeTravelNoOptions {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    area: "Forest".into(),
+                },
+                GameOutput::TributeTravelNoOptions("Alice", "Forest"),
+            ),
+            (
+                GameEvent::TributeBleeds {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeBleeds("Alice"),
+            ),
+            (
+                GameEvent::TributeSick {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeSick("Alice"),
+            ),
+            (
+                GameEvent::TributeElectrocuted {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeElectrocuted("Alice"),
+            ),
+            (
+                GameEvent::TributeFrozen {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeFrozen("Alice"),
+            ),
+            (
+                GameEvent::TributeOverheated {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeOverheated("Alice"),
+            ),
+            (
+                GameEvent::TributeDehydrated {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeDehydrated("Alice"),
+            ),
+            (
+                GameEvent::TributeStarving {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeStarving("Alice"),
+            ),
+            (
+                GameEvent::TributePoisoned {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributePoisoned("Alice"),
+            ),
+            (
+                GameEvent::TributeBrokenArm {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeBrokenArm("Alice"),
+            ),
+            (
+                GameEvent::TributeBrokenLeg {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeBrokenLeg("Alice"),
+            ),
+            (
+                GameEvent::TributeInfected {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeInfected("Alice"),
+            ),
+            (
+                GameEvent::TributeDrowned {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeDrowned("Alice"),
+            ),
+            (
+                GameEvent::TributeMauled {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    animal_count: 3,
+                    animal: Animal::Wolf,
+                    damage: 12,
+                },
+                GameOutput::TributeMauled("Alice", 3, "Wolf", 12),
+            ),
+            (
+                GameEvent::TributeBurned {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeBurned("Alice"),
+            ),
+            (
+                GameEvent::TributeHorrified {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    sanity_damage: 5,
+                },
+                GameOutput::TributeHorrified("Alice", 5),
+            ),
+            (
+                GameEvent::TributeSuffer {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeSuffer("Alice"),
+            ),
+            (
+                GameEvent::TributeSelfHarm {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeSelfHarm("Alice"),
+            ),
+            (
+                GameEvent::TributeSuicide {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeSuicide("Alice"),
+            ),
+            (
+                GameEvent::TributeAttackWin {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeAttackWin("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeAttackWinExtra {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeAttackWinExtra("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeAttackWound {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeAttackWound("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeAttackLose {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeAttackLose("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeAttackLoseExtra {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeAttackLoseExtra("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeAttackMiss {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeAttackMiss("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeAttackDied {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeAttackDied("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeAttackSuccessKill {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeAttackSuccessKill("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeAttackHidden {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeAttackHidden("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeCriticalHit {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeCriticalHit("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeCriticalFumble {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeCriticalFumble("Alice"),
+            ),
+            (
+                GameEvent::TributePerfectBlock {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributePerfectBlock("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeDiesFromStatus {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    status: "poison".into(),
+                },
+                GameOutput::TributeDiesFromStatus("Alice", "poison"),
+            ),
+            (
+                GameEvent::TributeDiesFromAreaEvent {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    area_event: "wildfire".into(),
+                },
+                GameOutput::TributeDiesFromAreaEvent("Alice", "wildfire"),
+            ),
+            (
+                GameEvent::TributeDiesFromTributeEvent {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    tribute_event: "Bob".into(),
+                },
+                GameOutput::TributeDiesFromTributeEvent("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeAlreadyDead {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeAlreadyDead("Alice"),
+            ),
+            (
+                GameEvent::TributeDead {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeDead("Alice"),
+            ),
+            (
+                GameEvent::TributeDeath {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::TributeDeath("Alice"),
+            ),
+            (
+                GameEvent::WeaponBreak {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    weapon_name: "spear".into(),
+                },
+                GameOutput::WeaponBreak("Alice", "spear"),
+            ),
+            (
+                GameEvent::WeaponWear {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    weapon_name: "spear".into(),
+                },
+                GameOutput::WeaponWear("Alice", "spear"),
+            ),
+            (
+                GameEvent::ShieldBreak {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    shield_name: "buckler".into(),
+                },
+                GameOutput::ShieldBreak("Alice", "buckler"),
+            ),
+            (
+                GameEvent::ShieldWear {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    shield_name: "buckler".into(),
+                },
+                GameOutput::ShieldWear("Alice", "buckler"),
+            ),
+            (
+                GameEvent::SponsorGift {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    item: item.clone(),
+                },
+                GameOutput::SponsorGift("Alice", item_ref),
+            ),
+            (
+                GameEvent::AreaEvent {
+                    area_event: "earthquake".into(),
+                    area_name: "The Forest".into(),
+                },
+                GameOutput::AreaEvent("earthquake", "The Forest"),
+            ),
+            (
+                GameEvent::AreaClose {
+                    area_name: "The Forest".into(),
+                },
+                GameOutput::AreaClose("The Forest"),
+            ),
+            (
+                GameEvent::AreaOpen {
+                    area_name: "The Forest".into(),
+                },
+                GameOutput::AreaOpen("The Forest"),
+            ),
+            (
+                GameEvent::TrappedInArea {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    area_name: "The Forest".into(),
+                },
+                GameOutput::TrappedInArea("Alice", "The Forest"),
+            ),
+            (
+                GameEvent::DiedInArea {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    area_name: "The Forest".into(),
+                },
+                GameOutput::DiedInArea("Alice", "The Forest"),
+            ),
+            (
+                GameEvent::TributeBetrayal {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeBetrayal("Alice", "Bob"),
+            ),
+            (
+                GameEvent::TributeForcedBetrayal {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                    target_id: uid_b(),
+                    target_name: "Bob".into(),
+                },
+                GameOutput::TributeForcedBetrayal("Alice", "Bob"),
+            ),
+            (
+                GameEvent::NoOneToAttack {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::NoOneToAttack("Alice"),
+            ),
+            (
+                GameEvent::AllAlone {
+                    tribute_id: uid_a(),
+                    tribute_name: "Alice".into(),
+                },
+                GameOutput::AllAlone("Alice"),
+            ),
+            (
+                GameEvent::AllianceFormed {
+                    tribute_a_id: uid_a(),
+                    tribute_a_name: "Alice".into(),
+                    tribute_b_id: uid_b(),
+                    tribute_b_name: "Bob".into(),
+                    factor: "trust".into(),
+                },
+                GameOutput::AllianceFormed("Alice", "Bob", "trust"),
+            ),
+            (
+                GameEvent::BetrayalTriggered {
+                    betrayer_id: uid_a(),
+                    betrayer_name: "Cato".into(),
+                    victim_id: uid_b(),
+                    victim_name: "Glimmer".into(),
+                },
+                GameOutput::BetrayalTriggered("Cato", "Glimmer"),
+            ),
+            (
+                GameEvent::TrustShockBreak {
+                    tribute_id: uid_a(),
+                    tribute_name: "Rue".into(),
+                },
+                GameOutput::TrustShockBreak("Rue"),
+            ),
+        ]
+    }
+
+    #[test]
+    fn parity_table_covers_every_variant() {
+        // Bumps any time a variant is added without a parity row.
+        // 77 = current count of GameOutput variants in output.rs.
+        assert_eq!(parity_table().len(), 77);
+    }
+
+    #[test]
+    fn display_matches_game_output_for_every_variant() {
+        for (event, output) in parity_table() {
+            assert_eq!(
+                event.to_string(),
+                output.to_string(),
+                "Display mismatch for {:?}",
+                event
+            );
+        }
+    }
+
+    // ---------- Serde roundtrip coverage ----------
+    // One assertion per data shape: unit, single-field, multi-field,
+    // optional-field-via-Item.
+
+    fn roundtrip(event: &GameEvent) {
+        let json = serde_json::to_string(event).expect("serialize");
+        let parsed: GameEvent = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(*event, parsed, "roundtrip mismatch: {}", json);
+    }
+
+    #[test]
+    fn serde_roundtrip_unit_variant() {
+        roundtrip(&GameEvent::FirstDayStart);
+        roundtrip(&GameEvent::FeastDayStart);
+        roundtrip(&GameEvent::NoOneWins);
+    }
+
+    #[test]
+    fn serde_roundtrip_single_primitive_field() {
+        roundtrip(&GameEvent::GameDayStart { day_number: 7 });
+        roundtrip(&GameEvent::TributesLeft { tribute_count: 11 });
+    }
+
+    #[test]
+    fn serde_roundtrip_multi_field_with_uuid() {
+        roundtrip(&GameEvent::AllianceFormed {
+            tribute_a_id: uid_a(),
+            tribute_a_name: "Alice".into(),
+            tribute_b_id: uid_b(),
+            tribute_b_name: "Bob".into(),
+            factor: "shared district".into(),
+        });
+    }
+
+    #[test]
+    fn serde_roundtrip_with_nested_item() {
+        roundtrip(&GameEvent::SponsorGift {
+            tribute_id: uid_a(),
+            tribute_name: "Alice".into(),
+            item: sample_item(),
+        });
+        roundtrip(&GameEvent::TributeUseItem {
+            tribute_id: uid_a(),
+            tribute_name: "Alice".into(),
+            item: sample_item(),
+        });
+    }
+
+    #[test]
+    fn serde_roundtrip_with_animal_enum() {
+        roundtrip(&GameEvent::TributeMauled {
+            tribute_id: uid_a(),
+            tribute_name: "Alice".into(),
+            animal_count: 4,
+            animal: Animal::TrackerJacker,
+            damage: 9,
+        });
+    }
+}

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod areas;
 pub mod config;
 pub mod districts;
+pub mod events;
 pub mod games;
 pub mod items;
 pub mod messages;


### PR DESCRIPTION
## Summary

First child of the **mqi** epic (Migrate event log from stringly-typed `GameOutput` to structured `GameEvent`). Introduces a typed, owned, serde-friendly counterpart to `GameOutput` with **byte-identical** `Display` output. No emission sites change yet — that is mqi.2. No persistence yet — that is mqi.3.

## Changes

- `game/src/events.rs` (new): `GameEvent` enum with 77 variants, one per `GameOutput` variant. All variants use named struct fields. Carries both `*_id: Uuid` and `*_name: String` where the rendered output needs the name.
- `game/src/lib.rs`: registers `pub mod events;`.
- `docs/superpowers/specs/2026-04-26-game-event-enum.md`: design spec covering rationale, variant inventory, serde shape choice (externally-tagged, justified), migration plan to mqi.2–6, and open questions.

### Design highlights

- **Serde shape:** externally-tagged (default). The only shape that uniformly handles unit variants, named-struct variants, and nested `Item` payloads with zero ambiguity. Internally-tagged was considered but cannot represent unit variants.
- **Both UUID + name carried** on every variant that mentions a tribute/area/item, because (a) UUIDs are the only stable cross-system reference and (b) `Display` must be self-contained — no name-lookup round-trips.
- **`Item` and `Animal` embedded as their real types** instead of pre-stringified, eliminating the `.unwrap()` on `Animal::from_str` that lives inside the legacy `TributeMauled` `Display` arm.
- **Derives:** `Debug, Clone, PartialEq, Serialize, Deserialize`. `Eq + Hash` deliberately omitted because `Item` does not derive `Hash`; consumers needing identity should hash a future `event_id` field added in mqi.3.

### Variant count clarification

Bead description estimated 75 variants; actual `GameOutput` count is **77** (`TributeBetrayal`, `TributeForcedBetrayal`, and `TributeTravelNoOptions` were added after the bead was written). All 77 have `GameEvent` equivalents. The parity table includes a `parity_table_covers_every_variant` test that asserts the count, so future variant additions cannot drift.

## Verification

```
cargo fmt --all                                                                # clean
cargo test -p game --lib                                                        # 475 passed (was 468; +7 new event tests)
cargo clippy -p game --all-targets -- -D warnings                               # clean
cargo check -p api                                                              # clean
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check -p web --target wasm32-unknown-unknown   # clean
```

The `display_matches_game_output_for_every_variant` test asserts byte-identical `Display` output for all 77 variants by constructing both `GameOutput::X(...)` and `GameEvent::X { ... }` from the same sample data and comparing `to_string()`.

Serde roundtrip coverage: unit variants, single-primitive-field, multi-field-with-UUID, nested `Item`, nested `Animal` enum.

## Follow-ups

- mqi.2 — switch emission sites to also emit `GameEvent`; add `Game.event_log` buffer.
- mqi.3 — persist `GameEvent` in SurrealDB; add `event_id` + `timestamp` + `severity` fields.
- mqi.4 — announcer (`announcers/`) consumes structured events.
- mqi.5 — frontend consumes structured events for live tickers.
- mqi.6 — remove `GameOutput` and the parallel emission path.