### PR TITLE
fix(api): rename Tribute.id serde column to avoid SurrealDB id collision

### DIFF
--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -58,7 +58,12 @@ pub struct Tribute {
     pub identifier: String,
     /// Stable typed UUID. Mirrors `identifier` for callers that want a
     /// non-stringly-typed key (alliance graph, betrayal events).
-    #[serde(default = "Uuid::new_v4")]
+    ///
+    /// Serialized as `tribute_id` to avoid collision with SurrealDB's
+    /// reserved `id` column on the `tribute` table — the SDK rejects any
+    /// payload that carries a non-RecordId `id` field when a record id is
+    /// also specified explicitly via `db.create(("tribute", ...))`.
+    #[serde(default = "Uuid::new_v4", rename = "tribute_id")]
     pub id: Uuid,
     /// Where are they?
     pub area: Area,


### PR DESCRIPTION
## Summary

Restore green `cargo test -p api --test games_tests` (was 1/10, now 10/10) by renaming the runtime `Tribute.id: Uuid` serde column from `id` to `tribute_id` so it no longer collides with SurrealDB's reserved record-id column.

Closes hangrier_games-xg4.

## Root cause

PR #122 (alliances) added a runtime `id: Uuid` field to `Tribute` that mirrors `identifier`, intended as a non-stringly-typed key for the alliance graph and betrayal events. The field was serialized as `id`, the same name SurrealDB uses for the reserved record-id column on every table.

`api::tributes::create_tribute` calls:

```rust
db.create(("tribute", &tribute.identifier)).content(tribute)
```

When the SDK sees a `content(...)` payload that carries a non-RecordId `id` field while the record id is already specified by the create call, it rejects the insert with:

```
Found encoding::base64::decode("…") for the `id` field, but a specific record has been specified
```

`api::games::create_game` spawns 24 tributes in parallel through this same helper, so every game-creation path failed. The integration tests surfaced as `POST /api/games -> 500 "Failed to create tributes: Internal Server Error"`. Only `test_full_summary` was unaffected because it never hits `create_game`.

The bug existed since #122 but was masked: the `AppError` `Display` impl returns a generic `"Internal Server Error"` string, so the propagated message hid the real SurrealDB error. Reproduced by temporarily switching the propagation to `{:?}` (Debug), captured the message, then reverted before commit.

## Changes

- `game/src/tributes/mod.rs`: add `#[serde(rename = "tribute_id")]` to `Tribute.id`. The column is purely a runtime convenience for the alliance graph; nothing in SurrealDB queries reads the field by name. Schema is `SCHEMALESS` so no migration is required, and the only databases that stored the colliding `id` field are ephemeral (tests, dev). The 482 game-crate unit tests round-trip `Tribute` through serde and continue to pass.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all` | clean |
| `cargo test -p game --lib` | 482 passed |
| `cargo test -p api --test games_tests` | **10/10 passed** (was 1/10) |
| `cargo clippy -p game --all-targets -- -D warnings` | clean |
| `cargo clippy -p api --all-targets -- -D warnings` | clean |
| `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check -p web --target wasm32-unknown-unknown` | clean |

## Follow-ups

- `AppError`'s `thiserror` `#[error("Internal Server Error")]` discards the inner `String`, which made this bug much harder to diagnose than it should have been (the wire response said `"Internal Server Error"` instead of the actual SurrealDB error). Worth filing a separate bead to either include the inner message in `Display` or surface it via tracing on the error path.