### PR TITLE
chore(web,api): orphan cache cleanup + AppError Display fix

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -27,23 +27,23 @@ pub struct AppState {
 
 #[derive(Debug, Error)]
 pub enum AppError {
-    #[error("Not Found")]
+    #[error("Not Found: {0}")]
     NotFound(String),
-    #[error("Internal Server Error")]
+    #[error("Internal Server Error: {0}")]
     InternalServerError(String),
-    #[error("Bad Request")]
+    #[error("Bad Request: {0}")]
     BadRequest(String),
-    #[error("Unauthorized")]
+    #[error("Unauthorized: {0}")]
     Unauthorized(String),
-    #[error("Game is full")]
+    #[error("Game is full: {0}")]
     GameFull(String),
-    #[error("Database error")]
+    #[error("Database error: {0}")]
     DbError(String),
-    #[error("Conflict")]
+    #[error("Conflict: {0}")]
     Conflict(String),
-    #[error("Invalid status")]
+    #[error("Invalid status: {0}")]
     InvalidStatus(String),
-    #[error("Validation error")]
+    #[error("Validation error: {0}")]
     ValidationError(String),
 }
 

--- a/web/src/cache.rs
+++ b/web/src/cache.rs
@@ -14,13 +14,10 @@ pub(crate) enum QueryKey {
     Tributes(String),
     Areas(String),
     Tribute(String, String),     // Game identifier, tribute identifier
-    _GameLog(String),            // Game identifier
     GameDayLog(String, u32),     // Game identifier, day (PR2: timeline UI)
     TributeLog(String),          // Tribute identifier
     _TributeDayLog(String, u32), // Tribute identifier, day
-    _GameSummary(String),
-    _GameDaySummary(String, u32), // Game identifier, day
-    TimelineSummary(String),      // Game identifier (PR2: timeline UI)
+    TimelineSummary(String),     // Game identifier (PR2: timeline UI)
     User,
     ServerVersion,
 }
@@ -48,7 +45,6 @@ pub(crate) enum QueryValue {
     Tribute(Box<Tribute>),
     Tributes(Vec<Tribute>),
     Logs(Vec<GameMessage>),
-    Summary(String),
     ServerVersion(String),
     TimelineSummary(shared::messages::TimelineSummary),
     // Pagination variants


### PR DESCRIPTION
## Summary
- Removes four orphaned cache enum variants left behind after the `/summarize/:day` endpoint was deleted.
- Fixes `AppError` Display impls so error logs and HTTP response bodies actually include the inner message instead of just the variant label.

## Changes
- **`web/src/cache.rs`** — drop unused `QueryKey::_GameLog`, `QueryKey::_GameSummary`, `QueryKey::_GameDaySummary`, and `QueryValue::Summary`. Confirmed no callers via grep. Retains the active `GameDayLog` (PR2 timeline), `_TributeDayLog` (still pending future use), and `TimelineSummary`.
- **`api/src/lib.rs`** — every `AppError` variant's `#[error("Label")]` becomes `#[error("Label: {0}")]` so the inner `String` payload is no longer dropped on Display. Affects `NotFound`, `InternalServerError`, `BadRequest`, `Unauthorized`, `GameFull`, `DbError`, `Conflict`, `InvalidStatus`, `ValidationError`.

## Verification
- `cargo check -p api` → clean
- `cargo check -p web --target wasm32-unknown-unknown` (with wasm RUSTFLAGS) → clean
- `just quality` → all checks pass (fmt + clippy + workspace tests)

## Follow-ups
Closes hangrier_games-twv, hangrier_games-bg8.