### PR TITLE
fix(devcontainer): install SurrealDB inside container and persist data

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,6 +15,12 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
+# Install SurrealDB into /usr/local/bin (must run as root for write access).
+# No '|| true' — fail the build if install fails so we don't end up with a
+# broken devcontainer that silently misses the binary.
+RUN curl -sSf https://install.surrealdb.com | sh -s -- --version v2.1.4 \
+    && surreal version
+
 # Add wasm32 target as the vscode user
 USER vscode
 RUN rustup target add wasm32-unknown-unknown \
@@ -22,10 +28,5 @@ RUN rustup target add wasm32-unknown-unknown \
 
 # Pre-install Dioxus CLI (matches justfile pin)
 RUN cargo install dioxus-cli@0.6.2 --locked
-
-# Install SurrealDB CLI for migrations / debugging
-RUN curl -sSf https://install.surrealdb.com | sh -s -- --version v2.1.4 \
-    || true
-ENV PATH="/home/vscode/.surrealdb:${PATH}"
 
 USER root

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -7,8 +7,8 @@ Reproducible dev environment for Hangrier Games. Opens in VS Code or any editor 
 - **Rust 1.x** (Debian bookworm base) with `wasm32-unknown-unknown`, `clippy`, `rustfmt`, `rust-src`.
 - **Dioxus CLI 0.6.2** preinstalled (matches `justfile`).
 - **Node LTS** + npm for Tailwind CSS.
-- **just**, **gh**, **SurrealDB CLI**.
-- **SurrealDB sidecar** (in-memory) reachable at `ws://surrealdb:8000`.
+- **just**, **gh**.
+- **SurrealDB CLI** (`surreal` binary, v2.1.4) in `/usr/local/bin`. Started in-container by `just dev` / `just db` with persistent on-disk storage at `.surrealdb/` in the workspace root (gitignored). Listens on `ws://localhost:8000`.
 - System libs for Dioxus desktop builds (`libwebkit2gtk-4.1`, `libgtk-3`, `libsoup-3.0`, `libxdo`, `clang`).
 
 Ollama is **not** included; install on the host and point at it if you want announcer commentary.
@@ -28,11 +28,16 @@ Ollama is **not** included; install on the host and point at it if you want anno
 After it finishes:
 
 ```bash
-just api    # in one terminal
-just web    # in another
+just dev    # starts SurrealDB + API + web together
 ```
 
-Or use `just dev` if you have a multiplexer set up.
+Or run them individually in separate terminals:
+
+```bash
+just db     # SurrealDB (memory mode, ws://localhost:8000)
+just api    # API server
+just web    # Dioxus dev server
+```
 
 ## Caches
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
   "remoteEnv": {
     "ENV": "development",
     "APP_API_HOST": "http://127.0.0.1:3000",
-    "SURREAL_HOST": "ws://surrealdb:8000",
+    "SURREAL_HOST": "ws://localhost:8000",
     "SURREAL_USER": "root",
     "SURREAL_PASS": "root"
   },

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,20 +8,12 @@ services:
       - cargo-cache:/usr/local/cargo/registry
       - target-cache:/workspaces/hangrier_games/target
     command: sleep infinity
-    depends_on:
-      - surrealdb
-    networks:
-      - hangrier
-
-  surrealdb:
-    image: surrealdb/surrealdb:v2.1.4
-    command: start --user root --pass root --bind 0.0.0.0:8000 memory
-    restart: unless-stopped
-    networks:
-      - hangrier
-
-networks:
-  hangrier:
+    # SurrealDB is installed inside this container (see Dockerfile) and started
+    # by `just dev` / `just db`. It listens on localhost:8000.
+    ports:
+      - "3000:3000"  # API
+      - "8000:8000"  # SurrealDB
+      - "8080:8080"  # Web (Dioxus)
 
 volumes:
   cargo-cache:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -19,11 +19,11 @@ if [ ! -f .env ]; then
   cat > .env <<'EOF'
 ENV=development
 APP_API_HOST=http://127.0.0.1:3000
-SURREAL_HOST=ws://surrealdb:8000
+SURREAL_HOST=ws://localhost:8000
 SURREAL_USER=root
 SURREAL_PASS=root
 EOF
-  echo "Created default .env (SurrealDB reachable at ws://surrealdb:8000 inside the devcontainer network)"
+  echo "Created default .env (SurrealDB runs in-container at ws://localhost:8000)"
 fi
 
-echo "==> Done. Run 'just api' and 'just web' (or 'just dev' if you have tmux)."
+echo "==> Done. Run 'just dev' (starts SurrealDB + API + web in one shell)."

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ web/assets/dist
 web/src/env.rs
 .env
 
+# SurrealDB on-disk data (persistent dev database)
+.surrealdb/
+
 # Beads / Dolt files (added by bd init)
 .dolt/
 *.db

--- a/justfile
+++ b/justfile
@@ -14,15 +14,15 @@ api:
 web:
     cd web && dx serve
 
-# Start SurrealDB in memory mode for local development
+# Start SurrealDB with persistent on-disk storage for local development
 db:
-    surrealdb start --log trace --user root --pass root memory
+    surreal start --log trace --user root --pass root surrealkv://.surrealdb
 
 # Start full development environment (DB, API, and web frontend)
 dev:
     #!/usr/bin/env bash
     echo "Starting SurrealDB..."
-    surrealdb start --log info --user root --pass root memory &
+    surreal start --log info --user root --pass root surrealkv://.surrealdb &
     DB_PID=$!
     sleep 2
     echo "Starting API server..."


### PR DESCRIPTION
## Summary
- Devcontainer was missing the `surreal` CLI because the install step ran as the unprivileged `vscode` user, into a directory it couldn't write, with `|| true` swallowing the failure. `just dev` then bailed out.
- Switched to running SurrealDB inside the dev container itself (no more sidecar service) and made the dev DB persist across container rebuilds.

## Changes
- **`.devcontainer/Dockerfile`** — install `surreal` as root into `/usr/local/bin`, drop the swallowed-failure `|| true`, add a `surreal version` smoke check, drop the bogus `PATH` override.
- **`.devcontainer/docker-compose.yml`** — remove the standalone `surrealdb` service; single `dev` service with explicit forwards for 3000/8000/8080. Networks block dropped.
- **`.devcontainer/devcontainer.json`** + **`post-create.sh`** — `SURREAL_HOST` now `ws://localhost:8000`.
- **`.devcontainer/README.md`** — documents the in-container DB and persistent storage layout; quickstart now recommends `just dev`.
- **`justfile`** — fix `surrealdb` → `surreal` binary-name typo in `db` and `dev`; switch storage backend from `memory` to `surrealkv://.surrealdb` so dev data survives rebuilds.
- **`.gitignore`** — ignore the new `.surrealdb/` data directory.

## Verification
- Manual: user SSH'd into devcontainer, confirmed Surrealist could authenticate and the DB was reachable on `localhost:8000`. Pre-rebuild manual test passed; full rebuild verification still pending after this lands.
- Heads-up: `surrealdb-migrations` records checksums; if migration files change locally, blow away `.surrealdb/` to avoid checksum drift.

## Follow-ups
- `hangrier_games-3l9` stays open until the user verifies `just dev` works after a clean rebuild.