### PR TITLE
feat(web): render structured GameEvent in day log (mqi.4)

### DIFF
--- a/web/src/components/game_day_log.rs
+++ b/web/src/components/game_day_log.rs
@@ -3,6 +3,7 @@ use crate::env::APP_API_HOST;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
+use game::events::GameEvent;
 use game::messages::{GameMessage, MessageKind};
 use shared::DisplayGame;
 
@@ -15,6 +16,52 @@ fn kind_styles(kind: &MessageKind) -> (&'static str, &'static str) {
         }
         MessageKind::BetrayalTriggered => ("border-l-4 border-rose-500 pl-2 bg-rose-500/10", "🗡️"),
         MessageKind::TrustShockBreak => ("border-l-4 border-amber-500 pl-2 bg-amber-500/10", "💔"),
+    }
+}
+
+/// Returns (container_classes, leading_glyph) for a structured event variant.
+/// Returns `None` for variants without bespoke styling (caller falls back to
+/// the legacy `kind`/`content` path).
+///
+/// Palette pattern matches PR #126: `border-l-4 border-<hue>-500 pl-2
+/// bg-<hue>-500/10`. Hues are theme-friendly because the semi-transparent
+/// `/10` overlay layers cleanly atop all three theme backgrounds (theme1
+/// stone, theme2 green, theme3 stone-dark).
+fn event_styles(event: &GameEvent) -> Option<(&'static str, &'static str)> {
+    match event {
+        // ---- Alliance / social (preserve PR #126 palette + glyph) ----
+        GameEvent::AllianceFormed { .. } => {
+            Some(("border-l-4 border-emerald-500 pl-2 bg-emerald-500/10", "🤝"))
+        }
+        GameEvent::BetrayalTriggered { .. } => {
+            Some(("border-l-4 border-rose-500 pl-2 bg-rose-500/10", "🗡️"))
+        }
+        GameEvent::TrustShockBreak { .. } => {
+            Some(("border-l-4 border-amber-500 pl-2 bg-amber-500/10", "💔"))
+        }
+
+        // ---- Combat outcomes ----
+        GameEvent::TributeAttackSuccessKill { .. } => {
+            Some(("border-l-4 border-red-600 pl-2 bg-red-600/10", "⚔️"))
+        }
+
+        // ---- Deaths ----
+        GameEvent::TributeDiesFromStatus { .. } => {
+            Some(("border-l-4 border-slate-500 pl-2 bg-slate-500/10", "☠️"))
+        }
+        GameEvent::TributeDeath { .. } => {
+            Some(("border-l-4 border-slate-500 pl-2 bg-slate-500/10", "⚰️"))
+        }
+
+        // ---- Area events ----
+        GameEvent::AreaEvent { .. } => {
+            Some(("border-l-4 border-orange-500 pl-2 bg-orange-500/10", "🌪️"))
+        }
+        GameEvent::AreaClose { .. } => {
+            Some(("border-l-4 border-orange-500 pl-2 bg-orange-500/10", "🚧"))
+        }
+
+        _ => None,
     }
 }
 
@@ -74,19 +121,43 @@ pub fn GameDayLog(game: DisplayGame, day: u32) -> Element {
                     "#,
                     for log in logs {
                         {
-                            match log.kind.as_ref() {
-                                Some(kind) => {
-                                    let (classes, glyph) = kind_styles(kind);
-                                    rsx! {
-                                        li {
-                                            class: "{classes}",
-                                            span { class: "mr-2", "{glyph}" }
-                                            "{log.content}"
+                            // 1. Prefer the structured event payload when
+                            //    present and decodable.
+                            let structured = log
+                                .structured_event()
+                                .and_then(Result::ok)
+                                .and_then(|event| {
+                                    event_styles(&event).map(|(classes, glyph)| {
+                                        (classes, glyph, event.to_string())
+                                    })
+                                });
+
+                            match structured {
+                                Some((classes, glyph, body)) => rsx! {
+                                    li {
+                                        class: "{classes}",
+                                        span { class: "mr-2", "{glyph}" }
+                                        "{body}"
+                                    }
+                                },
+                                // 2. Fall back to the PR #126 kind-based path
+                                //    (legacy rows have `event = None`; rows
+                                //    whose variant lacks bespoke styling also
+                                //    land here).
+                                None => match log.kind.as_ref() {
+                                    Some(kind) => {
+                                        let (classes, glyph) = kind_styles(kind);
+                                        rsx! {
+                                            li {
+                                                class: "{classes}",
+                                                span { class: "mr-2", "{glyph}" }
+                                                "{log.content}"
+                                            }
                                         }
                                     }
-                                }
-                                _ => rsx! {
-                                    li { "{log.content}" }
+                                    _ => rsx! {
+                                        li { "{log.content}" }
+                                    },
                                 },
                             }
                         }


### PR DESCRIPTION
## Summary

Frontend day log now renders structured `GameEvent` payloads attached to `GameMessage` rows (PR #130 / mqi.3 read path). Legacy rows without an `event` payload continue to render via the existing PR #126 `kind`-based + `content` fallback path.

Closes hangrier_games-mqi.4.

## Changes

`web/src/components/game_day_log.rs`:

- Imports `game::events::GameEvent` directly (no DTO mirror).
- New `event_styles(&GameEvent) -> Option<(classes, glyph)>` returns bespoke palette + glyph for selected variants, `None` for unmatched variants (which fall through to the legacy path).
- Render loop now matches `log.structured_event()` first; on `Some(Ok(event))` with bespoke styling, renders `event.to_string()` (Display impl is byte-identical to `GameOutput`, so visible text is unchanged).
- On `None`, `Some(Err(_))`, or unmatched variant → falls back to the existing `kind`-based render with `log.content`, else plain `<li>` (PR #126 behavior preserved).

## Variant categories rendered with custom UI

| Variant | Category | Glyph | Palette |
|---|---|---|---|
| `AllianceFormed` | social / alliance | 🤝 | emerald-500 |
| `BetrayalTriggered` | social / alliance | 🗡️ | rose-500 |
| `TrustShockBreak` | social / alliance | 💔 | amber-500 |
| `TributeAttackSuccessKill` | combat outcome | ⚔️ | red-600 |
| `TributeDiesFromStatus` | death | ☠️ | slate-500 |
| `TributeDeath` | death | ⚰️ | slate-500 |
| `AreaEvent` | area event | 🌪️ | orange-500 |
| `AreaClose` | area event | 🚧 | orange-500 |

Eight variants total (≥5 required), spread across the four required categories. The three alliance variants reuse the exact PR #126 palette + glyph so existing visual treatment is preserved when the structured event arrives.

## Theme palette choices

All chosen hues use the PR #126 pattern: `border-l-4 border-<hue>-500 pl-2 bg-<hue>-500/10`. The semi-transparent `/10` overlay layers cleanly atop all three theme backgrounds (theme1 stone, theme2 green, theme3 stone-dark) without theme-conditional classes. Hue selection follows established UI conventions:

- Combat / kills → red (high-energy danger)
- Deaths → slate (neutral, somber)
- Area events / closures → orange (warning / environmental hazard)
- Alliance / betrayal palette inherited from PR #126

## Fallback path for `None` events

The render order is:

1. `log.structured_event()` returns `Some(Ok(event))` AND `event_styles(&event)` returns `Some(...)` → custom UI with `event.to_string()`.
2. Otherwise → existing PR #126 path: match on `log.kind`, use `kind_styles` with `log.content`; else plain `<li>` with `log.content`.

`Some(Err(_))` (decode failure) is treated as fallthrough rather than panic — defensive against schema drift.

## Verification

- `cargo fmt --all` ✅
- `RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"' cargo check -p web --target wasm32-unknown-unknown` ✅
- `RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"' cargo clippy -p web --all-targets --target wasm32-unknown-unknown -- -D warnings` ✅
- `cargo check -p game` ✅
- `just build-css` ✅ (unchanged)

## Deviations from acceptance criteria

None. All seven acceptance criteria met.

## Follow-ups

None filed. Future work could extend `event_styles` to additional variants (sponsor gifts, weapon/shield breaks, status afflictions); current set covers the required categories without bloating the match arm.