### PR TITLE
fix(devcontainer): chown named volumes and stop poisoning native builds with RUSTFLAGS

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,8 +25,7 @@
     "APP_API_HOST": "http://127.0.0.1:3000",
     "SURREAL_HOST": "ws://surrealdb:8000",
     "SURREAL_USER": "root",
-    "SURREAL_PASS": "root",
-    "RUSTFLAGS": "--cfg getrandom_backend=\"wasm_js\""
+    "SURREAL_PASS": "root"
   },
 
   "postCreateCommand": "bash .devcontainer/post-create.sh",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+echo "==> Fixing volume ownership (named volumes mount as root by default)"
+sudo chown -R vscode:vscode /usr/local/cargo/registry /workspaces/hangrier_games/target 2>/dev/null || true
+
 echo "==> Installing web/assets npm deps"
 if [ -d web/assets ]; then
   (cd web/assets && npm install --no-audit --no-fund)


### PR DESCRIPTION
## Summary

First-run inside the devcontainer was broken: `just api` failed with permission denied during build, and `just web` failed the same way plus an `unwrap` on an `Err` from `dx`.

Two root causes:

1. **Named volumes mount as root.** `cargo-cache:/usr/local/cargo/registry` and `target-cache:/workspaces/hangrier_games/target` are owned by root inside the container, but builds run as `vscode`. Cargo couldn't write to either path.
2. **`RUSTFLAGS` poisoning native builds.** `RUSTFLAGS='--cfg getrandom_backend="wasm_js"'` was set in `remoteEnv`, so it applied to every cargo invocation — including the native `api` build, which doesn't want it. The justfile already sets it per-recipe for the wasm targets, so it doesn't belong globally.

The web `unwrap on Err` is a downstream symptom of #1 — `dx` panics when it can't write to `target/`.

## Changes

- `.devcontainer/post-create.sh`: `sudo chown -R vscode:vscode /usr/local/cargo/registry /workspaces/hangrier_games/target` before npm install (vscode user has passwordless sudo in the MS base image).
- `.devcontainer/devcontainer.json`: removed `RUSTFLAGS` from `remoteEnv`. The `build-web*` recipes in `justfile` still set it per-invocation.

## Verification

- Local sync clean (`jj git fetch && jj rebase -d main@origin`).
- Cannot run the devcontainer end-to-end inside this agent session. **Reviewer must rebuild the container** (`devcontainer up --workspace-folder . --remove-existing-container`) and confirm `just api` and `just web` now build and start.

## Follow-ups

Closes hangrier_games-(no ticket — surfaced from PR #137 first-run report).