### PR TITLE
fix(web): close loading modal on quickstart failure and send proper CreateGame DTO

### DIFF
--- a/web/src/components/create_game.rs
+++ b/web/src/components/create_game.rs
@@ -6,6 +6,7 @@ use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
 use dioxus_query::prelude::{MutationResult, MutationState, use_mutation, use_query_client};
 use game::games::Game;
+use shared::CreateGame;
 use std::ops::Deref;
 
 // TODO: Game Customization Enhancement
@@ -24,9 +25,11 @@ async fn create_game(
     let name = args.0.clone();
     let token = args.1.clone();
     let client = reqwest::Client::new();
-    let json_body = match name {
-        Some(name) => Game::new(&name),
-        None => Game::default(),
+    let json_body = CreateGame {
+        name,
+        item_quantity: Default::default(),
+        event_frequency: Default::default(),
+        starting_health_range: None,
     };
 
     let response = client
@@ -35,10 +38,25 @@ async fn create_game(
         .json(&json_body);
 
     match response.send().await {
-        Ok(response) => match response.json::<Game>().await {
-            Ok(game) => MutationResult::Ok(MutationValue::NewGame(game)),
-            Err(_) => MutationResult::Err(MutationError::UnableToCreateGame),
-        },
+        Ok(response) => {
+            let status = response.status();
+            if !status.is_success() {
+                let body = response.text().await.unwrap_or_default();
+                dioxus_logger::tracing::error!(
+                    "create_game failed: status={} body={}",
+                    status,
+                    body
+                );
+                return MutationResult::Err(MutationError::UnableToCreateGame);
+            }
+            match response.json::<Game>().await {
+                Ok(game) => MutationResult::Ok(MutationValue::NewGame(game)),
+                Err(e) => {
+                    dioxus_logger::tracing::error!("create_game parse error: {:?}", e);
+                    MutationResult::Err(MutationError::UnableToCreateGame)
+                }
+            }
+        }
         Err(e) => {
             dioxus_logger::tracing::error!("error creating game: {:?}", e);
             MutationResult::Err(MutationError::UnableToCreateGame)
@@ -62,8 +80,8 @@ pub fn CreateGameButton() -> Element {
                 && let MutationValue::NewGame(_game) = result
             {
                 client.invalidate_queries(&[QueryKey::Games]);
-                loading_signal.set(LoadingState::Loaded);
             };
+            loading_signal.set(LoadingState::Loaded);
         });
     };
 
@@ -98,9 +116,9 @@ pub fn CreateGameForm() -> Element {
                 && let MutationValue::NewGame(_game) = result
             {
                 client.invalidate_queries(&[QueryKey::Games]);
-                loading_signal.set(LoadingState::Loaded);
                 game_name_signal.set(String::default());
             }
+            loading_signal.set(LoadingState::Loaded);
         });
     };
 


### PR DESCRIPTION
## Summary

Two related bugs in the game-creation flow.

### Modal hangs on completion
`CreateGameButton` (and `CreateGameForm`) only resets `LoadingState::Loaded` inside the success branch of `if let MutationState::Settled(Ok(MutationValue::NewGame(_))) = ...`. If the mutation errors — or even if it succeeds but the result variant doesn't match — the loading signal stays at `Loading` forever and the loading modal never closes. The user sees a stuck spinner even though the API created the game (visible after a page refresh).

Fix: move `loading_signal.set(LoadingState::Loaded)` outside the `if let` so it always runs once the mutation settles.

### Sending the wrong DTO
The frontend was POSTing a fully-populated `Game` JSON (`Game::new(&name)` / `Game::default()`) to `POST /api/games`, but the API expects a `CreateGame` DTO (`name: Option<String>`, `item_quantity`, `event_frequency`, `starting_health_range`). It happened to work because serde silently ignores unknown fields, but it's brittle — any future `deny_unknown_fields` or validation tightening would break it, and it also wasn't sending the customization fields the API now supports.

Fix: import `shared::CreateGame` and build that struct instead.

Also added a guard for non-2xx responses with logging — previously a 4xx/5xx body would still be `.json::<Game>()`-parsed and just produce a generic "UnableToCreateGame", losing the actual error.

## Changes

- `web/src/components/create_game.rs`:
  - Send `CreateGame` DTO instead of full `Game`.
  - Check HTTP status before parsing; log status + body on failure.
  - Always reset `LoadingState::Loaded` after the mutation settles, regardless of outcome.

## Verification

- `cargo check --package web` (native target) — clean.
- Manual test pending against running devcontainer; reproduces with previous code (modal hangs, game appears on refresh).

## Follow-ups

- Wire actual `ItemQuantity` / `EventFrequency` selectors (the TODO at the top of `create_game.rs`) once the UX is decided. The DTO is now plumbed correctly so this becomes a UI-only change.