### PR TITLE
chore: add devcontainer with Rust + wasm + Dioxus + SurrealDB sidecar

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
+
+# System deps for Dioxus desktop targets, OpenSSL, and SurrealDB CLI
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        libgtk-3-dev \
+        libwebkit2gtk-4.1-dev \
+        libsoup-3.0-dev \
+        libjavascriptcoregtk-4.1-dev \
+        libxdo-dev \
+        clang \
+        ca-certificates \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add wasm32 target as the vscode user
+USER vscode
+RUN rustup target add wasm32-unknown-unknown \
+    && rustup component add clippy rustfmt rust-src
+
+# Pre-install Dioxus CLI (matches justfile pin)
+RUN cargo install dioxus-cli@0.6.2 --locked
+
+# Install SurrealDB CLI for migrations / debugging
+RUN curl -sSf https://install.surrealdb.com | sh -s -- --version v2.1.4 \
+    || true
+ENV PATH="/home/vscode/.surrealdb:${PATH}"
+
+USER root

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,39 @@
+# Devcontainer
+
+Reproducible dev environment for Hangrier Games. Opens in VS Code or any editor that speaks the [devcontainer spec](https://containers.dev/).
+
+## What's inside
+
+- **Rust 1.x** (Debian bookworm base) with `wasm32-unknown-unknown`, `clippy`, `rustfmt`, `rust-src`.
+- **Dioxus CLI 0.6.2** preinstalled (matches `justfile`).
+- **Node LTS** + npm for Tailwind CSS.
+- **just**, **gh**, **SurrealDB CLI**.
+- **SurrealDB sidecar** (in-memory) reachable at `ws://surrealdb:8000`.
+- System libs for Dioxus desktop builds (`libwebkit2gtk-4.1`, `libgtk-3`, `libsoup-3.0`, `libxdo`, `clang`).
+
+Ollama is **not** included; install on the host and point at it if you want announcer commentary.
+
+## Forwarded ports
+
+| Port | Service        |
+|------|----------------|
+| 3000 | API (axum)     |
+| 8000 | SurrealDB      |
+| 8080 | Dioxus web dev |
+
+## First-run
+
+`postCreateCommand` runs `.devcontainer/post-create.sh` which installs `web/assets` npm deps, builds Tailwind, and writes a default `.env` if one is missing.
+
+After it finishes:
+
+```bash
+just api    # in one terminal
+just web    # in another
+```
+
+Or use `just dev` if you have a multiplexer set up.
+
+## Caches
+
+`cargo registry` and the workspace `target/` directory are mounted as named Docker volumes so rebuilds survive container recreation.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,54 @@
+{
+  "name": "Hangrier Games",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "dev",
+  "workspaceFolder": "/workspaces/hangrier_games",
+  "shutdownAction": "stopCompose",
+
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/guiyomh/features/just:0": {}
+  },
+
+  "forwardPorts": [3000, 8000, 8080],
+  "portsAttributes": {
+    "3000": { "label": "API", "onAutoForward": "notify" },
+    "8000": { "label": "SurrealDB", "onAutoForward": "silent" },
+    "8080": { "label": "Web (Dioxus)", "onAutoForward": "openBrowser" }
+  },
+
+  "remoteEnv": {
+    "ENV": "development",
+    "APP_API_HOST": "http://127.0.0.1:3000",
+    "SURREAL_HOST": "ws://surrealdb:8000",
+    "SURREAL_USER": "root",
+    "SURREAL_PASS": "root",
+    "RUSTFLAGS": "--cfg getrandom_backend=\"wasm_js\""
+  },
+
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb",
+        "bradlc.vscode-tailwindcss",
+        "DioxusLabs.dioxus",
+        "skellock.just",
+        "GitHub.vscode-pull-request-github"
+      ],
+      "settings": {
+        "rust-analyzer.cargo.targetDir": true,
+        "editor.formatOnSave": true,
+        "[rust]": { "editor.defaultFormatter": "rust-lang.rust-analyzer" }
+      }
+    }
+  },
+
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+      - cargo-cache:/usr/local/cargo/registry
+      - target-cache:/workspaces/hangrier_games/target
+    command: sleep infinity
+    depends_on:
+      - surrealdb
+    networks:
+      - hangrier
+
+  surrealdb:
+    image: surrealdb/surrealdb:v2.1.4
+    command: start --user root --pass root --bind 0.0.0.0:8000 memory
+    restart: unless-stopped
+    networks:
+      - hangrier
+
+networks:
+  hangrier:
+
+volumes:
+  cargo-cache:
+  target-cache:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> Installing web/assets npm deps"
+if [ -d web/assets ]; then
+  (cd web/assets && npm install --no-audit --no-fund)
+fi
+
+echo "==> Building Tailwind CSS"
+just build-css || echo "build-css skipped (will run on first dev start)"
+
+echo "==> Ensuring .env exists"
+if [ ! -f .env ]; then
+  cat > .env <<'EOF'
+ENV=development
+APP_API_HOST=http://127.0.0.1:3000
+SURREAL_HOST=ws://surrealdb:8000
+SURREAL_USER=root
+SURREAL_PASS=root
+EOF
+  echo "Created default .env (SurrealDB reachable at ws://surrealdb:8000 inside the devcontainer network)"
+fi
+
+echo "==> Done. Run 'just api' and 'just web' (or 'just dev' if you have tmux)."


### PR DESCRIPTION
## Summary

Reproducible dev environment via the [devcontainer spec](https://containers.dev/). Opens with VS Code (Reopen in Container), JetBrains Gateway, GitHub Codespaces, or any compliant editor.

## Changes

- `.devcontainer/devcontainer.json` — service entry point, ports (3000/8000/8080), `remoteEnv` wiring (`APP_API_HOST`, `SURREAL_HOST=ws://surrealdb:8000`, wasm `RUSTFLAGS`), VS Code extensions (rust-analyzer, even-better-toml, lldb, Tailwind, Dioxus, just, gh).
- `.devcontainer/Dockerfile` — `mcr.microsoft.com/devcontainers/rust:1-bookworm` base + Dioxus desktop system libs (libwebkit2gtk-4.1, libgtk-3, libsoup-3.0, libxdo, clang, openssl, pkg-config). Adds `wasm32-unknown-unknown`, clippy, rustfmt, rust-src. Preinstalls `dioxus-cli@0.6.2` (matches `justfile` pin) and SurrealDB CLI v2.1.4.
- `.devcontainer/docker-compose.yml` — `dev` service + `surrealdb` sidecar (in-memory) on shared `hangrier` network. Named volumes for cargo registry + workspace `target/` so rebuilds survive container recreation.
- `.devcontainer/post-create.sh` — installs `web/assets` npm deps, runs `just build-css`, writes default `.env` if missing.
- `.devcontainer/README.md` — onboarding notes, port table, first-run instructions.
- Features: `node` (LTS), `github-cli`, `just`.

Ollama is intentionally excluded (heavy, optional). Install on the host and point at it for announcer commentary.

## Verification

- Files committed and pushed.
- Container build/run not exercised in this environment — needs validation on a host with Docker. Will iterate based on first-run feedback.

## Follow-ups

None filed yet. Possible future work: Codespaces-specific tweaks, Ollama profile behind `--profile ollama`, prebuild image pushed to GHCR.