### PR TITLE
docs(plans): add game timeline redesign spec and PR1/PR2 plans

### DIFF
--- a/docs/superpowers/plans/2026-04-26-game-timeline-pr1-backend.md
+++ b/docs/superpowers/plans/2026-04-26-game-timeline-pr1-backend.md
@@ -1,0 +1,1323 @@
+# Game Timeline PR1 — Backend Schema + Combat Refactor + Frontend Stub
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `GameMessage` and friends to `shared/`, replace its untyped `kind: Option<MessageKind>` with a structured `MessagePayload` enum, add `(phase, tick, emit_index)` causal-ordering fields, refactor combat to emit one structured `CombatEngagement` per fight, and ship a frontend stub that keeps `web/` compiling.
+
+**Architecture:** `GameMessage`/`MessagePayload`/`Phase`/`CombatEngagement`/`*Ref` types move from `game/src/messages.rs` to `shared/src/messages.rs`. A new `TaggedEvent { content, payload }` collection type stays in `game/`. Every `&mut Vec<String>` parameter currently used to accumulate per-action prose becomes `&mut Vec<TaggedEvent>`. The drain site at `game/src/games.rs::do_step` (NOT `api/src/games.rs` as the spec says — confirmed L791-1046) builds `GameMessage`s by attaching `(game_day, phase, tick, emit_index)` from a per-period `TickCounter`. The frontend `game_day_log.rs` and `game_day_summary.rs` are deleted; a temporary `game_log_stub.rs` renders raw `content` lines so `web/` keeps building.
+
+**Tech Stack:** Rust 2024 edition, Axum (api), Dioxus (web), SurrealDB. New shared crate deps: `chrono` (with `serde` feature), `serde_json`. Frontend uses no new deps in PR1.
+
+**Spec corrections discovered during planning:**
+1. Spec §3 says drain is in `api/src/games.rs ~L957`. **Wrong.** Actual location is `game/src/games.rs` L1001-L1046 inside `Game::do_step`. Plan uses correct location.
+2. Current `GameMessage` has `event: Option<GameEvent>` and `event_id: Option<String>` fields not mentioned in spec. Plan removes them with the rest of the schema reshape.
+3. Spec lists `game/src/tributes/state.rs` as a file to modify. **No such file exists.** State events (rest, sponsor gift, etc.) live in `tributes/mod.rs`. Plan handles them there.
+4. `game/src/areas/` only contains `mod.rs` + `events.rs`; area events already use the typed `AreaEvent` enum on `area_details.events`, not `Vec<String>`. They are emitted as messages from `do_step`, not from area code. No `&mut Vec<TaggedEvent>` thread needed inside `areas/`.
+
+These corrections are reflected below. A spec-followup task at the end updates the spec doc to match.
+
+---
+
+## Task Ordering Rationale
+
+Tasks are grouped to minimize "broken tree" time. The schema move (Tasks 1-3) breaks the `game` crate temporarily; Tasks 4-9 fix it incrementally per emit site; Task 10 fixes the drain; Tasks 11-12 clean up callers; Tasks 13-14 add the new API endpoint; Task 15 stubs the frontend so `web/` compiles. Quality gates (Task 16) run last. Each task ends with a commit.
+
+> **TDD note:** The schema-move tasks (1-3) cannot start with a failing test — they're pure mechanical relocations. New behavior tasks (kind mapping, summarize_periods, Phase parsing, the timeline-summary endpoint) follow strict red-green-commit.
+
+---
+
+## Task 1: Add chrono and serde_json to shared/
+
+**Files:**
+- Modify: `shared/Cargo.toml`
+
+- [ ] **Step 1: Inspect current shared/Cargo.toml**
+
+Run: `cat shared/Cargo.toml`
+Expected: shows `serde`, `validator`, `uuid` as deps. No `chrono`, no `serde_json`.
+
+- [ ] **Step 2: Add chrono and serde_json**
+
+Edit `shared/Cargo.toml` `[dependencies]` table. Add:
+
+```toml
+chrono = { version = "0.4", features = ["serde"] }
+serde_json = "1"
+```
+
+(Match existing version pins for these crates if already used elsewhere in the workspace — check `game/Cargo.toml` for the chrono version and use the same.)
+
+- [ ] **Step 3: Verify shared crate still builds**
+
+Run: `cargo check -p shared`
+Expected: PASS (no compile errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "chore(shared): add chrono and serde_json deps for GameMessage move"
+```
+
+---
+
+## Task 2: Move schema types from game/src/messages.rs to shared/src/messages.rs (no behavior change)
+
+**Files:**
+- Create: `shared/src/messages.rs`
+- Modify: `shared/src/lib.rs` (add `pub mod messages;`)
+- Modify: `game/src/messages.rs` (will become a thin re-export shim)
+
+This task is pure relocation. No type signatures change yet. Reshape happens in Task 3.
+
+- [ ] **Step 1: Read full current game/src/messages.rs**
+
+Run: `wc -l game/src/messages.rs && cat game/src/messages.rs`
+Expected: 667 lines. Note: contains `GameMessage`, `MessageKind` (3 variants), `MessageSource`, `serde_event_via_json` module, narrative helpers (`movement_narrative`, `hiding_spot_narrative`, `stamina_narrative`, `terrain_name`).
+
+- [ ] **Step 2: Create shared/src/messages.rs as copy of the schema-only portions**
+
+Move to `shared/src/messages.rs`:
+- `GameMessage` struct (lines ~70-110 in current file)
+- `MessageKind` enum (lines ~10-30)
+- `MessageSource` enum
+- `serde_event_via_json` module (lines 32-67) — KEEP TEMPORARILY in shared so the move compiles; will be deleted in Task 3.
+- All `impl` blocks for these types
+- Existing tests for these types (relocate from `#[cfg(test)] mod tests` — drop only the narrative-helper tests).
+
+Do NOT move:
+- `movement_narrative`, `hiding_spot_narrative`, `stamina_narrative`, `terrain_name` (game-only narrative helpers)
+- Anything that references `GameEvent` from `game/` (the `serde_event_via_json` module references it — leave the `Option<GameEvent>` field as `Option<serde_json::Value>` temporarily; we delete it in Task 3)
+
+For the temporary move, in `shared/src/messages.rs` replace the `event: Option<GameEvent>` field with `event: Option<serde_json::Value>` (will be removed in Task 3).
+
+- [ ] **Step 3: Add `pub mod messages;` to shared/src/lib.rs**
+
+Edit `shared/src/lib.rs`. Add the module declaration alongside existing `pub mod` lines.
+
+- [ ] **Step 4: Replace game/src/messages.rs with a thin shim**
+
+Rewrite `game/src/messages.rs` to contain ONLY:
+- `pub use shared::messages::{GameMessage, MessageKind, MessageSource};`
+- The narrative helper fns (`movement_narrative`, `hiding_spot_narrative`, `stamina_narrative`, `terrain_name`) and their tests
+- The `with_kind` constructor moved here as a free fn IF any callers still use it (there are 3: `game/src/games.rs:232, 906, 1187, 1223`); easier: keep `with_kind` on the moved type for now and remove it in Task 3.
+
+- [ ] **Step 5: Build the workspace**
+
+Run: `cargo check --workspace`
+Expected: PASS. If `api/` or `web/` reference `game::messages::*` paths, those still work via the shim.
+
+- [ ] **Step 6: Run game crate tests**
+
+Run: `cargo test -p game --lib messages`
+Expected: PASS (all relocated tests still green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "refactor(shared): move GameMessage and friends from game/ to shared/ (no behavior change)"
+```
+
+---
+
+## Task 3: Reshape GameMessage to typed payload + new ordering fields
+
+**Files:**
+- Modify: `shared/src/messages.rs`
+- Modify: `game/src/messages.rs` (shim — update re-exports)
+
+This task introduces the breaking change. After this task the workspace WILL NOT BUILD until Tasks 4-15 fix every caller.
+
+- [ ] **Step 1: Replace `GameMessage` struct definition**
+
+In `shared/src/messages.rs`, replace the struct with:
+
+```rust
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GameMessage {
+    pub identifier: String,
+    pub source: MessageSource,
+    pub game_day: u32,
+    pub phase: Phase,
+    pub tick: u32,
+    pub emit_index: u32,
+    pub subject: String,
+    #[serde(with = "chrono::serde::ts_nanoseconds")]
+    pub timestamp: DateTime<Utc>,
+    pub content: String,
+    pub payload: MessagePayload,
+}
+```
+
+DELETE: the old `kind: Option<MessageKind>` field, the `event: Option<...>` field, the `event_id: Option<String>` field, and the entire `serde_event_via_json` module (no longer needed).
+
+- [ ] **Step 2: Add `Phase` enum**
+
+In `shared/src/messages.rs`:
+
+```rust
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Phase { Day, Night }
+
+impl std::fmt::Display for Phase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Phase::Day => write!(f, "day"),
+            Phase::Night => write!(f, "night"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsePhaseError;
+
+impl std::fmt::Display for ParsePhaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "phase must be 'day' or 'night'")
+    }
+}
+
+impl std::error::Error for ParsePhaseError {}
+
+impl FromStr for Phase {
+    type Err = ParsePhaseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "day" => Ok(Phase::Day),
+            "night" => Ok(Phase::Night),
+            _ => Err(ParsePhaseError),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add reference structs**
+
+In `shared/src/messages.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TributeRef { pub identifier: String, pub name: String }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AreaRef { pub identifier: String, pub name: String }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ItemRef { pub identifier: String, pub name: String }
+```
+
+- [ ] **Step 4: Add `AreaEventKind` and `CombatEngagement` / `CombatOutcome`**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AreaEventKind {
+    Hazard, Storm, Mutts, Earthquake, Flood, Fire, Other,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CombatEngagement {
+    pub attacker: TributeRef,
+    pub target: TributeRef,
+    pub outcome: CombatOutcome,
+    pub detail_lines: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CombatOutcome {
+    Killed, Wounded, TargetFled, AttackerFled, Stalemate,
+}
+```
+
+- [ ] **Step 5: Replace `MessageKind` with the new 6-variant enum + add `MessagePayload`**
+
+DELETE the existing 3-variant `MessageKind` (`AllianceFormed`, `BetrayalTriggered`, `TrustShockBreak`).
+
+ADD:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum MessageKind { Death, Combat, Alliance, Movement, Item, State }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum MessagePayload {
+    TributeKilled  { victim: TributeRef, killer: Option<TributeRef>, cause: String },
+    TributeWounded { victim: TributeRef, attacker: Option<TributeRef>, hp_lost: u32 },
+
+    Combat(CombatEngagement),
+
+    AllianceFormed     { members: Vec<TributeRef> },
+    AllianceProposed   { proposer: TributeRef, target: TributeRef },
+    AllianceDissolved  { members: Vec<TributeRef>, reason: String },
+    BetrayalTriggered  { betrayer: TributeRef, victim: TributeRef },
+    TrustShockBreak    { tribute: TributeRef, partner: TributeRef },
+
+    TributeMoved   { tribute: TributeRef, from: AreaRef, to: AreaRef },
+    TributeHidden  { tribute: TributeRef, area: AreaRef },
+    AreaClosed     { area: AreaRef },
+    AreaEvent      { area: AreaRef, kind: AreaEventKind, description: String },
+
+    ItemFound    { tribute: TributeRef, item: ItemRef, area: AreaRef },
+    ItemUsed     { tribute: TributeRef, item: ItemRef },
+    ItemDropped  { tribute: TributeRef, item: ItemRef, area: AreaRef },
+    SponsorGift  { recipient: TributeRef, item: ItemRef, donor: String },
+
+    TributeRested      { tribute: TributeRef, hp_restored: u32 },
+    TributeStarved     { tribute: TributeRef, hp_lost: u32 },
+    TributeDehydrated  { tribute: TributeRef, hp_lost: u32 },
+    SanityBreak        { tribute: TributeRef },
+}
+
+impl MessagePayload {
+    pub fn kind(&self) -> MessageKind {
+        use MessagePayload::*;
+        match self {
+            TributeKilled { .. } => MessageKind::Death,
+            Combat(_) => MessageKind::Combat,
+            AllianceFormed { .. } | AllianceProposed { .. } | AllianceDissolved { .. }
+                | BetrayalTriggered { .. } | TrustShockBreak { .. } => MessageKind::Alliance,
+            TributeMoved { .. } | TributeHidden { .. }
+                | AreaClosed { .. } | AreaEvent { .. } => MessageKind::Movement,
+            ItemFound { .. } | ItemUsed { .. }
+                | ItemDropped { .. } | SponsorGift { .. } => MessageKind::Item,
+            TributeWounded { .. } | TributeRested { .. } | TributeStarved { .. }
+                | TributeDehydrated { .. } | SanityBreak { .. } => MessageKind::State,
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Replace `GameMessage::new` constructor; delete `with_kind`**
+
+```rust
+impl GameMessage {
+    pub fn new(
+        source: MessageSource,
+        game_day: u32,
+        phase: Phase,
+        tick: u32,
+        emit_index: u32,
+        subject: String,
+        content: String,
+        payload: MessagePayload,
+    ) -> Self {
+        Self {
+            identifier: uuid::Uuid::new_v4().to_string(),
+            source,
+            game_day,
+            phase,
+            tick,
+            emit_index,
+            subject,
+            timestamp: chrono::Utc::now(),
+            content,
+            payload,
+        }
+    }
+}
+```
+
+DELETE: `with_kind` method entirely.
+
+- [ ] **Step 7: Update game/src/messages.rs shim re-exports**
+
+```rust
+pub use shared::messages::{
+    AreaEventKind, AreaRef, CombatEngagement, CombatOutcome, GameMessage, ItemRef,
+    MessageKind, MessagePayload, MessageSource, ParsePhaseError, Phase, TributeRef,
+};
+```
+
+Keep narrative helper fns (`movement_narrative`, etc.) in this file.
+
+- [ ] **Step 8: Add `TaggedEvent` to game/src/messages.rs**
+
+After the re-exports, add:
+
+```rust
+/// Per-action accumulator: a typed payload plus its already-formatted prose line.
+/// Drain site converts each into a `GameMessage` with `(game_day, phase, tick, emit_index)`.
+#[derive(Debug, Clone)]
+pub struct TaggedEvent {
+    pub content: String,
+    pub payload: MessagePayload,
+}
+
+impl TaggedEvent {
+    pub fn new(content: impl Into<String>, payload: MessagePayload) -> Self {
+        Self { content: content.into(), payload }
+    }
+}
+```
+
+- [ ] **Step 9: Verify shared crate compiles**
+
+Run: `cargo check -p shared`
+Expected: PASS.
+
+(The full workspace is intentionally broken at this point. Tasks 4-15 fix it.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+jj commit -m "feat(shared): reshape GameMessage with typed payload and causal-ordering fields"
+```
+
+---
+
+## Task 4: Add MessagePayload::kind() unit tests
+
+**Files:**
+- Modify: `shared/src/messages.rs` (`#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test module:
+
+```rust
+#[test]
+fn kind_lifecycle_variants_map_correctly() {
+    let t = TributeRef { identifier: "t1".into(), name: "T1".into() };
+    let p = MessagePayload::TributeKilled {
+        victim: t.clone(), killer: None, cause: "fall".into(),
+    };
+    assert_eq!(p.kind(), MessageKind::Death);
+
+    let p = MessagePayload::TributeWounded {
+        victim: t.clone(), attacker: None, hp_lost: 5,
+    };
+    assert_eq!(p.kind(), MessageKind::State);
+}
+
+#[test]
+fn kind_combat_maps_to_combat() {
+    let a = TributeRef { identifier: "a".into(), name: "A".into() };
+    let b = TributeRef { identifier: "b".into(), name: "B".into() };
+    let p = MessagePayload::Combat(CombatEngagement {
+        attacker: a, target: b,
+        outcome: CombatOutcome::Wounded,
+        detail_lines: vec![],
+    });
+    assert_eq!(p.kind(), MessageKind::Combat);
+}
+
+#[test]
+fn kind_alliance_variants_all_map_to_alliance() {
+    let a = TributeRef { identifier: "a".into(), name: "A".into() };
+    let b = TributeRef { identifier: "b".into(), name: "B".into() };
+    let cases = vec![
+        MessagePayload::AllianceFormed { members: vec![a.clone(), b.clone()] },
+        MessagePayload::AllianceProposed { proposer: a.clone(), target: b.clone() },
+        MessagePayload::AllianceDissolved { members: vec![a.clone()], reason: "x".into() },
+        MessagePayload::BetrayalTriggered { betrayer: a.clone(), victim: b.clone() },
+        MessagePayload::TrustShockBreak { tribute: a.clone(), partner: b.clone() },
+    ];
+    for c in cases {
+        assert_eq!(c.kind(), MessageKind::Alliance);
+    }
+}
+
+#[test]
+fn kind_movement_variants_map_to_movement() {
+    let t = TributeRef { identifier: "t".into(), name: "T".into() };
+    let area = AreaRef { identifier: "a".into(), name: "Ar".into() };
+    let cases = vec![
+        MessagePayload::TributeMoved { tribute: t.clone(), from: area.clone(), to: area.clone() },
+        MessagePayload::TributeHidden { tribute: t.clone(), area: area.clone() },
+        MessagePayload::AreaClosed { area: area.clone() },
+        MessagePayload::AreaEvent { area: area.clone(), kind: AreaEventKind::Storm, description: "s".into() },
+    ];
+    for c in cases {
+        assert_eq!(c.kind(), MessageKind::Movement);
+    }
+}
+
+#[test]
+fn kind_item_variants_map_to_item() {
+    let t = TributeRef { identifier: "t".into(), name: "T".into() };
+    let i = ItemRef { identifier: "i".into(), name: "I".into() };
+    let area = AreaRef { identifier: "a".into(), name: "Ar".into() };
+    let cases = vec![
+        MessagePayload::ItemFound { tribute: t.clone(), item: i.clone(), area: area.clone() },
+        MessagePayload::ItemUsed { tribute: t.clone(), item: i.clone() },
+        MessagePayload::ItemDropped { tribute: t.clone(), item: i.clone(), area: area.clone() },
+        MessagePayload::SponsorGift { recipient: t.clone(), item: i.clone(), donor: "d".into() },
+    ];
+    for c in cases {
+        assert_eq!(c.kind(), MessageKind::Item);
+    }
+}
+
+#[test]
+fn kind_state_variants_map_to_state() {
+    let t = TributeRef { identifier: "t".into(), name: "T".into() };
+    let cases = vec![
+        MessagePayload::TributeRested { tribute: t.clone(), hp_restored: 1 },
+        MessagePayload::TributeStarved { tribute: t.clone(), hp_lost: 1 },
+        MessagePayload::TributeDehydrated { tribute: t.clone(), hp_lost: 1 },
+        MessagePayload::SanityBreak { tribute: t.clone() },
+    ];
+    for c in cases {
+        assert_eq!(c.kind(), MessageKind::State);
+    }
+}
+
+#[test]
+fn unknown_payload_tag_hard_errors() {
+    let json = r#"{"type":"FutureKindNobodyKnows","extra":"x"}"#;
+    let result: Result<MessagePayload, _> = serde_json::from_str(json);
+    assert!(result.is_err(), "unknown tag must hard-error, no silent default");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cargo test -p shared --lib messages::tests::kind`
+Expected: PASS for all 6 `kind_*` tests + the unknown-tag hard-error test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj commit -m "test(shared): cover MessagePayload::kind() and unknown-tag hard-error"
+```
+
+---
+
+## Task 5: Add Phase enum tests
+
+**Files:**
+- Modify: `shared/src/messages.rs` (`#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the test module:
+
+```rust
+#[test]
+fn phase_from_str_accepts_lowercase_only() {
+    assert_eq!(Phase::from_str("day").unwrap(), Phase::Day);
+    assert_eq!(Phase::from_str("night").unwrap(), Phase::Night);
+}
+
+#[test]
+fn phase_from_str_rejects_mixed_case_and_garbage() {
+    assert!(Phase::from_str("Day").is_err());
+    assert!(Phase::from_str("NIGHT").is_err());
+    assert!(Phase::from_str("sideways").is_err());
+    assert!(Phase::from_str("").is_err());
+    assert!(Phase::from_str(" day ").is_err());
+}
+
+#[test]
+fn phase_display_round_trip() {
+    for p in [Phase::Day, Phase::Night] {
+        let s = p.to_string();
+        let back = Phase::from_str(&s).unwrap();
+        assert_eq!(p, back);
+    }
+}
+
+#[test]
+fn phase_serde_round_trip() {
+    let p = Phase::Day;
+    let s = serde_json::to_string(&p).unwrap();
+    assert_eq!(s, "\"day\"");
+    let back: Phase = serde_json::from_str(&s).unwrap();
+    assert_eq!(p, back);
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p shared --lib messages::tests::phase`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj commit -m "test(shared): cover Phase FromStr/Display/serde round-trips"
+```
+
+---
+
+## Task 6: Refactor combat.rs to emit TaggedEvent (one Combat per fight)
+
+**Files:**
+- Modify: `game/src/tributes/combat.rs` (787 lines; `attacks` at L34, `apply_violence_stress` at L195, helpers at L254 and L366)
+
+- [ ] **Step 1: Read the current combat.rs**
+
+Run: `cat game/src/tributes/combat.rs`
+Note: 4 fns take `events: &mut Vec<String>`. `attacks()` pushes 3-6 lines per call.
+
+- [ ] **Step 2: Write a failing test for the new contract**
+
+Add to the existing combat tests module:
+
+```rust
+#[rstest]
+fn attacks_emits_one_combat_taggedevent(/* existing fixtures */) {
+    // Construct attacker, target, world per existing test pattern
+    let mut events: Vec<TaggedEvent> = Vec::new();
+    attacker.attacks(&mut target, &mut events, /* other params */);
+
+    let combat_events: Vec<_> = events.iter()
+        .filter(|e| matches!(e.payload, MessagePayload::Combat(_)))
+        .collect();
+    assert_eq!(combat_events.len(), 1, "exactly one Combat payload per attacks() call");
+
+    if let MessagePayload::Combat(eng) = &combat_events[0].payload {
+        assert_eq!(eng.attacker.name, attacker.name);
+        assert_eq!(eng.target.name, target.name);
+        assert!(matches!(eng.outcome, CombatOutcome::Killed | CombatOutcome::Wounded
+            | CombatOutcome::TargetFled | CombatOutcome::AttackerFled | CombatOutcome::Stalemate));
+    } else {
+        panic!("expected Combat payload");
+    }
+}
+```
+
+(Match the existing `#[rstest]` fixture pattern in the file. If the file already has a working "attacks_kills_target" test or similar, model after that.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test -p game --lib tributes::combat::tests::attacks_emits_one_combat_taggedevent`
+Expected: FAIL (the function still takes `&mut Vec<String>`).
+
+- [ ] **Step 4: Change function signatures**
+
+In `game/src/tributes/combat.rs`, change the 4 `&mut Vec<String>` parameters to `&mut Vec<TaggedEvent>`:
+- `attacks` (L34)
+- `apply_violence_stress` (L195)
+- helper at L254
+- helper at L366
+
+Add `use crate::messages::{TaggedEvent, MessagePayload, CombatEngagement, CombatOutcome, TributeRef};` at the top.
+
+- [ ] **Step 5: Replace per-line `events.push(string)` with one Combat TaggedEvent at end of attacks()**
+
+Inside `attacks()`, accumulate prose into a local `let mut detail_lines: Vec<String> = Vec::new();` instead of pushing to `events`. Track `outcome: CombatOutcome` based on the existing branches:
+- Tribute dies → `CombatOutcome::Killed`
+- HP reduced but alive → `CombatOutcome::Wounded`
+- Target flees → `CombatOutcome::TargetFled`
+- Attacker flees → `CombatOutcome::AttackerFled`
+- No one lands a blow → `CombatOutcome::Stalemate`
+
+For lines that today are SELF-HARM / SUICIDE / CRITICAL FUMBLE (combat.rs L38, L55, L80) — these are NOT engagements. Emit them as their own `TaggedEvent` with `MessagePayload::TributeKilled` (suicide/self-harm-fatal) or as state-change payloads, NOT as part of a Combat engagement.
+
+At the end of an actual two-tribute engagement, push one:
+
+```rust
+let engagement = CombatEngagement {
+    attacker: TributeRef { identifier: self.identifier.clone(), name: self.name.clone() },
+    target:   TributeRef { identifier: target.identifier.clone(), name: target.name.clone() },
+    outcome,
+    detail_lines: detail_lines.clone(),
+};
+let summary = format!("{} attacks {} ({:?})", self.name, target.name, outcome);
+events.push(TaggedEvent::new(summary, MessagePayload::Combat(engagement)));
+```
+
+`apply_violence_stress` and the helpers: same treatment — convert each `events.push(string)` to a `TaggedEvent::new(string, MessagePayload::<appropriate variant>)`. For violence-stress-induced sanity breaks, use `MessagePayload::SanityBreak { tribute: TributeRef { .. } }`.
+
+- [ ] **Step 6: Run combat tests**
+
+Run: `cargo test -p game --lib tributes::combat`
+Expected: New test PASSES. Existing combat tests fail until they're updated in Step 7.
+
+- [ ] **Step 7: Update existing combat tests**
+
+For every existing combat rstest in this file, change `let mut events: Vec<String> = Vec::new();` to `let mut events: Vec<TaggedEvent> = Vec::new();`. Change assertions on event strings to assertions on payload variants. Example:
+
+```rust
+// Before:
+assert!(events.iter().any(|e| e.contains("dies")));
+// After:
+assert!(events.iter().any(|e| matches!(e.payload, MessagePayload::TributeKilled { .. })
+    || matches!(&e.payload, MessagePayload::Combat(c) if c.outcome == CombatOutcome::Killed)));
+```
+
+- [ ] **Step 8: Run combat tests, all passing**
+
+Run: `cargo test -p game --lib tributes::combat`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+jj commit -m "refactor(game): emit one Combat TaggedEvent per attacks() call"
+```
+
+---
+
+## Task 7: Refactor lifecycle.rs and movement.rs to use TaggedEvent
+
+**Files:**
+- Modify: `game/src/tributes/lifecycle.rs` (485 lines; `&mut Vec<String>` at L210, push at L282; AreaEvent push at L480)
+- Modify: `game/src/tributes/movement.rs` (213 lines; `&mut Vec<String>` at L30, pushes at L39, L53, L69, L80, L95, L114, L129)
+
+- [ ] **Step 1: Update lifecycle.rs**
+
+Change the `events: &mut Vec<String>` parameter (L210, in `take_damage` or equivalent — confirm by reading the fn signature) to `events: &mut Vec<TaggedEvent>`. Replace L282's `events.push(string)` with `events.push(TaggedEvent::new(line, MessagePayload::TributeKilled { victim: ..., killer: ..., cause: ... }))`. Source the `killer` field from the existing damage-source argument; `cause` is a short string like `"combat"`, `"poison"`, `"fall"`, `"starvation"` — pick based on the call context branch.
+
+L480's `area_details.events.push(AreaEvent::Wildfire)` is unchanged — that's an `AreaEvent` enum push, not a string push.
+
+Add `use crate::messages::{TaggedEvent, MessagePayload, TributeRef};` at the top.
+
+- [ ] **Step 2: Update movement.rs**
+
+Change `events: &mut Vec<String>` (L30, in `move_to_area` or equivalent) to `events: &mut Vec<TaggedEvent>`.
+
+Each push site (L39, L53, L69, L80, L95, L114, L129) becomes a `TaggedEvent` with `MessagePayload::TributeMoved { tribute, from, to }` or `MessagePayload::TributeHidden { tribute, area }` based on the branch. Source `from`/`to` from the existing area variables in scope; `tribute` from `self`.
+
+Add `use crate::messages::{TaggedEvent, MessagePayload, TributeRef, AreaRef};` at the top.
+
+- [ ] **Step 3: Verify game crate compiles up to mod.rs callers**
+
+Run: `cargo check -p game --lib 2>&1 | head -50`
+Expected: Errors only in `game/src/tributes/mod.rs` (callers not yet updated) and `game/src/games.rs` (drain not yet updated). lifecycle.rs and movement.rs themselves compile clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "refactor(game): convert lifecycle and movement to TaggedEvent"
+```
+
+---
+
+## Task 8: Refactor tributes/mod.rs to use TaggedEvent
+
+**Files:**
+- Modify: `game/src/tributes/mod.rs` (1021 lines; `&mut Vec<String>` at L214, L430, L497; pushes at L218, L238, L274, L333, L354, L360, L363, L387, L396, L437, L512; 8 internal Vec<String> declarations between L832-L1000)
+
+> **Note:** `game/src/tributes/alliances.rs` (473 lines) was confirmed to have NO `events.push` and NO `&mut Vec<String>` parameters — it is pure decision logic (gates, rolls, factors, `try_form_alliance`). Alliance message emission happens in `game/src/games.rs::do_step` and is handled by Task 10 Steps 4-5.
+
+- [ ] **Step 1: Update mod.rs three public methods**
+
+For `do_day_action` (L214), `do_night_action` (L430), and the third method (L497), change `events: &mut Vec<String>` to `events: &mut Vec<TaggedEvent>`.
+
+For each push site, choose the payload by branch:
+- L218: `TributeAlreadyDead` — this is informational, no useful payload. Use `MessagePayload::TributeWounded { victim, attacker: None, hp_lost: 0 }` is wrong; better: drop this push entirely (skip emit when already dead), as the simulator already short-circuits.
+- L238: `TributeDead` — `MessagePayload::TributeKilled { victim, killer: None, cause: "untracked".into() }` (rare branch).
+- L274: `SponsorGift` — currently no emit per spec §2 LOW-3, BUT this code already exists. Either keep emitting `MessagePayload::SponsorGift { recipient, item, donor: "Sponsor".into() }` (preferred — the variant exists) or drop the push. **Prefer keeping it; revisit if too noisy.**
+- L333, L387, L396: depend on branch context — read surrounding code; most are state-change events. Map to `MessagePayload::SanityBreak { .. }` or similar based on what the line text says.
+- L354: `TributeRest` → `MessagePayload::TributeRested { tribute, hp_restored: <local var or 0> }`.
+- L360, L363: `TributeHide` → `MessagePayload::TributeHidden { tribute, area }`.
+- L437: `TributeSuicide` → `MessagePayload::TributeKilled { victim, killer: None, cause: "suicide".into() }`.
+- L512: format-string event — read surrounding code; map by branch.
+
+- [ ] **Step 2: Update internal Vec<String> declarations**
+
+The 8 internal `let mut events: Vec<String> = Vec::new();` (L832, L853, L875, L899, L911, L925, L978, L1000) become `let mut events: Vec<TaggedEvent> = Vec::new();`. They are then drained into the parent context — confirm by reading each. If they're consumed locally to format a final string, leave the type as `Vec<String>` and rename to `lines` to avoid the typename clash. If they're pushed into the outer `events: &mut Vec<TaggedEvent>`, they must be `Vec<TaggedEvent>` and pushed via `events.extend(local_events)`.
+
+- [ ] **Step 3: Verify game crate compiles up to games.rs**
+
+Run: `cargo check -p game --lib 2>&1 | grep -E '^(error|warning)' | head -30`
+Expected: Errors only in `game/src/games.rs` (drain not yet updated). Tribute module clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "refactor(game): convert tributes mod to TaggedEvent"
+```
+
+---
+
+## Task 9: Add TickCounter and CycleContext to Game
+
+**Files:**
+- Modify: `game/src/games.rs` (struct and impl Game)
+
+- [ ] **Step 1: Add TickCounter struct**
+
+Near the top of `game/src/games.rs` after the existing imports:
+
+```rust
+/// Per-period tick counter. Resets to 0 at every phase boundary.
+/// Phase-boundary side-effect messages get tick=0.
+/// First action in a phase gets tick=1.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TickCounter { current: u32 }
+
+impl TickCounter {
+    pub fn reset(&mut self) { self.current = 0; }
+    pub fn next(&mut self) -> u32 {
+        self.current += 1;
+        self.current
+    }
+    pub fn boundary(&self) -> u32 { 0 }
+}
+```
+
+- [ ] **Step 2: Add a tick_counter field to Game (transient, not persisted)**
+
+In the `Game` struct, add:
+
+```rust
+#[serde(skip, default)]
+pub tick_counter: TickCounter,
+```
+
+- [ ] **Step 3: Verify it compiles standalone**
+
+Run: `cargo check -p game --lib 2>&1 | grep TickCounter`
+Expected: No errors mentioning TickCounter.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "feat(game): add TickCounter for per-period causal ordering"
+```
+
+---
+
+## Task 10: Refactor games.rs::do_step drain to build typed GameMessages
+
+**Files:**
+- Modify: `game/src/games.rs` (L201, L212, L224, L232, L791-L1046 — main drain block, plus tests at L906, L1187, L1223, L2158, L2165, L2208, L2257, L2347)
+
+- [ ] **Step 1: Inspect the drain block**
+
+Run: `sed -n '780,1050p' game/src/games.rs`
+Expected: Read the per-tribute action loop. Identify where `Vec<String>` events are drained into `GameMessage`s.
+
+- [ ] **Step 2: Change all internal events accumulators to Vec<TaggedEvent>**
+
+In `do_step`, convert every `let mut events: Vec<String> = Vec::new();` (and any `Vec<String>` passed to tribute methods) to `Vec<TaggedEvent>`.
+
+The drain block (~L1001) currently calls `log_output` / `log_output_kind` per string. Replace with a per-event loop that:
+
+```rust
+let phase = if game.is_day { Phase::Day } else { Phase::Night };
+let mut emit_index: u32 = 0;
+let tick = game.tick_counter.next();
+
+for tagged in events.drain(..) {
+    let msg = GameMessage::new(
+        MessageSource::Tribute(tribute.identifier.clone()),
+        game.day,
+        phase,
+        tick,
+        emit_index,
+        tribute.name.clone(),  // subject
+        tagged.content,
+        tagged.payload,
+    );
+    game.messages.push(msg);
+    emit_index += 1;
+}
+```
+
+(Adjust `MessageSource` per the actual emit context — `Game(...)`, `Area(...)`, or `Tribute(...)`.)
+
+`emit_index` is per-period, NOT per-tick. Hoist its declaration to the top of the per-period block; reset it on phase boundary in step 6.
+
+- [ ] **Step 3: Delete `log_output` and `log_output_kind`**
+
+Remove the two methods at L212 and L224 entirely. All callers were just rewritten in Step 2.
+
+- [ ] **Step 4: Update the existing alliance-formed emit (L902-L906)**
+
+Replace:
+```rust
+collected_events.push((
+    /* ... */,
+    Some(crate::messages::MessageKind::AllianceFormed),
+));
+```
+With code that builds a `MessagePayload::AllianceFormed { members: Vec<TributeRef> }` directly into a `GameMessage::new(...)` push onto `game.messages`. Use `game.tick_counter.next()` for the tick and a per-period `emit_index` (separate counter from the action drain — alliance emits happen outside the action loop in this code path).
+
+- [ ] **Step 5: Update betrayal/trust-shock emit sites (L1187, L1223)**
+
+Similarly: build `MessagePayload::BetrayalTriggered { betrayer, victim }` and `MessagePayload::TrustShockBreak { tribute, partner }` payloads. Construct `TributeRef`s from the in-scope tribute structs.
+
+- [ ] **Step 6: Reset TickCounter on phase boundary**
+
+Find the place in `do_step` (or its phase-advance helper) where `game.is_day` flips. Immediately after the flip, call `game.tick_counter.reset();`.
+
+- [ ] **Step 7: Update tests in games.rs**
+
+The 5 test sites at L2158, L2165, L2208, L2257, L2347 currently assert `m.kind == Some(MessageKind::AllianceFormed)` etc. Change to `matches!(m.payload, MessagePayload::AllianceFormed { .. })` and similar for `BetrayalTriggered`.
+
+- [ ] **Step 8: Run game crate tests**
+
+Run: `cargo test -p game --lib`
+Expected: PASS. (Some tests may need additional cleanup if they construct `GameMessage` directly — fix in place.)
+
+- [ ] **Step 9: Verify the workspace compiles minus web/api**
+
+Run: `cargo check -p game`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+jj commit -m "refactor(game): drain TaggedEvents into typed GameMessages with tick/emit_index"
+```
+
+---
+
+## Task 11: Add summarize_periods to shared/
+
+**Files:**
+- Modify: `shared/src/messages.rs` (add fn + tests)
+
+- [ ] **Step 1: Add the PeriodSummary struct and stub fn**
+
+Append to `shared/src/messages.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PeriodSummary {
+    pub day: u32,
+    pub phase: Phase,
+    pub deaths: u32,
+    pub event_count: u32,
+    pub is_current: bool,
+}
+
+/// Aggregate messages into one summary per (day, phase). Includes empty periods
+/// up to and including `current` so the hub shows the live period even when
+/// nothing has been emitted there yet. Periods past `current` are not emitted.
+pub fn summarize_periods(messages: &[GameMessage], current: (u32, Phase)) -> Vec<PeriodSummary> {
+    use std::collections::BTreeMap;
+
+    let (current_day, current_phase) = current;
+    let mut bucket: BTreeMap<(u32, u32), (u32, u32)> = BTreeMap::new();
+    // key: (day, phase as u32)  value: (deaths, event_count)
+    let phase_ord = |p: Phase| match p { Phase::Day => 0, Phase::Night => 1 };
+
+    for m in messages {
+        let key = (m.game_day, phase_ord(m.phase));
+        let entry = bucket.entry(key).or_insert((0, 0));
+        entry.1 += 1;
+        if matches!(m.payload, MessagePayload::TributeKilled { .. }) {
+            entry.0 += 1;
+        }
+    }
+
+    // Ensure all reached periods appear, even with zero messages.
+    for d in 1..=current_day {
+        bucket.entry((d, 0)).or_insert((0, 0));
+        if d < current_day || matches!(current_phase, Phase::Night) {
+            bucket.entry((d, 1)).or_insert((0, 0));
+        }
+    }
+
+    bucket.into_iter().map(|((day, p), (deaths, count))| {
+        let phase = if p == 0 { Phase::Day } else { Phase::Night };
+        PeriodSummary {
+            day, phase, deaths, event_count: count,
+            is_current: day == current_day && phase == current_phase,
+        }
+    }).collect()
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to the test module:
+
+```rust
+fn make_msg(day: u32, phase: Phase, payload: MessagePayload) -> GameMessage {
+    GameMessage::new(
+        MessageSource::Game("g".into()),
+        day, phase, 1, 0,
+        "subject".into(), "content".into(), payload,
+    )
+}
+
+#[test]
+fn summarize_empty_input_with_current_day_zero() {
+    let result = summarize_periods(&[], (0, Phase::Day));
+    assert!(result.is_empty(), "no periods reached when current_day=0");
+}
+
+#[test]
+fn summarize_groups_by_day_and_phase() {
+    let t = TributeRef { identifier: "t".into(), name: "T".into() };
+    let killed = MessagePayload::TributeKilled { victim: t.clone(), killer: None, cause: "x".into() };
+    let moved = MessagePayload::TributeHidden { tribute: t.clone(), area: AreaRef { identifier: "a".into(), name: "A".into() } };
+
+    let msgs = vec![
+        make_msg(1, Phase::Day, killed.clone()),
+        make_msg(1, Phase::Day, moved.clone()),
+        make_msg(1, Phase::Night, moved.clone()),
+        make_msg(2, Phase::Day, killed.clone()),
+    ];
+    let result = summarize_periods(&msgs, (2, Phase::Day));
+    assert_eq!(result.len(), 4);
+    assert_eq!(result[0], PeriodSummary { day: 1, phase: Phase::Day, deaths: 1, event_count: 2, is_current: false });
+    assert_eq!(result[1], PeriodSummary { day: 1, phase: Phase::Night, deaths: 0, event_count: 1, is_current: false });
+    assert_eq!(result[2], PeriodSummary { day: 2, phase: Phase::Day, deaths: 1, event_count: 1, is_current: true });
+}
+
+#[test]
+fn summarize_includes_empty_reached_periods() {
+    let result = summarize_periods(&[], (2, Phase::Day));
+    // Day 1 (Day + Night) reached, Day 2 Day reached, Day 2 Night not reached
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0], PeriodSummary { day: 1, phase: Phase::Day, deaths: 0, event_count: 0, is_current: false });
+    assert_eq!(result[1], PeriodSummary { day: 1, phase: Phase::Night, deaths: 0, event_count: 0, is_current: false });
+    assert_eq!(result[2], PeriodSummary { day: 2, phase: Phase::Day, deaths: 0, event_count: 0, is_current: true });
+}
+
+#[test]
+fn summarize_is_current_flag_set_correctly() {
+    let t = TributeRef { identifier: "t".into(), name: "T".into() };
+    let p = MessagePayload::TributeRested { tribute: t, hp_restored: 1 };
+    let msgs = vec![make_msg(2, Phase::Night, p.clone())];
+    let result = summarize_periods(&msgs, (2, Phase::Night));
+    let current: Vec<_> = result.iter().filter(|s| s.is_current).collect();
+    assert_eq!(current.len(), 1);
+    assert_eq!(current[0].day, 2);
+    assert_eq!(current[0].phase, Phase::Night);
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p shared --lib messages::tests::summarize`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "feat(shared): add summarize_periods aggregation for timeline summary"
+```
+
+---
+
+## Task 12: Add causal-ordering regression test
+
+**Files:**
+- Modify: `game/src/games.rs` (test module)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` mod in `games.rs`:
+
+```rust
+#[test]
+fn dead_tribute_has_no_movement_event_after_death_in_same_period() {
+    // Build a small scenario: tribute B killed by tribute A in Day 1.
+    // After do_step, no MessagePayload::TributeMoved { tribute: B, .. }
+    // should appear at a later (tick, emit_index) than B's TributeKilled.
+    let mut game = /* construct game with A and B in same area, A guaranteed to win */;
+    game.do_step(&mut rand::thread_rng());
+
+    let b_killed = game.messages.iter()
+        .find(|m| matches!(&m.payload,
+            MessagePayload::TributeKilled { victim, .. } if victim.name == "B"));
+    let b_killed = b_killed.expect("B should have died");
+
+    let later_b_move = game.messages.iter().find(|m| {
+        m.game_day == b_killed.game_day
+            && m.phase == b_killed.phase
+            && (m.tick, m.emit_index) > (b_killed.tick, b_killed.emit_index)
+            && matches!(&m.payload,
+                MessagePayload::TributeMoved { tribute, .. } if tribute.name == "B")
+    });
+
+    assert!(later_b_move.is_none(), "no TributeMoved for B after B dies in same period");
+}
+```
+
+(If existing test scaffolding doesn't make this scenario easy to construct, mark as `#[ignore]` with a note pointing to the scenario gap; do NOT skip the assertion structure.)
+
+- [ ] **Step 2: Run test**
+
+Run: `cargo test -p game --lib games::tests::dead_tribute_has_no_movement`
+Expected: PASS (or `#[ignore]`'d if scenario can't be set up).
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj commit -m "test(game): regression test for causal ordering of TributeKilled vs TributeMoved"
+```
+
+---
+
+## Task 13: Update API drain and serialization
+
+**Files:**
+- Modify: `api/src/games.rs` (any `kind` references for `GameMessage`)
+- Modify: `api/tests/games_tests.rs`
+
+- [ ] **Step 1: Find broken sites**
+
+Run: `cargo check -p api 2>&1 | grep -E '^(error|warning)' | head -40`
+Expected: Errors at any site referencing `GameMessage.kind` or `MessageKind::AllianceFormed/BetrayalTriggered/TrustShockBreak` (the old 3-variant enum).
+
+- [ ] **Step 2: Update each error site**
+
+For each error, replace `kind: Some(MessageKind::Xxx)` checks with `matches!(payload, MessagePayload::Xxx { .. })`. Replace `MessageKind` use statements with `MessagePayload`.
+
+- [ ] **Step 3: Update api integration tests**
+
+In `api/tests/games_tests.rs`, change assertions on the old `kind` field to assertions on `payload` variants. Add tests for the new `phase`, `tick`, `emit_index` fields appearing in `/log/:day` responses.
+
+- [ ] **Step 4: Verify api compiles**
+
+Run: `cargo check -p api`
+Expected: PASS.
+
+- [ ] **Step 5: Run api tests**
+
+Run: `cargo test -p api`
+Expected: PASS. (If SurrealDB-dependent tests fail because the runner has no DB, they were already broken — note in commit message and skip.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "refactor(api): adapt to new GameMessage payload shape"
+```
+
+---
+
+## Task 14: Add GET /api/games/:id/timeline-summary endpoint
+
+**Files:**
+- Modify: `api/src/games.rs` (add handler, register route)
+- Modify: `api/tests/games_tests.rs` (integration test)
+
+- [ ] **Step 1: Write the failing integration test**
+
+In `api/tests/games_tests.rs`:
+
+```rust
+#[tokio::test]
+async fn timeline_summary_empty_for_unstarted_game() {
+    let app = test_app().await;
+    let game_id = create_game(&app).await;
+
+    let resp = app
+        .request(format!("/api/games/{}/timeline-summary", game_id))
+        .send().await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Vec<shared::messages::PeriodSummary> = resp.json().await;
+    assert!(body.is_empty(), "unstarted game has no reached periods");
+}
+
+#[tokio::test]
+async fn timeline_summary_includes_current_period_even_when_empty() {
+    let app = test_app().await;
+    let game_id = create_game_with_day(&app, 1).await;  // helper that advances to day 1
+
+    let resp = app.request(format!("/api/games/{}/timeline-summary", game_id)).send().await;
+    let body: Vec<shared::messages::PeriodSummary> = resp.json().await;
+    assert!(body.iter().any(|s| s.day == 1 && s.is_current));
+}
+```
+
+(Adapt to the existing `tests/games_tests.rs` style — match how other endpoints are tested.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p api timeline_summary`
+Expected: FAIL (route doesn't exist → 404).
+
+- [ ] **Step 3: Add the handler**
+
+In `api/src/games.rs`:
+
+```rust
+async fn timeline_summary(
+    State(state): State<AppState>,
+    Path(game_id): Path<String>,
+) -> Result<Json<Vec<shared::messages::PeriodSummary>>, ApiError> {
+    let game = state.db.load_game(&game_id).await?;
+    let messages = state.db.load_messages_for_game(&game_id).await?;
+    let current_phase = if game.is_day { shared::messages::Phase::Day } else { shared::messages::Phase::Night };
+    let summaries = shared::messages::summarize_periods(&messages, (game.current_day, current_phase));
+    Ok(Json(summaries))
+}
+```
+
+(Adapt names to actual State and DB-access patterns in the file. `game.current_day` and `game.is_day` may have different names — read the `Game` struct to confirm.)
+
+- [ ] **Step 4: Register the route**
+
+In whatever fn builds the api router (probably near other `/api/games/:id/*` routes):
+
+```rust
+.route("/api/games/:id/timeline-summary", get(timeline_summary))
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p api timeline_summary`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "feat(api): add /timeline-summary endpoint backed by summarize_periods"
+```
+
+---
+
+## Task 15: Stub the frontend so web/ compiles
+
+**Files:**
+- Delete: `web/src/components/game_day_log.rs`
+- Delete: `web/src/components/game_day_summary.rs`
+- Create: `web/src/components/game_log_stub.rs`
+- Modify: `web/src/components/mod.rs` (or wherever components are registered)
+- Modify: `web/src/components/game_detail.rs` (replace day-log / day-summary calls with the stub)
+
+- [ ] **Step 1: Find current usages**
+
+Run: `rg 'game_day_log|game_day_summary|GameDayLog|GameDaySummary' web/src/`
+Expected: Lists the import sites and component-call sites in `game_detail.rs` and `mod.rs`.
+
+- [ ] **Step 2: Create web/src/components/game_log_stub.rs**
+
+```rust
+use dioxus::prelude::*;
+use shared::messages::GameMessage;
+
+#[component]
+pub fn GameLogStub(messages: Vec<GameMessage>) -> Element {
+    rsx! {
+        div { class: "border border-yellow-400 bg-yellow-50 p-3 my-2 text-xs",
+            p { class: "font-bold mb-2", "[PR1 stub — full timeline lands in PR2]" }
+            ul { class: "space-y-1",
+                for m in messages.iter() {
+                    li {
+                        span { class: "text-gray-500", "Day {m.game_day} {m.phase} t{m.tick}.{m.emit_index} — " }
+                        "{m.content}"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Delete the old components**
+
+```bash
+rm -f web/src/components/game_day_log.rs web/src/components/game_day_summary.rs
+```
+
+- [ ] **Step 4: Update web/src/components/mod.rs**
+
+Remove `pub mod game_day_log;` and `pub mod game_day_summary;` lines. Add `pub mod game_log_stub;`.
+
+- [ ] **Step 5: Update game_detail.rs**
+
+Replace the call sites for `<GameDayLog ... />` and `<GameDaySummary ... />` (lines ~220-630 per spec) with a single `<GameLogStub messages={...} />` call. The `messages` prop comes from the existing `/api/games/:id/log/:day` query — collect across days or keep the existing per-day fetch and pass that day's messages.
+
+To keep this PR small and avoid touching the larger game_detail.rs structure: leave the per-day loops in place but inside each day's section, replace `<GameDayLog />` with `<GameLogStub messages={day_messages.clone()} />`. Strip `<GameDaySummary />` entirely.
+
+- [ ] **Step 6: Build web crate**
+
+Run: `cd web && RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "refactor(web): stub day log to keep web crate compiling for PR1"
+```
+
+---
+
+## Task 16: Quality gates and spec correction
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-26-game-timeline-redesign.md` (correct drain location and state.rs reference)
+
+- [ ] **Step 1: Run full quality suite**
+
+Run: `just quality`
+Expected: PASS (fmt, check, clippy, test).
+
+- [ ] **Step 2: If any failures, fix in place and re-run**
+
+Iterate until clean. Commit fixes individually with descriptive messages.
+
+- [ ] **Step 3: Correct the spec**
+
+Edit `docs/superpowers/specs/2026-04-26-game-timeline-redesign.md`:
+- §3 "Drain site" line: change `api/src/games.rs ~L957` to `game/src/games.rs ~L1001 (inside Game::do_step)`.
+- §3 emit-sites bullet list: remove `game/src/tributes/state.rs (rest, starve, dehydrate, sanity-break helpers)` (no such file). Replace with: `game/src/tributes/mod.rs (rest, sponsor, hide, suicide, sanity helpers across do_day_action/do_night_action)`.
+- §2 "Changes to GameMessage": add a one-line note that the legacy `event: Option<GameEvent>` and `event_id: Option<String>` fields plus the `serde_event_via_json` helper module are also removed by this PR.
+
+- [ ] **Step 4: Commit spec correction**
+
+```bash
+jj commit -m "docs(spec): correct drain location and state.rs reference for timeline redesign"
+```
+
+---
+
+## Task 17: Open the PR
+
+- [ ] **Step 1: Sync with remote**
+
+```bash
+jj git fetch
+jj rebase -d main@origin
+```
+
+- [ ] **Step 2: Push beads (if any new issues filed during the work)**
+
+```bash
+bd dolt push
+```
+
+- [ ] **Step 3: Create the bookmark and push**
+
+```bash
+jj bookmark create feat-timeline-pr1-backend -r @-
+jj git push --bookmark feat-timeline-pr1-backend
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --base main --head feat-timeline-pr1-backend \
+  --title "feat(game,api,shared): timeline schema reshape + combat refactor (PR1 of 2)" \
+  --body "$(cat <<'EOF'
+## Summary
+PR1 of 2 for the game timeline redesign. Backend schema move + combat refactor + frontend stub. Spec: docs/superpowers/specs/2026-04-26-game-timeline-redesign.md.
+
+## Changes
+- Move GameMessage / Phase / CombatEngagement / *Ref types from game/ to shared/
+- Replace kind: Option<MessageKind> with structured payload: MessagePayload (22 variants in 6 categories)
+- Add (phase, tick, emit_index) for causal ordering; TickCounter on Game
+- Refactor combat to emit one CombatEngagement per attacks() call (was 3-6 lines)
+- Convert all &mut Vec<String> emit sites in tributes/ to &mut Vec<TaggedEvent>
+- New GET /api/games/:id/timeline-summary endpoint
+- Delete game_day_log.rs and game_day_summary.rs; add temporary game_log_stub.rs
+- Spec correction commit (drain location, state.rs reference)
+
+## Verification
+- just quality: PASS
+- cargo test -p shared: PASS (+ new MessagePayload, Phase, summarize_periods coverage)
+- cargo test -p game: PASS (+ updated combat assertions, causal-ordering regression test)
+- cargo test -p api: PASS (+ /timeline-summary integration)
+- web/ builds for wasm32
+
+## Breaking
+- Dev DB MUST be wiped before deploy. Unknown payload tags hard-error on deserialize.
+
+## Follow-ups
+- PR2 (frontend timeline UI): RecapCard, PeriodGrid, FilterChips, timeline cards.
+- Beads issues to be filed at PR2 close-out per spec §7.
+EOF
+)"
+```
+
+- [ ] **Step 5: Verify PR URL**
+
+Output the PR URL from the previous command. Hand off to user.

--- a/docs/superpowers/plans/2026-04-26-game-timeline-pr2-frontend.md
+++ b/docs/superpowers/plans/2026-04-26-game-timeline-pr2-frontend.md
@@ -1,0 +1,1323 @@
+# Game Timeline PR2 — Frontend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the PR1 stub on `GamePage` with a structured day/phase timeline UI: a hub of period cards, a per-period view with category filter chips and typed event cards, and a finished-game recap.
+
+**Architecture:** Dioxus 0.7 components compiled to WASM. Period hub fetches `/api/games/:id/timeline-summary`. Per-period view fetches `/api/games/:id/log/:day` and filters by `phase`. Filter state lives in a `PeriodFilters` context provided at the `Navbar` layout layer, persisted per-game to `gloo-storage`. Generation counter (in-memory) bumped by mutation handlers triggers dioxus-query re-fetches. Event card dispatcher routes each `MessagePayload` variant to a typed sub-card.
+
+**Tech Stack:** Dioxus 0.7 + dioxus-router, dioxus-query (already in use), Tailwind CSS (3-theme system), gloo-storage 0.3.0 (already in use), `shared::messages` types from PR1.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-game-timeline-redesign.md` §5 (components), §6 (rollout), §7 (follow-ups).
+
+**Pre-condition:** PR1 is merged. `shared::messages` exposes `GameMessage`, `MessagePayload`, `MessageKind`, `Phase`, `TributeRef`, `AreaRef`, `ItemRef`, `CombatOutcome`, `PeriodSummary`, `TimelineSummary`. The temporary `web/src/components/game_log_stub.rs` exists and is wired into `game_detail.rs`. `web/src/cache.rs` has `MutationValue::GameDeleted(String, String)` already.
+
+---
+
+## Task 1: Add PeriodFilters context type and provider
+
+**Files:**
+- Create: `web/src/components/timeline/filters.rs`
+- Modify: `web/src/components/timeline/mod.rs` (created in PR1; add `pub mod filters; pub use filters::*;`)
+- Modify: `web/src/components/navbar.rs` — provide context inside `Navbar`
+
+- [ ] **Step 1: Define FilterMode and PeriodFilters in `web/src/components/timeline/filters.rs`**
+
+```rust
+use shared::messages::MessageKind;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum FilterMode {
+    All,
+    Subset(HashSet<MessageKind>),
+}
+
+impl Default for FilterMode {
+    fn default() -> Self { FilterMode::All }
+}
+
+impl FilterMode {
+    pub fn matches(&self, kind: MessageKind) -> bool {
+        match self {
+            FilterMode::All => true,
+            FilterMode::Subset(set) => set.contains(&kind) || kind == MessageKind::State,
+        }
+    }
+    pub fn is_all(&self) -> bool { matches!(self, FilterMode::All) }
+}
+
+#[derive(Clone, PartialEq, Default, Debug)]
+pub struct PeriodFilters {
+    pub by_game: HashMap<String, FilterMode>,
+    pub generations: HashMap<String, u32>,
+}
+
+impl PeriodFilters {
+    pub fn filter_for(&self, game_id: &str) -> FilterMode {
+        self.by_game.get(game_id).cloned().unwrap_or_default()
+    }
+
+    pub fn set_filter(&mut self, game_id: &str, mode: FilterMode) {
+        self.by_game.insert(game_id.to_string(), mode.clone());
+        let key = format!("period_filters:{game_id}");
+        // best-effort persist; ignore failure
+        let _ = gloo_storage::LocalStorage::set(&key, &SerializableFilter::from(&mode));
+    }
+
+    pub fn hydrate(&mut self, game_id: &str) {
+        if self.by_game.contains_key(game_id) { return; }
+        let key = format!("period_filters:{game_id}");
+        if let Ok(saved) = gloo_storage::LocalStorage::get::<SerializableFilter>(&key) {
+            self.by_game.insert(game_id.to_string(), saved.into());
+        }
+    }
+
+    pub fn generation(&self, game_id: &str) -> u32 {
+        self.generations.get(game_id).copied().unwrap_or(0)
+    }
+
+    pub fn bump(&mut self, game_id: &str) {
+        let entry = self.generations.entry(game_id.to_string()).or_insert(0);
+        *entry += 1;
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct SerializableFilter {
+    mode: String,
+    kinds: Vec<MessageKind>,
+}
+
+impl From<&FilterMode> for SerializableFilter {
+    fn from(m: &FilterMode) -> Self {
+        match m {
+            FilterMode::All => Self { mode: "all".into(), kinds: vec![] },
+            FilterMode::Subset(s) => Self { mode: "subset".into(), kinds: s.iter().copied().collect() },
+        }
+    }
+}
+
+impl From<SerializableFilter> for FilterMode {
+    fn from(s: SerializableFilter) -> Self {
+        if s.mode == "subset" {
+            FilterMode::Subset(s.kinds.into_iter().collect())
+        } else {
+            FilterMode::All
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add module exports to `web/src/components/timeline/mod.rs`**
+
+Append:
+
+```rust
+pub mod filters;
+pub use filters::{FilterMode, PeriodFilters};
+```
+
+- [ ] **Step 3: Provide context in `Navbar`**
+
+Modify `web/src/components/navbar.rs`. Inside `pub fn Navbar() -> Element`, near other `use_context_provider` / `provide_context` calls (or right before the `rsx!` block), add:
+
+```rust
+use_context_provider(|| Signal::new(crate::components::timeline::PeriodFilters::default()));
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `cargo check --package web --target wasm32-unknown-unknown` (or `just web-check` if defined).
+Expected: compiles cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(web): add PeriodFilters context for timeline UI"
+```
+
+---
+
+## Task 2: Add timeline-summary query key and fetcher
+
+**Files:**
+- Modify: `web/src/cache.rs` — add `TimelineSummary(String)` key and `TimelineSummary(shared::messages::TimelineSummary)` value variant
+- Create: `web/src/hooks/use_timeline_summary.rs`
+- Modify: `web/src/hooks/mod.rs` (or wherever hooks are re-exported)
+
+- [ ] **Step 1: Extend `QueryKey` enum in `web/src/cache.rs`**
+
+Add variant:
+
+```rust
+TimelineSummary(String), // Game identifier
+```
+
+Add to `QueryValue`:
+
+```rust
+TimelineSummary(shared::messages::TimelineSummary),
+```
+
+- [ ] **Step 2: Create `web/src/hooks/use_timeline_summary.rs`**
+
+```rust
+use crate::cache::{QueryError, QueryKey, QueryValue};
+use crate::env::API_HOST;
+use dioxus::prelude::*;
+use dioxus_query::prelude::*;
+use reqwest::StatusCode;
+use shared::messages::TimelineSummary;
+
+async fn fetch_timeline_summary(keys: Vec<QueryKey>) -> QueryResult<QueryValue, QueryError> {
+    let Some(QueryKey::TimelineSummary(id)) = keys.first() else {
+        return Err(QueryError::Unknown).into();
+    };
+    let url = format!("{API_HOST}/api/games/{id}/timeline-summary");
+    match reqwest::get(&url).await {
+        Ok(resp) => match resp.status() {
+            StatusCode::OK => match resp.json::<TimelineSummary>().await {
+                Ok(s) => Ok(QueryValue::TimelineSummary(s)).into(),
+                Err(_) => Err(QueryError::BadJson).into(),
+            },
+            StatusCode::NOT_FOUND => Err(QueryError::GameNotFound(id.clone())).into(),
+            _ => Err(QueryError::Unknown).into(),
+        },
+        Err(_) => Err(QueryError::ServerNotFound).into(),
+    }
+}
+
+pub fn use_timeline_summary(game_id: String) -> UseQuery<QueryValue, QueryError, QueryKey> {
+    use_get_query([QueryKey::TimelineSummary(game_id)], fetch_timeline_summary)
+}
+```
+
+- [ ] **Step 3: Wire into `web/src/hooks/mod.rs`**
+
+Add `pub mod use_timeline_summary;` and `pub use use_timeline_summary::use_timeline_summary;`.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check --package web --target wasm32-unknown-unknown`.
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(web): add use_timeline_summary query hook"
+```
+
+---
+
+## Task 3: PeriodCard component
+
+**Files:**
+- Create: `web/src/components/period_card.rs`
+- Modify: `web/src/components/mod.rs` — `mod period_card; pub use period_card::PeriodCard;`
+
+- [ ] **Step 1: Implement `PeriodCard`**
+
+```rust
+use crate::routes::Routes;
+use dioxus::prelude::*;
+use shared::messages::Phase;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct PeriodCardProps {
+    pub game_identifier: String,
+    pub day: u32,
+    pub phase: Phase,
+    pub deaths: u32,
+    pub event_count: u32,
+    pub is_current: bool,
+}
+
+#[component]
+pub fn PeriodCard(props: PeriodCardProps) -> Element {
+    let phase_label = match props.phase {
+        Phase::Day => "Day",
+        Phase::Night => "Night",
+    };
+    let current_class = if props.is_current {
+        "ring-2 ring-amber-400 theme2:ring-green-400 theme3:ring-purple-400"
+    } else { "" };
+    let route = Routes::GamePeriodPage {
+        identifier: props.game_identifier.clone(),
+        day: props.day,
+        phase: props.phase,
+    };
+    rsx! {
+        Link {
+            to: route,
+            class: "block rounded-lg border p-4 hover:shadow-lg transition theme1:bg-amber-50 theme1:border-amber-200 theme2:bg-slate-800 theme2:border-green-700 theme3:bg-purple-900 theme3:border-purple-600 {current_class}",
+            div { class: "flex items-baseline justify-between",
+                h3 { class: "text-lg font-semibold", "Day {props.day} — {phase_label}" }
+                if props.is_current { span { class: "text-xs uppercase tracking-wide", "live" } }
+            }
+            div { class: "mt-2 text-sm",
+                span { class: "mr-3", "💀 {props.deaths} deaths" }
+                span { "📜 {props.event_count} events" }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register in `mod.rs`**
+
+Add `mod period_card;` and `pub use period_card::PeriodCard;`.
+
+- [ ] **Step 3: Build**
+
+Run: `cargo check --package web --target wasm32-unknown-unknown`.
+Expected: compiles. Note: `Routes::GamePeriodPage` does not exist yet — this step will FAIL. Defer the `Link { to: route, … }` line by stubbing with `to: Routes::Home {}` temporarily, or skip this build step until Task 8 adds the route.
+
+> **Author note:** Use a placeholder route in Step 1 (`Routes::Home {}`) and fix it up in Task 8 Step 3. Or accept that this task's build only passes after Task 8.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(web): add PeriodCard component"
+```
+
+---
+
+## Task 4: PeriodGrid + PeriodGridEmpty components
+
+**Files:**
+- Create: `web/src/components/period_grid.rs`
+- Create: `web/src/components/period_grid_empty.rs`
+- Modify: `web/src/components/mod.rs`
+
+- [ ] **Step 1: Implement `PeriodGridEmpty` in `web/src/components/period_grid_empty.rs`**
+
+```rust
+use dioxus::prelude::*;
+
+#[derive(PartialEq, Clone)]
+pub enum EmptyKind { NotStarted, LoadFailed, NotFound }
+
+#[derive(Props, PartialEq, Clone)]
+pub struct PeriodGridEmptyProps {
+    pub kind: EmptyKind,
+    pub on_retry: Option<EventHandler<()>>,
+}
+
+#[component]
+pub fn PeriodGridEmpty(props: PeriodGridEmptyProps) -> Element {
+    let copy = match props.kind {
+        EmptyKind::NotStarted => "This game hasn't started yet. Click Begin to start.",
+        EmptyKind::LoadFailed => "Couldn't load the timeline.",
+        EmptyKind::NotFound  => "Game not found.",
+    };
+    rsx! {
+        div { class: "rounded-lg border border-dashed p-8 text-center text-sm",
+            p { "{copy}" }
+            if matches!(props.kind, EmptyKind::LoadFailed) {
+                if let Some(retry) = props.on_retry {
+                    button {
+                        class: "mt-4 rounded bg-amber-500 px-3 py-1 text-amber-50 hover:bg-amber-600",
+                        onclick: move |_| retry.call(()),
+                        "Retry"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Implement `PeriodGrid` in `web/src/components/period_grid.rs`**
+
+```rust
+use crate::cache::{QueryError, QueryValue};
+use crate::components::period_card::PeriodCard;
+use crate::components::period_grid_empty::{EmptyKind, PeriodGridEmpty};
+use crate::hooks::use_timeline_summary::use_timeline_summary;
+use dioxus::prelude::*;
+use dioxus_query::prelude::*;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct PeriodGridProps {
+    pub game_identifier: String,
+}
+
+#[component]
+pub fn PeriodGrid(props: PeriodGridProps) -> Element {
+    let query = use_timeline_summary(props.game_identifier.clone());
+    rsx! {
+        match query.result().value() {
+            QueryResult::Ok(QueryValue::TimelineSummary(s)) => {
+                if s.periods.is_empty() {
+                    rsx!{ PeriodGridEmpty { kind: EmptyKind::NotStarted, on_retry: None } }
+                } else {
+                    rsx!{
+                        div { class: "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4",
+                            for p in s.periods.iter() {
+                                PeriodCard {
+                                    key: "{p.day}-{p.phase:?}",
+                                    game_identifier: props.game_identifier.clone(),
+                                    day: p.day,
+                                    phase: p.phase,
+                                    deaths: p.deaths,
+                                    event_count: p.event_count,
+                                    is_current: p.is_current,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            QueryResult::Err(_) => rsx!{ PeriodGridEmpty { kind: EmptyKind::LoadFailed, on_retry: None } },
+            _ => rsx!{ div { class: "animate-pulse h-32 rounded-lg bg-gray-200" } },
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Register in `mod.rs`**
+
+```rust
+mod period_grid;
+mod period_grid_empty;
+pub use period_grid::PeriodGrid;
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cargo check --package web --target wasm32-unknown-unknown`.
+Expected: compiles after Task 8 lands the route. Until then, `PeriodCard` uses placeholder route from Task 3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(web): add PeriodGrid + PeriodGridEmpty components"
+```
+
+---
+
+## Task 5: RecapCard component
+
+**Files:**
+- Create: `web/src/components/recap_card.rs`
+- Modify: `web/src/components/mod.rs`
+
+- [ ] **Step 1: Implement `RecapCard`**
+
+```rust
+use dioxus::prelude::*;
+use gloo_storage::{LocalStorage, Storage};
+use shared::DisplayGame;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct RecapCardProps { pub game: DisplayGame }
+
+#[component]
+pub fn RecapCard(props: RecapCardProps) -> Element {
+    let key = format!("recap_collapsed:{}", props.game.identifier);
+    let initial: bool = LocalStorage::get(&key).unwrap_or(false);
+    let mut collapsed = use_signal(|| initial);
+
+    let toggle = {
+        let key = key.clone();
+        move |_| {
+            let new = !collapsed();
+            collapsed.set(new);
+            let _ = LocalStorage::set(&key, &new);
+        }
+    };
+
+    let winner_line = match props.game.winner.as_deref() {
+        Some(w) if !w.is_empty() => format!("🏆 Winner: {w}"),
+        _ => "All tributes died".to_string(),
+    };
+
+    rsx! {
+        section { class: "rounded-lg border bg-amber-50 theme2:bg-slate-800 theme3:bg-purple-900 p-4 mb-4",
+            header { class: "flex items-center justify-between cursor-pointer", onclick: toggle,
+                h2 { class: "text-xl font-semibold", "Game Recap" }
+                span { if collapsed() { "▸" } else { "▾" } }
+            }
+            if !collapsed() {
+                div { class: "mt-3 space-y-1 text-sm",
+                    p { "{winner_line}" }
+                    p { "Days played: {props.game.day}" }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register in `mod.rs`**
+
+```rust
+mod recap_card;
+pub use recap_card::RecapCard;
+```
+
+- [ ] **Step 3: Build & commit**
+
+```bash
+cargo check --package web --target wasm32-unknown-unknown
+jj describe -m "feat(web): add RecapCard for finished games"
+```
+
+---
+
+## Task 6: FilterChips component
+
+**Files:**
+- Create: `web/src/components/filter_chips.rs`
+- Modify: `web/src/components/mod.rs`
+
+- [ ] **Step 1: Implement `FilterChips`**
+
+```rust
+use crate::components::timeline::{FilterMode, PeriodFilters};
+use dioxus::prelude::*;
+use shared::messages::MessageKind;
+use std::collections::HashSet;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct FilterChipsProps { pub game_identifier: String }
+
+const CATEGORIES: &[(MessageKind, &str)] = &[
+    (MessageKind::TributeKilled, "Deaths"),
+    (MessageKind::Combat,        "Combat"),
+    (MessageKind::AllianceFormed, "Alliances"),
+    (MessageKind::TributeMoved,   "Movement"),
+    (MessageKind::ItemFound,      "Items"),
+];
+
+#[component]
+pub fn FilterChips(props: FilterChipsProps) -> Element {
+    let mut filters: Signal<PeriodFilters> = use_context();
+    let game_id = props.game_identifier.clone();
+    {
+        let mut f = filters.write();
+        f.hydrate(&game_id);
+    }
+    let current = filters.read().filter_for(&game_id);
+
+    let chip_class = |active: bool| -> &'static str {
+        if active {
+            "rounded-full px-3 py-1 text-sm bg-amber-500 text-amber-50 theme2:bg-green-600 theme3:bg-purple-500"
+        } else {
+            "rounded-full px-3 py-1 text-sm border border-amber-400 text-amber-700 theme2:border-green-600 theme2:text-green-300 theme3:border-purple-400 theme3:text-purple-200"
+        }
+    };
+
+    let on_all = {
+        let game_id = game_id.clone();
+        move |_| filters.write().set_filter(&game_id, FilterMode::All)
+    };
+
+    rsx! {
+        div { class: "flex flex-wrap gap-2 mb-4",
+            button { class: chip_class(current.is_all()), onclick: on_all, "All" }
+            for (kind, label) in CATEGORIES.iter().copied() {
+                {
+                    let game_id = game_id.clone();
+                    let current = current.clone();
+                    let active = match &current {
+                        FilterMode::All => false,
+                        FilterMode::Subset(s) => s.contains(&kind),
+                    };
+                    rsx!{
+                        button {
+                            key: "{label}",
+                            class: chip_class(active),
+                            onclick: move |_| {
+                                let mut f = filters.write();
+                                let next = match f.filter_for(&game_id) {
+                                    FilterMode::All => {
+                                        let mut s = HashSet::new();
+                                        s.insert(kind);
+                                        FilterMode::Subset(s)
+                                    }
+                                    FilterMode::Subset(mut s) => {
+                                        if s.contains(&kind) { s.remove(&kind); } else { s.insert(kind); }
+                                        if s.is_empty() { FilterMode::All } else { FilterMode::Subset(s) }
+                                    }
+                                };
+                                f.set_filter(&game_id, next);
+                            },
+                            "{label}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register in `mod.rs`**
+
+```rust
+mod filter_chips;
+pub use filter_chips::FilterChips;
+```
+
+- [ ] **Step 3: Build & commit**
+
+```bash
+cargo check --package web --target wasm32-unknown-unknown
+jj describe -m "feat(web): add FilterChips with All/Subset toggle behavior"
+```
+
+---
+
+## Task 7: Timeline event card subcomponents
+
+**Files:**
+- Create: `web/src/components/timeline/cards/death_card.rs`
+- Create: `web/src/components/timeline/cards/combat_card.rs`
+- Create: `web/src/components/timeline/cards/alliance_card.rs`
+- Create: `web/src/components/timeline/cards/movement_card.rs`
+- Create: `web/src/components/timeline/cards/item_card.rs`
+- Create: `web/src/components/timeline/cards/state_card.rs`
+- Create: `web/src/components/timeline/cards/mod.rs`
+- Create: `web/src/components/timeline/event_card.rs`
+- Create: `web/src/components/timeline/timeline.rs`
+- Modify: `web/src/components/timeline/mod.rs`
+
+- [ ] **Step 1: Create `cards/mod.rs`**
+
+```rust
+pub mod death_card;
+pub mod combat_card;
+pub mod alliance_card;
+pub mod movement_card;
+pub mod item_card;
+pub mod state_card;
+```
+
+- [ ] **Step 2: Implement `cards/death_card.rs`**
+
+```rust
+use crate::routes::Routes;
+use dioxus::prelude::*;
+use shared::messages::TributeRef;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct DeathCardProps {
+    pub game_identifier: String,
+    pub victim: TributeRef,
+    pub killer: Option<TributeRef>,
+    pub cause: String,
+}
+
+#[component]
+pub fn DeathCard(props: DeathCardProps) -> Element {
+    let victim_route = Routes::TributeDetail {
+        game_identifier: props.game_identifier.clone(),
+        tribute_identifier: props.victim.identifier.clone(),
+    };
+    rsx! {
+        article { class: "rounded border-l-4 border-red-500 bg-red-50 theme2:bg-red-950 p-3",
+            header { class: "font-semibold",
+                "💀 "
+                Link { to: victim_route, class: "underline", "{props.victim.name}" }
+                " killed"
+            }
+            if let Some(k) = props.killer.as_ref() {
+                p { class: "text-sm",
+                    "by "
+                    Link {
+                        to: Routes::TributeDetail {
+                            game_identifier: props.game_identifier.clone(),
+                            tribute_identifier: k.identifier.clone(),
+                        },
+                        class: "underline",
+                        "{k.name}"
+                    }
+                }
+            }
+            p { class: "text-xs text-gray-600", "{props.cause}" }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Implement `cards/combat_card.rs`**
+
+```rust
+use crate::routes::Routes;
+use dioxus::prelude::*;
+use shared::messages::{CombatOutcome, TributeRef};
+
+#[derive(Props, PartialEq, Clone)]
+pub struct CombatCardProps {
+    pub game_identifier: String,
+    pub attacker: TributeRef,
+    pub defender: TributeRef,
+    pub outcome: CombatOutcome,
+    pub detail_lines: Vec<String>,
+}
+
+#[component]
+pub fn CombatCard(props: CombatCardProps) -> Element {
+    let mut expanded = use_signal(|| false);
+    let outcome_label = match props.outcome {
+        CombatOutcome::Killed       => "killed",
+        CombatOutcome::Wounded      => "wounded",
+        CombatOutcome::TargetFled   => "drove off",
+        CombatOutcome::AttackerFled => "fled from",
+        CombatOutcome::Stalemate    => "fought to a stalemate with",
+    };
+    let has_details = !props.detail_lines.is_empty();
+    rsx! {
+        article { class: "rounded border-l-4 border-orange-500 bg-orange-50 theme2:bg-orange-950 p-3",
+            header { class: "font-semibold",
+                "⚔️ "
+                Link {
+                    to: Routes::TributeDetail {
+                        game_identifier: props.game_identifier.clone(),
+                        tribute_identifier: props.attacker.identifier.clone(),
+                    },
+                    class: "underline",
+                    "{props.attacker.name}"
+                }
+                " {outcome_label} "
+                Link {
+                    to: Routes::TributeDetail {
+                        game_identifier: props.game_identifier.clone(),
+                        tribute_identifier: props.defender.identifier.clone(),
+                    },
+                    class: "underline",
+                    "{props.defender.name}"
+                }
+            }
+            if has_details {
+                button {
+                    class: "mt-1 text-xs underline",
+                    onclick: move |_| expanded.set(!expanded()),
+                    if expanded() { "hide details" } else { "show details" }
+                }
+                if expanded() {
+                    ul { class: "mt-2 list-disc pl-5 text-sm",
+                        for line in props.detail_lines.iter() { li { "{line}" } }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Implement `cards/alliance_card.rs`**
+
+```rust
+use dioxus::prelude::*;
+use shared::messages::{MessagePayload, TributeRef};
+
+#[derive(Props, PartialEq, Clone)]
+pub struct AllianceCardProps { pub payload: MessagePayload }
+
+#[component]
+pub fn AllianceCard(props: AllianceCardProps) -> Element {
+    let (icon, body) = match &props.payload {
+        MessagePayload::AllianceFormed { members } => ("🤝", names(members, "formed an alliance")),
+        MessagePayload::AllianceDisbanded { members, reason } =>
+            ("💔", format!("{} ({reason})", names(members, "disbanded"))),
+        MessagePayload::BetrayalTriggered { betrayer, victims } =>
+            ("🗡️", format!("{} betrayed {}", betrayer.name, joined(victims))),
+        MessagePayload::TrustShockBreak { tribute, source } =>
+            ("⚡", format!("{} broke trust with {}", tribute.name, source.name)),
+        MessagePayload::AllianceJoined { joiner, members } =>
+            ("➕", format!("{} joined {}", joiner.name, joined(members))),
+        _ => ("🤝", "alliance event".to_string()),
+    };
+    rsx! {
+        article { class: "rounded border-l-4 border-emerald-500 bg-emerald-50 theme2:bg-emerald-950 p-3",
+            header { class: "font-semibold", "{icon} {body}" }
+        }
+    }
+}
+
+fn names(members: &[TributeRef], verb: &str) -> String {
+    format!("{} {verb}", joined(members))
+}
+
+fn joined(members: &[TributeRef]) -> String {
+    members.iter().map(|m| m.name.as_str()).collect::<Vec<_>>().join(", ")
+}
+```
+
+- [ ] **Step 5: Implement `cards/movement_card.rs`**
+
+```rust
+use dioxus::prelude::*;
+use shared::messages::MessagePayload;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct MovementCardProps { pub payload: MessagePayload }
+
+#[component]
+pub fn MovementCard(props: MovementCardProps) -> Element {
+    let body = match &props.payload {
+        MessagePayload::TributeMoved { tribute, from, to } =>
+            format!("{} moved from {} to {}", tribute.name, from.name, to.name),
+        MessagePayload::TributeFled { tribute, area } =>
+            format!("{} fled from {}", tribute.name, area.name),
+        MessagePayload::AreaClosed { area } =>
+            format!("Area closed: {}", area.name),
+        MessagePayload::AreaReopened { area } =>
+            format!("Area reopened: {}", area.name),
+        _ => "movement event".to_string(),
+    };
+    rsx! {
+        article { class: "rounded border-l-4 border-sky-500 bg-sky-50 theme2:bg-sky-950 p-3",
+            header { class: "font-semibold", "🧭 {body}" }
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Implement `cards/item_card.rs`**
+
+```rust
+use dioxus::prelude::*;
+use shared::messages::MessagePayload;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct ItemCardProps { pub payload: MessagePayload }
+
+#[component]
+pub fn ItemCard(props: ItemCardProps) -> Element {
+    let body = match &props.payload {
+        MessagePayload::ItemFound { tribute, item } =>
+            format!("{} found {}", tribute.name, item.name),
+        MessagePayload::ItemUsed { tribute, item } =>
+            format!("{} used {}", tribute.name, item.name),
+        MessagePayload::ItemBroken { tribute, item } =>
+            format!("{}'s {} broke", tribute.name, item.name),
+        MessagePayload::ItemDropped { tribute, item } =>
+            format!("{} dropped {}", tribute.name, item.name),
+        _ => "item event".to_string(),
+    };
+    rsx! {
+        article { class: "rounded border-l-4 border-yellow-500 bg-yellow-50 theme2:bg-yellow-950 p-3",
+            header { class: "font-semibold", "🎒 {body}" }
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Implement `cards/state_card.rs`**
+
+```rust
+use dioxus::prelude::*;
+use shared::messages::MessagePayload;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct StateCardProps { pub payload: MessagePayload }
+
+#[component]
+pub fn StateCard(props: StateCardProps) -> Element {
+    let body = match &props.payload {
+        MessagePayload::TributeWounded { tribute, source } =>
+            format!("{} wounded by {}", tribute.name, source),
+        MessagePayload::TributeRested { tribute } =>
+            format!("{} rested", tribute.name),
+        MessagePayload::TributeStarved { tribute } =>
+            format!("{} is starving", tribute.name),
+        MessagePayload::TributeDehydrated { tribute } =>
+            format!("{} is dehydrated", tribute.name),
+        MessagePayload::SanityBreak { tribute } =>
+            format!("{} suffered a sanity break", tribute.name),
+        _ => "state event".to_string(),
+    };
+    rsx! {
+        article { class: "rounded border-l-4 border-gray-400 bg-gray-50 theme2:bg-gray-900 p-2 text-sm",
+            "🌫️ {body}"
+        }
+    }
+}
+```
+
+- [ ] **Step 8: Implement `event_card.rs` dispatcher**
+
+```rust
+use crate::components::timeline::cards::{
+    alliance_card::AllianceCard, combat_card::CombatCard, death_card::DeathCard,
+    item_card::ItemCard, movement_card::MovementCard, state_card::StateCard,
+};
+use dioxus::prelude::*;
+use shared::messages::{GameMessage, MessageKind, MessagePayload};
+
+#[derive(Props, PartialEq, Clone)]
+pub struct EventCardProps {
+    pub game_identifier: String,
+    pub message: GameMessage,
+}
+
+#[component]
+pub fn EventCard(props: EventCardProps) -> Element {
+    let kind = props.message.payload.kind();
+    let payload = props.message.payload.clone();
+    rsx! {
+        match kind {
+            MessageKind::TributeKilled => {
+                if let MessagePayload::TributeKilled { victim, killer, cause } = payload {
+                    rsx!{ DeathCard {
+                        game_identifier: props.game_identifier.clone(),
+                        victim, killer, cause,
+                    } }
+                } else { rsx!{} }
+            }
+            MessageKind::Combat => {
+                if let MessagePayload::Combat { attacker, defender, outcome, detail_lines } = payload {
+                    rsx!{ CombatCard {
+                        game_identifier: props.game_identifier.clone(),
+                        attacker, defender, outcome, detail_lines,
+                    } }
+                } else { rsx!{} }
+            }
+            MessageKind::AllianceFormed
+            | MessageKind::AllianceDisbanded
+            | MessageKind::AllianceJoined
+            | MessageKind::BetrayalTriggered
+            | MessageKind::TrustShockBreak => rsx!{ AllianceCard { payload } },
+            MessageKind::TributeMoved
+            | MessageKind::TributeFled
+            | MessageKind::AreaClosed
+            | MessageKind::AreaReopened => rsx!{ MovementCard { payload } },
+            MessageKind::ItemFound
+            | MessageKind::ItemUsed
+            | MessageKind::ItemBroken
+            | MessageKind::ItemDropped => rsx!{ ItemCard { payload } },
+            MessageKind::State
+            | MessageKind::TributeWounded
+            | MessageKind::TributeRested
+            | MessageKind::TributeStarved
+            | MessageKind::TributeDehydrated
+            | MessageKind::SanityBreak => rsx!{ StateCard { payload } },
+        }
+    }
+}
+```
+
+> **Note:** The exact `MessageKind` variants must match what PR1's `MessagePayload::kind()` returns. If PR1 chose different variant names, adjust the match arms here.
+
+- [ ] **Step 9: Implement `timeline.rs`**
+
+```rust
+use crate::components::timeline::event_card::EventCard;
+use crate::components::timeline::FilterMode;
+use dioxus::prelude::*;
+use shared::messages::GameMessage;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct TimelineProps {
+    pub game_identifier: String,
+    pub messages: Vec<GameMessage>,
+    pub filter: FilterMode,
+}
+
+#[component]
+pub fn Timeline(props: TimelineProps) -> Element {
+    let mut sorted: Vec<GameMessage> = props.messages
+        .into_iter()
+        .filter(|m| props.filter.matches(m.payload.kind()))
+        .collect();
+    sorted.sort_by_key(|m| (m.tick, m.emit_index));
+    rsx! {
+        if sorted.is_empty() {
+            div { class: "rounded border border-dashed p-6 text-center text-sm",
+                "Nothing happened this period."
+            }
+        } else {
+            div { class: "space-y-2",
+                for (i, msg) in sorted.into_iter().enumerate() {
+                    EventCard {
+                        key: "{i}",
+                        game_identifier: props.game_identifier.clone(),
+                        message: msg,
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 10: Update `web/src/components/timeline/mod.rs`**
+
+```rust
+pub mod cards;
+pub mod event_card;
+pub mod filters;
+pub mod timeline;
+
+pub use event_card::EventCard;
+pub use filters::{FilterMode, PeriodFilters};
+pub use timeline::Timeline;
+```
+
+- [ ] **Step 11: Build**
+
+Run: `cargo check --package web --target wasm32-unknown-unknown`.
+Expected: compiles. Variants in match arms must match PR1's actual enum exactly — fix any mismatches.
+
+- [ ] **Step 12: Commit**
+
+```bash
+jj describe -m "feat(web): add timeline event cards (death/combat/alliance/movement/item/state)"
+```
+
+---
+
+## Task 8: GamePeriodPage component + route
+
+**Files:**
+- Create: `web/src/components/game_period_page.rs`
+- Modify: `web/src/components/mod.rs`
+- Modify: `web/src/routes.rs`
+
+- [ ] **Step 1: Implement `GamePeriodPage` in `web/src/components/game_period_page.rs`**
+
+```rust
+use crate::cache::{QueryError, QueryKey, QueryValue};
+use crate::components::filter_chips::FilterChips;
+use crate::components::timeline::{PeriodFilters, Timeline};
+use crate::env::API_HOST;
+use dioxus::prelude::*;
+use dioxus_query::prelude::*;
+use reqwest::StatusCode;
+use shared::messages::{GameMessage, Phase, TimelineSummary};
+
+async fn fetch_day_log(keys: Vec<QueryKey>) -> QueryResult<QueryValue, QueryError> {
+    let Some(QueryKey::GameDayLog(id, day)) = keys.first() else {
+        return Err(QueryError::Unknown).into();
+    };
+    let url = format!("{API_HOST}/api/games/{id}/log/{day}");
+    match reqwest::get(&url).await {
+        Ok(resp) if resp.status() == StatusCode::OK => {
+            match resp.json::<Vec<GameMessage>>().await {
+                Ok(v) => Ok(QueryValue::Logs(v)).into(),
+                Err(_) => Err(QueryError::BadJson).into(),
+            }
+        }
+        Ok(_) => Err(QueryError::GameNotFound(id.clone())).into(),
+        Err(_) => Err(QueryError::ServerNotFound).into(),
+    }
+}
+
+#[component]
+pub fn GamePeriodPage(identifier: String, day: u32, phase: Phase) -> Element {
+    let filters: Signal<PeriodFilters> = use_context();
+    let filter = filters.read().filter_for(&identifier);
+
+    // validate (day, phase) against TimelineSummary
+    let summary_q = use_get_query(
+        [QueryKey::TimelineSummary(identifier.clone())],
+        crate::hooks::use_timeline_summary::fetch_timeline_summary,
+    );
+
+    let valid = match summary_q.result().value() {
+        QueryResult::Ok(QueryValue::TimelineSummary(s)) => {
+            s.periods.iter().any(|p| p.day == day && p.phase == phase)
+        }
+        QueryResult::Err(_) => false,
+        _ => true, // assume valid while loading
+    };
+
+    if !valid {
+        return rsx! {
+            h1 { "Period not found" }
+            p { "Day {day} ({phase:?}) doesn't exist for this game." }
+        };
+    }
+
+    let log_q = use_get_query([QueryKey::GameDayLog(identifier.clone(), day)], fetch_day_log);
+
+    rsx! {
+        div { class: "space-y-4",
+            h1 { class: "text-2xl font-semibold", "Day {day} — {phase:?}" }
+            FilterChips { game_identifier: identifier.clone() }
+            match log_q.result().value() {
+                QueryResult::Ok(QueryValue::Logs(msgs)) => {
+                    let filtered: Vec<GameMessage> = msgs.iter()
+                        .filter(|m| m.phase == phase)
+                        .cloned()
+                        .collect();
+                    rsx!{ Timeline {
+                        game_identifier: identifier.clone(),
+                        messages: filtered,
+                        filter,
+                    } }
+                }
+                QueryResult::Err(_) => rsx!{ p { "Failed to load events." } },
+                _ => rsx!{ div { class: "animate-pulse h-32 rounded bg-gray-200" } },
+            }
+        }
+    }
+}
+```
+
+> **Note:** `fetch_timeline_summary` must be `pub` in `web/src/hooks/use_timeline_summary.rs` for re-use here. Update Task 2 Step 2 if needed.
+
+- [ ] **Step 2: Register in `mod.rs`**
+
+```rust
+mod game_period_page;
+pub use game_period_page::GamePeriodPage;
+```
+
+- [ ] **Step 3: Add route in `web/src/routes.rs`**
+
+Inside the `Games` layout block (right after `GamePage`), add:
+
+```rust
+                #[route("/:identifier/day/:day/:phase")]
+                GamePeriodPage { identifier: String, day: u32, phase: shared::messages::Phase },
+```
+
+Update the imports at the top of `routes.rs`:
+
+```rust
+use crate::components::{
+    Accounts, AccountsPage, Credits, GamePage, GamePeriodPage, Games, GamesList, Home,
+    IconsPage, Navbar, TributeDetail,
+};
+```
+
+> **Note:** `shared::messages::Phase` must implement `FromStr`, `Display`, `Clone`, and `PartialEq` for the dioxus-router macro. PR1 already requires this. If routing complains, the path is the issue — verify with `dx serve` and the dioxus-router error.
+
+- [ ] **Step 4: Update `PeriodCard` in Task 3 to use the real route**
+
+In `web/src/components/period_card.rs`, change `Routes::Home {}` (placeholder) back to:
+
+```rust
+let route = Routes::GamePeriodPage {
+    identifier: props.game_identifier.clone(),
+    day: props.day,
+    phase: props.phase,
+};
+```
+
+(If you didn't use a placeholder, this step is a no-op verification.)
+
+- [ ] **Step 5: Build**
+
+Run: `cargo check --package web --target wasm32-unknown-unknown`.
+Expected: compiles end-to-end.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(web): add GamePeriodPage route and component"
+```
+
+---
+
+## Task 9: Replace stub in game_detail.rs
+
+**Files:**
+- Modify: `web/src/components/game_detail.rs` — remove `GameLogStub` usage; insert `RecapCard` (when finished) + `PeriodGrid`; wire mutation handlers
+- Delete: `web/src/components/game_log_stub.rs`
+- Modify: `web/src/components/mod.rs` — drop `mod game_log_stub;`
+
+- [ ] **Step 1: In `game_detail.rs`, replace the stub render block**
+
+Find the place where `GameLogStub { ... }` (or whatever PR1 named it) is rendered. Replace with:
+
+```rust
+if game.status == shared::GameStatus::Finished {
+    rsx!{ RecapCard { game: game.clone() } }
+}
+PeriodGrid { game_identifier: game.identifier.clone() }
+```
+
+Add imports:
+
+```rust
+use crate::components::{PeriodGrid, RecapCard};
+```
+
+- [ ] **Step 2: Wire mutation handlers**
+
+Find the `next_step` mutation success branch. Add a side effect to bump generation on `MutationValue::GameAdvanced`:
+
+```rust
+MutationValue::GameAdvanced(game_identifier) => {
+    let mut filters: Signal<crate::components::timeline::PeriodFilters> = use_context();
+    filters.write().bump(&game_identifier);
+    // (existing query-invalidation code)
+    ...
+}
+```
+
+Find the game-delete mutation handler (or add one if absent). On `MutationValue::GameDeleted(id, _)`:
+
+```rust
+MutationValue::GameDeleted(id, _) => {
+    let _ = gloo_storage::LocalStorage::delete(&format!("recap_collapsed:{id}"));
+    let _ = gloo_storage::LocalStorage::delete(&format!("period_filters:{id}"));
+    // (existing navigate-away / list-refresh code)
+}
+```
+
+> **Note:** `use_context::<Signal<PeriodFilters>>()` must be called at component scope, not inside the mutation closure. Move the `let mut filters = use_context::<…>();` to the top of the `GamePage` function and capture it by `move`.
+
+- [ ] **Step 3: Delete `game_log_stub.rs`**
+
+```bash
+rm -f web/src/components/game_log_stub.rs
+```
+
+Remove `mod game_log_stub;` from `web/src/components/mod.rs`.
+
+- [ ] **Step 4: Build**
+
+Run: `cargo check --package web --target wasm32-unknown-unknown`.
+Expected: compiles. Fix any leftover references to the stub or `MessageKind` enum mismatches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(web): replace timeline stub with RecapCard + PeriodGrid"
+```
+
+---
+
+## Task 10: Quality gates and smoke test
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Format**
+
+```bash
+just fmt
+```
+
+- [ ] **Step 2: Quality checks**
+
+```bash
+just quality
+```
+
+Fix anything that isn't clean.
+
+- [ ] **Step 3: Build CSS**
+
+```bash
+just build-css
+```
+
+- [ ] **Step 4: Smoke test with `just dev`**
+
+Start the stack:
+
+```bash
+just dev
+```
+
+Walk through the spec §6 verification list:
+1. Open a game's page → period card grid appears; current period has highlight ring.
+2. Click a card → navigates to `/games/:id/day/N/day` (or night).
+3. On the period page: chip row shows `[All] [Deaths] [Combat] [Alliances] [Movement] [Items]`. State events still appear with `All`.
+4. Click `[Combat]` → only Combat (and ambient State) cards remain.
+5. Click `[Combat]` again → snaps back to `All`, `All` chip visually active.
+6. Refresh the page → filter persists for that game.
+7. Click a Combat card with `detail_lines` → expands. Combat with empty `detail_lines` shows no expand button.
+8. Click a tribute name in any card → navigates to tribute detail.
+9. Finish a game (advance through to end). Recap card appears. Collapse it. Reload — stays collapsed.
+10. Delete the game → navigate to a fresh page → both `recap_collapsed:{id}` and `period_filters:{id}` are gone from `LocalStorage` (verify in DevTools).
+11. Browser back/forward across hub  period works.
+12. Click "Begin / Next Step" → both `/timeline-summary` and `/log/N` re-fetch (generation bump).
+
+- [ ] **Step 5: Commit any final fixes**
+
+```bash
+jj describe -m "chore(web): cleanup after smoke test"
+```
+
+---
+
+## Task 11: Open the PR
+
+**Files:** none.
+
+- [ ] **Step 1: Sync with main**
+
+```bash
+jj git fetch
+jj rebase -d main@origin
+```
+
+- [ ] **Step 2: Push beads data**
+
+```bash
+bd dolt push
+```
+
+- [ ] **Step 3: Create the bookmark**
+
+```bash
+jj bookmark create feat-timeline-pr2-frontend -r @-
+```
+
+- [ ] **Step 4: Push the bookmark**
+
+```bash
+jj git push --bookmark feat-timeline-pr2-frontend
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --base main --head feat-timeline-pr2-frontend \
+  --title "feat(web): structured day/phase timeline UI" \
+  --body "$(cat <<'EOF'
+## Summary
+Replaces the unstyled day-log on `GamePage` with a structured timeline UI:
+- Hub of period cards (Day/Night per simulated day) with deaths + event counts
+- Per-period view at `/games/:id/day/:day/:phase` with filter chips and typed event cards
+- Finished-game `RecapCard`, collapsible, persisted per-game
+
+Builds on PR1's typed `MessagePayload` schema and `/api/games/:id/timeline-summary` endpoint.
+
+## Changes
+- New components: `PeriodGrid`, `PeriodGridEmpty`, `PeriodCard`, `GamePeriodPage`, `RecapCard`, `FilterChips`, `Timeline`, `EventCard`, and 6 typed sub-cards.
+- New context: `PeriodFilters` provided in `Navbar`, persisted to `gloo-storage`.
+- Mutation handlers in `game_detail.rs` bump per-game generation on advance, clear localStorage on delete.
+- Deleted: `game_log_stub.rs` (PR1's placeholder).
+
+## Verification
+- `just fmt && just quality` clean.
+- `just dev` smoke test passed (see plan Task 10 Step 4 list).
+
+## Follow-ups
+See spec §7. Beads issues filed: combat redesign, mobile polish, announcer cards, per-tribute filter, orphaned summarize endpoint, hover-preview, item/area routes, URL filter params, sponsor gift confirmation, winner→TributeRef upgrade, websocket cache invalidation.
+EOF
+)"
+```
+
+- [ ] **Step 6: Verify**
+
+The PR URL is printed. Open it in a browser, confirm CI starts.
+
+- [ ] **Step 7: Hand off**
+
+Report the PR URL to the user.
+
+---
+
+## Self-review notes
+
+**Spec coverage check:**
+- §5 component tree → Tasks 3, 4, 5, 6, 7, 8 cover every file in the spec's tree.
+- §5 state (`PeriodFilters` at Navbar layer, `gloo-storage` per game) → Task 1.
+- §5 mutation handlers (generation bump, gloo cleanup) → Task 9 Step 2.
+- §6 testing — frontend has no test infrastructure; smoke test in Task 10 substitutes per spec.
+- §6 rollout PR2 description matches Task 9 + 11.
+- §7 follow-ups → Task 11 Step 5 references all of them in the PR body.
+
+**Placeholder scan:** No TBDs. Two "Note:" callouts flag dependencies (route variants matching PR1's `MessageKind`, `fetch_timeline_summary` visibility) — these are explicit verify-and-adjust points, not placeholders.
+
+**Type consistency:** `PeriodFilters`, `FilterMode`, `MessageKind`, `MessagePayload`, `Phase`, `TributeRef`, `CombatOutcome`, `TimelineSummary`, `PeriodSummary` are all types defined by PR1 in `shared::messages`. `QueryKey::GameDayLog(String, u32)` and `QueryKey::TimelineSummary(String)` consistent across Tasks 2 and 8.

--- a/docs/superpowers/specs/2026-04-26-game-timeline-redesign.md
+++ b/docs/superpowers/specs/2026-04-26-game-timeline-redesign.md
@@ -1,0 +1,534 @@
+# Game Timeline Redesign
+
+**Status:** Draft (revised post-review)
+**Date:** 2026-04-26
+**Owner:** kennethlove
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Replace the long, unstyled `<ul>` text list (`game_day_log.rs`) with a structured, navigable timeline.
+- Give each day/phase a dedicated URL and view (`/games/:identifier/day/:day/:phase`).
+- Turn `GamePage` (`/games/:identifier`) into a hub: a card grid where each card is one period (Day N + Day/Night).
+- Restructure `GameMessage` so events carry typed, structured payloads — enabling per-kind styling, filtering, and (later) richer interactions.
+- Guarantee causally correct ordering of events within a period (no "Peeta moves" after "Peeta dies").
+- Add a finished-game recap card (winner, day count, duration) above the grid when the game is over.
+
+### Non-Goals (Out of Scope)
+
+The following are explicitly deferred. Each becomes a follow-up beads issue at close-out:
+
+1. **Combat mechanics redesign.** Only refactor *how* combat events are emitted, not how combat resolves.
+2. **Mobile polish.** Desktop-first; basic Tailwind responsive only. No swipe nav, touch-target tuning, or mobile-specific layouts.
+3. **Inline announcer commentary cards.** `game_day_summary.rs` is deleted; no replacement in this redesign. Future direction is `MessagePayload::AnnouncerCommentary { speaker, text }` interleaved into the timeline.
+4. **Per-tribute timeline filter.** Filter chips in this design are by event *category* only.
+5. **Sponsor mechanics UI**, real-time WebSocket push, replay/scrubber controls, search, export/share — all out.
+6. **Frontend tests.** No web-crate test infra exists; staying out of scope.
+
+## 2. Schema (location: `shared/src/messages.rs`)
+
+> **Crate move (HIGH-1):** `GameMessage`, `MessagePayload`, `MessageKind`, `Phase`, `CombatEngagement`, `CombatOutcome`, and the supporting `*Ref` structs move from `game/src/messages.rs` to `shared/src/messages.rs`. The `game/` crate already depends on `shared/` (per the existing `GameEvent` precedent). `TaggedEvent` stays in `game/` as an internal collection type. The narrative helper functions (`movement_narrative`, `hiding_spot_narrative`, `stamina_narrative`, `terrain_name`) stay in `game/`.
+
+### Changes to `GameMessage`
+
+```rust
+pub struct GameMessage {
+    pub identifier: String,
+    pub source: MessageSource,
+    pub game_day: u32,
+    pub phase: Phase,                 // NEW
+    pub tick: u32,                    // NEW
+    pub emit_index: u32,              // NEW (HIGH-4: persisted, not implicit)
+    pub subject: String,
+    #[serde(with = "chrono::serde::ts_nanoseconds")]
+    pub timestamp: DateTime<Utc>,
+    pub content: String,              // KEEP — human-readable line
+    pub payload: MessagePayload,      // REPLACES `kind: Option<MessageKind>`
+}
+```
+
+> **No `#[serde(default)]` on `payload`** (see CRITICAL-1). Missing/unknown payload tags hard-error during deserialization. This is intentional: dev DB will be wiped (see §6).
+
+### Reference structs (CRITICAL-2)
+
+Tribute / area / item references in payloads are typed structs, not bare strings, so the frontend can build links from `identifier`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TributeRef { pub identifier: String, pub name: String }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AreaRef { pub identifier: String, pub name: String }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ItemRef { pub identifier: String, pub name: String }
+```
+
+These are denormalized: `name` is captured at emit time, so renames after the fact don't retroactively rewrite history. `identifier` is the routing key.
+
+### `Phase`
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Phase { Day, Night }
+```
+
+`FromStr` and `Display` impls for URL parsing/rendering. `FromStr` accepts `"day"` and `"night"` only (rejects mixed case, whitespace, etc.). No `Default` impl — phase must always be supplied at construction.
+
+### Tick assignment (HIGH-3: explicit table)
+
+The simulator owns a `TickCounter` on `Game` (or per-cycle context). `next_tick()` is called exactly once per **atomic narrative unit**:
+
+| Source | When `next_tick()` fires |
+|---|---|
+| Tribute action dispatched | Once, before action runs. All `TaggedEvent`s emitted by that action — including knock-on deaths in `lifecycle.rs` triggered by `attacks()` — share that tick. |
+| Area event (closure, hazard) | Once per area-event scheduling pass. All events scheduled in one pass share that tick. |
+| Sponsor gift | Once per gift dispatch. |
+| Phase-boundary side effects (e.g., area closures at night-start) emitted *as messages* | One tick at the very start of the new phase (`tick = 0`), shared across all boundary messages. |
+| `GameEvent::DayStarted` / `NightStarted` | These stay in `GameEvent`, are NOT `GameMessage`s, and have no tick. |
+
+`TickCounter` resets to `0` at every phase boundary. First action in a phase gets `tick = 1`. Phase-boundary side-effect messages get `tick = 0`.
+
+> **Note:** No phase-boundary side-effect emit sites exist today. The `tick = 0` slot is reserved for future area-closure-at-phase-start work and is documented here so the sort key is unambiguous when that work lands.
+
+Combined sort key for in-period rendering:
+
+```
+(game_day, phase, tick, emit_index)
+```
+
+`emit_index` is the position of the message within the per-period emit sequence, persisted as a real field on `GameMessage` (HIGH-4). Filling it: the drain site in `api/src/games.rs` increments a per-period counter as it builds `GameMessage`s from `Vec<TaggedEvent>` and assigns `emit_index` accordingly. No `ORDER BY id ASC` reliance.
+
+### `MessagePayload`
+
+Typed enum, ~22 variants in 6 categories. **No `Other` variant; no `#[serde(other)]`** (CRITICAL-1). Unknown tags hard-error.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum MessagePayload {
+    // Lifecycle
+    TributeKilled  { victim: TributeRef, killer: Option<TributeRef>, cause: String },
+    TributeWounded { victim: TributeRef, attacker: Option<TributeRef>, hp_lost: u32 },
+
+    // Combat
+    Combat(CombatEngagement),
+
+    // Alliance
+    AllianceFormed     { members: Vec<TributeRef> },
+    AllianceProposed   { proposer: TributeRef, target: TributeRef },
+    AllianceDissolved  { members: Vec<TributeRef>, reason: String },
+    BetrayalTriggered  { betrayer: TributeRef, victim: TributeRef },
+    TrustShockBreak    { tribute: TributeRef, partner: TributeRef },
+
+    // Movement / Area
+    TributeMoved   { tribute: TributeRef, from: AreaRef, to: AreaRef },
+    TributeHidden  { tribute: TributeRef, area: AreaRef },
+    AreaClosed     { area: AreaRef },
+    AreaEvent      { area: AreaRef, kind: AreaEventKind, description: String },
+
+    // Items
+    ItemFound    { tribute: TributeRef, item: ItemRef, area: AreaRef },
+    ItemUsed     { tribute: TributeRef, item: ItemRef },
+    ItemDropped  { tribute: TributeRef, item: ItemRef, area: AreaRef },
+    SponsorGift  { recipient: TributeRef, item: ItemRef, donor: String },
+
+    // Tribute state
+    TributeRested      { tribute: TributeRef, hp_restored: u32 },
+    TributeStarved     { tribute: TributeRef, hp_lost: u32 },
+    TributeDehydrated  { tribute: TributeRef, hp_lost: u32 },
+    SanityBreak        { tribute: TributeRef },
+}
+```
+
+`AreaEvent.kind` is typed (LOW-4):
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AreaEventKind {
+    Hazard, Storm, Mutts, Earthquake, Flood, Fire, Other,
+}
+```
+
+(`Other` here is OK — this is a small enum of known categories, not a deserialize-fallback.)
+
+`SponsorGift` (LOW-3): there is currently no emit site for sponsor gifts. The variant is included for forward compatibility but is **not emitted in PR1**. If we decide it adds friction, drop it; otherwise keep dormant.
+
+### `MessageSource`
+
+`MessageSource` keeps its existing shape (`Game(String)`, `Area(String)`, `Tribute(String)` where the `String` is the source's identifier). Several payloads denormalize tribute identity from `source` into payload fields (e.g., `TributeMoved { tribute, .. }` while `source = MessageSource::Tribute(tribute_id)`). This is intentional (LOW-5): payloads are self-contained for rendering without joining back to `source`. Card components prefer payload fields.
+
+### `CombatEngagement`
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CombatEngagement {
+    pub attacker: TributeRef,
+    pub target: TributeRef,
+    pub outcome: CombatOutcome,
+    pub detail_lines: Vec<String>,    // per-swing prose, shown when card expanded
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CombatOutcome {
+    Killed, Wounded, TargetFled, AttackerFled, Stalemate,
+}
+```
+
+`detail_lines` may be empty (e.g., `TargetFled` before any swing). UI handles this (see §5).
+
+One `attacks()` call → one `MessagePayload::Combat(...)` message. Death (if any) is still emitted separately as `TributeKilled` from the lifecycle code, sharing the attacker's tick (per the table above). Result: a killing combat shows two cards (combat detail card + death announcement card) at the same tick. Intentional (MEDIUM-2). `event_count` in `PeriodSummary` counts both; `deaths` counts only `TributeKilled`.
+
+### `MessageKind` (for filter chips)
+
+Small enum, derived from payload via `.kind()`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum MessageKind { Death, Combat, Alliance, Movement, Item, State }
+
+impl MessagePayload {
+    pub fn kind(&self) -> MessageKind {
+        use MessagePayload::*;
+        match self {
+            TributeKilled { .. } => MessageKind::Death,
+            Combat(_) => MessageKind::Combat,
+            AllianceFormed { .. } | AllianceProposed { .. } | AllianceDissolved { .. }
+                | BetrayalTriggered { .. } | TrustShockBreak { .. } => MessageKind::Alliance,
+            TributeMoved { .. } | TributeHidden { .. }
+                | AreaClosed { .. } | AreaEvent { .. } => MessageKind::Movement,
+            ItemFound { .. } | ItemUsed { .. }
+                | ItemDropped { .. } | SponsorGift { .. } => MessageKind::Item,
+            TributeWounded { .. } | TributeRested { .. } | TributeStarved { .. }
+                | TributeDehydrated { .. } | SanityBreak { .. } => MessageKind::State,
+        }
+    }
+}
+```
+
+No `Other` variant (since `MessagePayload` has no `Other`). Single source of truth: payload. No separate `kind` field on `GameMessage`.
+
+### Phase markers
+
+`GameEvent::DayStarted { day }` and `GameEvent::NightStarted { day }` stay in `GameEvent`, not `MessagePayload`. They are emitted at phase boundaries and used for debugging / future use, but do not appear as cards in the timeline.
+
+### Constructor
+
+```rust
+impl GameMessage {
+    pub fn new(
+        source: MessageSource,
+        game_day: u32,
+        phase: Phase,
+        tick: u32,
+        emit_index: u32,
+        subject: String,
+        content: String,
+        payload: MessagePayload,
+    ) -> Self { /* ... */ }
+}
+```
+
+`with_kind` is removed. There is no migration path: dev DB is wiped (§6). Unknown payload tags from any persisted legacy data fail to deserialize, surfacing the wipe-required precondition immediately rather than silently producing `Other`.
+
+## 3. Combat Refactor
+
+### Problem
+
+Today, `Tribute::attacks()` in `game/src/tributes/combat.rs` pushes 3-6 `String` lines into `events: &mut Vec<String>`. The drain site at `api/src/games.rs` ~L957 turns each line into a `GameMessage` with `kind=None`. We can't tag combat messages at the drain site because the drain only sees strings.
+
+### Approach: tag at emit
+
+Introduce `TaggedEvent` in `game/src/messages.rs` (or a new `game/src/events.rs`):
+
+```rust
+pub struct TaggedEvent {
+    pub content: String,
+    pub payload: MessagePayload,
+}
+```
+
+Thread `&mut Vec<TaggedEvent>` (replacing `&mut Vec<String>`) through these known emit sites (LOW-2):
+
+- `game/src/tributes/combat.rs::attacks` and its per-swing helpers
+- `game/src/tributes/mod.rs::do_day_action` / `do_night_action`
+- `game/src/tributes/lifecycle.rs::take_damage` / death emission helpers
+- `game/src/tributes/movement.rs::move_to_area` and movement helpers
+- `game/src/tributes/state.rs` (rest, starve, dehydrate, sanity-break helpers)
+- `game/src/areas/*` area-event / area-closure emit sites
+- `game/src/alliances/*` alliance-lifecycle emit sites
+
+Any further sites the compiler flags during the change get the same treatment.
+
+### `attacks()` after refactor
+
+During the per-swing loop, accumulate prose into a local `detail_lines: Vec<String>` and track outcome. At the end, push **one** `TaggedEvent`:
+
+```rust
+let engagement = CombatEngagement {
+    attacker: TributeRef { identifier: self.identifier.clone(), name: self.name.clone() },
+    target:   TributeRef { identifier: target.identifier.clone(), name: target.name.clone() },
+    outcome,
+    detail_lines,
+};
+events.push(TaggedEvent {
+    content: summary_line(&engagement),
+    payload: MessagePayload::Combat(engagement),
+});
+```
+
+Death stays a separate `TaggedEvent` emitted from `lifecycle.rs` with `MessagePayload::TributeKilled { victim, killer, cause }`. Both events share the attacker's tick.
+
+### Drain site
+
+`api/src/games.rs` ~L957 takes `Vec<TaggedEvent>` and builds `GameMessage`s, attaching `(game_day, phase, tick, emit_index)` from the cycle context. `emit_index` increments per message within the period. `log_output_kind` is removed; `log_output` is removed entirely (no more untagged emissions).
+
+### Test impact
+
+Existing combat rstest tests in the game crate need updating to assert against payload variants — typically `assert!(matches!(msg.payload, MessagePayload::Combat(CombatEngagement { outcome: CombatOutcome::Killed, .. })))` and length checks on `detail_lines`.
+
+## 4. Routes & API
+
+### Routes (`web/src/routes.rs`)
+
+```rust
+#[layout(Navbar)]
+    #[route("/")]                                                       Home {},
+    #[route("/games/")]                                                 GamesList {},
+    #[route("/games/:identifier")]                                      GamePage { identifier: String },
+    #[route("/games/:identifier/day/:day/:phase")]                      GamePeriodPage { identifier: String, day: u32, phase: Phase },  // NEW — typed Phase param (MEDIUM-4)
+    #[route("/games/:game_identifier/tributes/:tribute_identifier")]    TributeDetail { /* ... */ },
+    /* ... unchanged ... */
+#[end_layout]
+```
+
+`phase: Phase` uses Dioxus router's `FromStr`-based typed param: invalid values fail to match the route and the router falls through to `PageNotFound`. No string-parsing in the component.
+
+### API endpoints
+
+- **`GET /api/games/:id/log/:day`** — KEEP & EXTEND. Still returns `Vec<GameMessage>` for the entire day, now with `phase`, `tick`, `emit_index`, and `payload` fields populated. The period view filters client-side by phase.
+
+- **`GET /api/games/:id/timeline-summary`** — NEW. Returns:
+
+  ```rust
+  Vec<PeriodSummary {
+      day: u32,
+      phase: Phase,
+      deaths: u32,
+      event_count: u32,
+      is_current: bool,    // MEDIUM-6: derived from game.current_day + current_phase
+  }>
+  ```
+
+  Implemented in `shared/src/messages.rs` (MEDIUM-1) as a pure function:
+
+  ```rust
+  pub fn summarize_periods(messages: &[GameMessage], current: (u32, Phase)) -> Vec<PeriodSummary> { ... }
+  ```
+
+  The API handler loads all messages for the game (already done elsewhere), calls `summarize_periods`, and serializes. No SurrealDB `GROUP BY` — Rust aggregation keeps the wire format decoupled from DB schema as `MessagePayload` variants evolve. Empty periods (no messages) still appear in the result if the game has reached or passed that period (sourced from `game.current_day`); periods past `current_day` do not appear.
+
+  Auth: public read, mirroring `/log/:day` (MEDIUM-10).
+
+- **`GET /api/games/:id/summarize/:day`** — orphaned by this redesign (used only by the deleted `game_day_summary.rs`). **A beads issue is filed at PR-open time** (MEDIUM-11) to delete the endpoint and its handler in a follow-up. Not deleted in this PR to keep diff scope tight.
+
+- **Recap data** (winner, day count, duration) is already on `DisplayGame`. No new endpoint needed. Today `DisplayGame.winner` is a string (tribute name); RecapCard renders it as plain text. A follow-up beads issue (§7) tracks upgrading `winner` to `Option<TributeRef>` so the name can become a link.
+
+### Cache invalidation (HIGH-5)
+
+dioxus-query cache keys for this redesign:
+
+```rust
+pub enum QueryKey {
+    GameDayLog(String /*game_id*/, u32 /*day*/, u32 /*generation*/),
+    TimelineSummary(String /*game_id*/, u32 /*generation*/),
+    /* existing variants */
+}
+```
+
+A per-game `generation: u32` signal is held in the `PeriodFilters` context (or a sibling `GameCache` context — see §5). It is bumped on `MutationValue::GameAdvanced` (existing handler in `game_detail.rs`).
+
+WebSocket-driven invalidation (bumping `generation` when the WS hook reports `GameEvent::DayStarted` / `NightStarted`) is **out of scope for PR2**. A follow-up beads issue (§7) tracks adding it once the hook surface is verified. Mutation-driven invalidation is sufficient for the user-driven "advance day" flow that exists today.
+
+All readers of `GameDayLog` / `TimelineSummary` interpolate the current generation into their key, so a bump invalidates everything game-scoped without per-key wildcard tracking. Past-day logs are still re-fetched on bump but their content is immutable, so the network cost is bounded and acceptable.
+
+## 5. Frontend Components
+
+### Component tree
+
+```
+components/
+  game_detail.rs                    (modified — Game info + RecapCard + PeriodGrid)
+  recap_card.rs                     (new)
+  period_grid.rs                    (new)
+  period_grid_empty.rs              (new — empty/error states for the grid; MEDIUM-5)
+  period_card.rs                    (new)
+  game_period_page.rs               (new — top-level for GamePeriodPage route)
+  filter_chips.rs                   (new)
+  timeline/
+    mod.rs                          (re-exports)
+    timeline.rs                     (new — list + empty state)
+    event_card.rs                   (new — thin dispatcher, ~30 lines, matches kind, delegates)
+    cards/
+      death_card.rs                 (new — TributeKilled)
+      combat_card.rs                (new — Combat, with local expand Signal)
+      alliance_card.rs              (new — 5 alliance variants)
+      movement_card.rs              (new — 4 movement/area variants)
+      item_card.rs                  (new — 4 item variants)
+      state_card.rs                 (new — 5 state variants incl. TributeWounded)
+```
+
+(HIGH-8: `event_card.rs` is split.)
+
+### Component behaviors
+
+- **`game_period_page.rs`** — top-level for the `GamePeriodPage` route. Reads `(identifier, day, phase)`. Validates `(day, phase)` against the cached `TimelineSummary` (M5/MEDIUM-5): if the period doesn't exist, renders `PageNotFound`. Otherwise fetches `/api/games/:id/log/:day` via dioxus-query (with current generation), filters returned `Vec<GameMessage>` by `phase`, and renders `<FilterChips />` then `<Timeline />`.
+
+- **`period_card.rs`** — single hub card. Props: `{ game_identifier: String, day: u32, phase: Phase, deaths: u32, event_count: u32, is_current: bool }`. Click navigates to `GamePeriodPage`. `is_current` styles the live period subtly (MEDIUM-6). Tailwind styling matches the existing 3-theme color scheme.
+
+- **`period_grid.rs`** — props: `{ game_identifier: String }`. Fetches `/api/games/:id/timeline-summary`. Renders Tailwind `grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4` of `<PeriodCard />`. Loading state: skeleton placeholder. Error state and empty state delegated to `period_grid_empty.rs`.
+
+- **`period_grid_empty.rs`** — renders one of three states:
+  - **Empty** (game exists but has not been simulated yet): "This game hasn't started yet. Click 'Begin' to start." (or matching existing copy from `game_detail.rs` actions).
+  - **Loading failure** (HTTP error from `/timeline-summary`): "Couldn't load the timeline." with a retry button that re-runs the query.
+  - **Game not yet found** (404 from `/timeline-summary`): defer to parent route — should not happen if reached from a valid `GamePage` instance.
+
+- **`recap_card.rs`** — props: `{ game: DisplayGame }` (MEDIUM-7). Collapsible card pinned above the grid when `game.status == Finished`. Shows winner (or "All tributes died" when `winner.is_none()`), day count, and duration. Collapsed state persisted in `gloo-storage` keyed `recap_collapsed:{game.identifier}`. **Default: expanded on first view** (LOW-7). Winner name is plain text (not a link) for consistency with existing `DisplayGame.winner` shape; if/when `winner` becomes a `TributeRef`, render as link.
+
+- **`filter_chips.rs`** — props: `{ game_identifier: String }`. Reads/writes `PeriodFilters` from context (see State below). Chip row: `[All] [Deaths] [Combat] [Alliances] [Movement] [Items]`. `State` events (TributeWounded/Rested/Starved/Dehydrated/SanityBreak) are always visible when `All` is active and never filtered out by category chips (MEDIUM-8). State of the chip row is rendered from the explicit `FilterMode` enum (HIGH-7):
+
+  ```rust
+  pub enum FilterMode {
+      All,
+      Subset(HashSet<MessageKind>),
+  }
+
+  impl FilterMode {
+      pub fn matches(&self, kind: MessageKind) -> bool {
+          match self {
+              FilterMode::All => true,
+              FilterMode::Subset(set) => set.contains(&kind) || kind == MessageKind::State,
+          }
+      }
+      pub fn is_all(&self) -> bool { matches!(self, FilterMode::All) }
+  }
+  ```
+
+  Chip click rules:
+  - Click `[All]` → `FilterMode::All`. (No-op if already All.)
+  - Click a category while `All` → `FilterMode::Subset({that category})`.
+  - Click a category in a Subset → toggle membership.
+  - Toggling off the last category in a Subset → snap to `FilterMode::All` and visually flip the `All` chip on (so the transition is explicit, not silent — addresses HIGH-2 UX trap).
+
+  > **No `[State]` chip.** State events (TributeWounded/Rested/Starved/Dehydrated/SanityBreak) are treated as ambient context and always rendered, in both `All` and `Subset` modes. They have no chip representation; this is intentional.
+
+- **`timeline/event_card.rs`** — thin dispatcher (~30 lines). Matches on `payload.kind()` and renders the corresponding card subcomponent from `cards/`. Passes the full `GameMessage` (or relevant payload variant) as a prop.
+
+- **`timeline/cards/*.rs`** — one file per `MessageKind`. Owns its icon, Tailwind classes, and any local UI state. `combat_card.rs` owns a local `use_signal(|| false)` for expand/collapse. If `engagement.detail_lines.is_empty()`, the expand affordance is hidden (MEDIUM-1). Tribute names render as plain links to `/games/:gid/tributes/:tribute_identifier` using `TributeRef.identifier`. Item / area names use their refs' `identifier` similarly (no item/area route today, so render as plain text with `title=identifier` for now; future link work is out of scope).
+
+- **`timeline/timeline.rs`** — vertical list of `<EventCard />`s, sorted by `(tick, emit_index)`, filtered by the active `FilterMode`. Empty state: "Nothing happened this period."
+
+### Modified
+
+- **`game_detail.rs`** — strip the day-by-day rendering (~lines 220-630). Keep header, tribute roster, and map as a "Game info" section above the new `<RecapCard />` (when finished) and `<PeriodGrid />`. Pass the already-fetched `DisplayGame` into both `RecapCard` and `PeriodGrid` props (MEDIUM-7) — no double-fetch even though dioxus-query would dedupe by key.
+
+  **Mutation handlers in `game_detail.rs`:**
+  - On `MutationValue::GameAdvanced` — bump per-game `generation` in `PeriodFilters` context (HIGH-5).
+  - On `MutationValue::GameDeleted(id, _)` — call `gloo_storage::LocalStorage::delete("recap_collapsed:{id}")` and `gloo_storage::LocalStorage::delete("period_filters:{id}")` (MEDIUM-3).
+
+### Deleted
+
+- `web/src/components/game_day_log.rs`
+- `web/src/components/game_day_summary.rs`
+
+### State (HIGH-6: scope resolved)
+
+New context signal, **provided at the `Navbar` layout layer** (top-level under the router). Per-game state is keyed inside the struct, not by component scope:
+
+```rust
+pub struct PeriodFilters {
+    pub by_game: HashMap<String /*game_id*/, FilterMode>,
+    pub generations: HashMap<String /*game_id*/, u32>,
+}
+
+impl PeriodFilters {
+    pub fn filter_for(&self, game_id: &str) -> FilterMode { /* default: All */ }
+    pub fn set_filter(&mut self, game_id: &str, mode: FilterMode) { /* + persist to gloo-storage */ }
+    pub fn generation(&self, game_id: &str) -> u32 { /* default: 0 */ }
+    pub fn bump(&mut self, game_id: &str) { /* +=1 */ }
+}
+```
+
+Per-game `FilterMode` is persisted to `gloo-storage` keyed `period_filters:{game_id}`, mirrored into the in-memory `HashMap`. On boot, no preload is needed — entries are lazily hydrated when first read for a given `game_id`. Generations are in-memory only (reset to 0 on full reload, which correctly invalidates everything).
+
+**Filter state is NOT in URL query params** (LOW-1): keeps URLs clean for sharing the period view itself (`/games/:id/day/3/night`), and back/forward already navigate by period URL. Filter state is per-user, per-game, and persists across reloads via gloo-storage.
+
+## 6. Testing & Rollout
+
+### Game crate
+
+- Update existing combat rstest tests to assert `MessagePayload::Combat` variants — match on `outcome` and `detail_lines.len()`.
+- Add `MessagePayload::kind()` mapping tests covering every variant.
+- Add ordering test for the `(game_day, phase, tick, emit_index)` sort key.
+- Add `Phase` enum tests: `FromStr` accepts `"day"` / `"night"` and rejects `"Day"`, `"sideways"`, `""`, whitespace; `Display` round-trip; serde round-trip.
+- Add a causal-ordering regression test (LOW-8): construct a scenario where Tribute A kills Tribute B, then assert that no `MessagePayload::TributeMoved { tribute: B, .. }` appears at a later `(tick, emit_index)` than the `TributeKilled { victim: B, .. }` for that period.
+- Add `CombatOutcome` coverage: at least one test per variant (`Killed`, `Wounded`, `TargetFled`, `AttackerFled`, `Stalemate`).
+- Add `summarize_periods` tests in shared crate: empty input → empty output; mixed days/phases; deaths counted only from `TributeKilled`; current period flagged correctly.
+- Unknown-tag round-trip test: serialize a synthetic JSON object with `"type": "FutureKind"` and assert `serde_json::from_str::<MessagePayload>` returns `Err` (confirming hard-error behavior, no silent `Other`).
+
+### API crate
+
+- Update `api/tests/games_tests.rs` for the new `/log/:day` shape (`phase`, `tick`, `emit_index`, `payload`).
+- New integration test for `GET /api/games/:id/timeline-summary`:
+  - Empty for a game with `current_day == 0` / not started.
+  - Returns Day+Night entries for each completed period.
+  - Period with zero messages but reached (e.g., `current_day=2` with empty Day 1 Night) still appears with `event_count=0`.
+  - `is_current` flag matches `game.current_day` + `current_phase`.
+  - 404 (or empty, depending on existing convention) for unknown game id.
+- Update existing alliance-lifecycle tests: change assertions from `kind: Some(MessageKind::AllianceFormed)` to matching `MessagePayload::AllianceFormed { members }`.
+
+### Web crate
+
+No tests. No frontend test infrastructure exists — out of scope.
+
+### Rollout
+
+**Stacked PRs (HIGH-2 mitigation):**
+
+- **PR1 — backend + frontend stub.** Schema move (`game/` → `shared/`), `TaggedEvent` introduced, all known emit sites converted from `&mut Vec<String>` to `&mut Vec<TaggedEvent>` with typed payloads, combat refactor, API extensions (`/log/:day` extension + new `/timeline-summary`). Includes deletion of `game_day_log.rs` and `game_day_summary.rs` from the frontend, replaced with a temporary stub component **`web/src/components/game_log_stub.rs`** used by `game_detail.rs` that renders raw `content` lines from `GameMessage` (no styling, no filtering). This is the minimum change to keep `web/` compiling. The stub is deleted in PR2. The deleted-and-stubbed approach is preferred over keeping a serde-shim `kind` field, because it avoids a double-migration of the schema.
+
+- **PR2 — frontend timeline.** Add new components (`recap_card`, `period_grid`, `period_grid_empty`, `period_card`, `game_period_page`, `filter_chips`, `timeline/*`, `cards/*`). Add new route. Replace the PR1 stub in `game_detail.rs` with `RecapCard` + `PeriodGrid`. Delete `game_log_stub.rs`. Wire up cache invalidation and gloo-storage cleanup.
+
+Hard cutover. No feature flag.
+
+### Dev DB
+
+**Wipe `data/` directory required** before PR1 lands (LOW-4 lifted out of "recommended" into hard requirement). The `#[serde(default)]` fallback path is removed, so unknown payload tags or missing required fields hard-error. Wiping is the only safe path. Documented in PR1 description.
+
+### Verification
+
+- `just fmt` and `just quality` clean on each PR.
+- `just dev` smoke test after PR2:
+  - Hub renders period card grid; current period visually highlighted.
+  - Click card → navigate to period view.
+  - Filter chips work: `All` → category subset → empty subset snaps back to All; persists across DayNight nav within a game and across full reload (per game).
+  - Combat cards expand to show `detail_lines`; Combat with empty `detail_lines` shows no expand control.
+  - Tribute names in cards link to tribute detail page using `TributeRef.identifier`.
+  - Recap card appears when game is finished, collapses, persists collapsed state across reload, cleared from localStorage on game delete.
+  - Browser back/forward across hub  period works.
+  - Advancing a day (existing "next step" action) refreshes timeline summary AND the current day's log without manual reload.
+
+## 7. Follow-up beads issues (filed at PR-open)
+
+1. Combat mechanics redesign ("At some point, let's look at changing how combat works"). Includes modeling per-swing combat as `Vec<CombatBeat>` typed structs instead of `Vec<String> detail_lines`.
+2. Mobile polish (touch targets, swipe between periods, mobile-first card layouts).
+3. Inline announcer commentary cards (`MessagePayload::AnnouncerCommentary { speaker, text }`).
+4. Per-tribute timeline filter (filter chips by `TributeRef.identifier`).
+5. Delete `/api/games/:id/summarize/:day` endpoint and handler (orphaned by this redesign).
+6. Hover-preview cards for tribute / item / area links in the timeline.
+7. Item and area detail routes (currently `ItemRef` and `AreaRef` carry identifiers but no route to link to).
+8. Filter state in URL query params (`?filter=combat,deaths`) for shareable timeline views.
+9. Confirm or drop `MessagePayload::SponsorGift` once sponsor mechanics are designed.


### PR DESCRIPTION
## Summary

Recovered three planning documents from a working-copy split during PR #130 (mqi.3) ship. Pure docs add — no code changes.

## Changes

- `docs/superpowers/specs/2026-04-26-game-timeline-redesign.md` (534 lines) — design spec
- `docs/superpowers/plans/2026-04-26-game-timeline-pr1-backend.md` (1323 lines) — 17-task backend plan
- `docs/superpowers/plans/2026-04-26-game-timeline-pr2-frontend.md` (1323 lines) — frontend follow-up plan

## Verification

- N/A — markdown only, no code paths touched.

## Follow-ups

- Unblocks `hangrier_games-lca` (P2 epic) for dispatch.
- `hangrier_games-h8z` (P2 epic, frontend timeline UI) follows after lca.