### PR TITLE
fix(api): persist all Item fields and use raw RELATE for game-area edges

### DIFF
--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -156,23 +156,22 @@ async fn create_game_area_edge(
         }
     };
 
-    let gar = db
-        .insert::<Option<GameAreaEdge>>(RecordId::from(("areas", area_uuid.to_string())))
-        .relation(GameAreaEdge {
-            game: game_id.clone(),
-            area: RecordId::from(("area", &area_uuid.to_string())),
-        })
+    let edge = GameAreaEdge {
+        game: game_id.clone(),
+        area: RecordId::from(("area", &area_uuid.to_string())),
+    };
+
+    // RELATE always returns an array; the SDK's typed Option<T> path fails to
+    // deserialize that into a single struct. Use a raw query so the response
+    // shape doesn't matter. The (game, area) unique index keeps duplicates out.
+    db.query("RELATE $game->areas->$area")
+        .bind(("game", edge.game.clone()))
+        .bind(("area", edge.area.clone()))
         .await
         .map_err(|e| {
             AppError::InternalServerError(format!("Failed to link game and area: {}", e))
         })?;
-
-    match gar {
-        Some(edge) => Ok(edge),
-        None => Err(AppError::InternalServerError(
-            "Failed to create game area record".into(),
-        )),
-    }
+    Ok(edge)
 }
 
 pub async fn create_game(
@@ -1087,37 +1086,25 @@ async fn save_area_items(
 
     // Batch update operations
     if !items_to_update.is_empty() {
-        // Build bulk update query. Hyphenated UUIDs must be wrapped in
-        // ⟨angle brackets⟩ or Surreal's SQL parser splits them on `-`.
-        let mut query_parts = Vec::new();
+        // Use serde_json::to_value + bound CONTENT so ALL Item fields round-trip
+        // (the previous hand-rolled CONTENT block silently dropped `rarity`,
+        // and string-interpolating fields is fragile around quoting).
         for item in &items_to_update {
-            query_parts.push(format!(
-                "UPDATE item:⟨{}⟩ CONTENT {{
-                    identifier: '{}',
-                    name: '{}',
-                    item_type: '{:?}',
-                    effect: {},
-                    current_durability: {},
-                    max_durability: {},
-                    attribute: '{:?}'
-                }}",
-                item.identifier,
-                item.identifier,
-                item.name.replace("'", "\\'"),
-                item.item_type,
-                item.effect,
-                item.current_durability,
-                item.max_durability,
-                item.attribute
-            ));
+            let rid = RecordId::from(("item", item.identifier.to_string().as_str()));
+            let body = serde_json::to_value(item).map_err(|e| {
+                AppError::InternalServerError(format!("Failed to encode item: {}", e))
+            })?;
+            db.query("UPDATE $rid CONTENT $body")
+                .bind(("rid", rid))
+                .bind(("body", body))
+                .await
+                .map_err(|e| {
+                    AppError::InternalServerError(format!("Failed to update item: {}", e))
+                })?;
         }
 
-        let bulk_query = query_parts.join(";\n");
-        db.query(&bulk_query).await.map_err(|e| {
-            AppError::InternalServerError(format!("Failed to batch update items: {}", e))
-        })?;
-
-        // Batch insert relations
+        // Batch insert relations. Hyphenated UUIDs must be wrapped in
+        // ⟨angle brackets⟩ or Surreal's SQL parser splits them on `-`.
         let mut relation_parts = Vec::new();
         for item in &items_to_update {
             relation_parts.push(format!(
@@ -1209,37 +1196,25 @@ async fn save_tribute_items(
 
     // Batch update operations
     if !items_to_update.is_empty() {
-        // Build bulk update query. Hyphenated UUIDs must be wrapped in
-        // ⟨angle brackets⟩ or Surreal's SQL parser splits them on `-`.
-        let mut query_parts = Vec::new();
+        // Use serde_json::to_value + bound CONTENT so ALL Item fields round-trip
+        // (the previous hand-rolled CONTENT block silently dropped `rarity`,
+        // and string-interpolating fields is fragile around quoting).
         for item in &items_to_update {
-            query_parts.push(format!(
-                "UPDATE item:⟨{}⟩ CONTENT {{
-                    identifier: '{}',
-                    name: '{}',
-                    item_type: '{:?}',
-                    effect: {},
-                    current_durability: {},
-                    max_durability: {},
-                    attribute: '{:?}'
-                }}",
-                item.identifier,
-                item.identifier,
-                item.name.replace("'", "\\'"),
-                item.item_type,
-                item.effect,
-                item.current_durability,
-                item.max_durability,
-                item.attribute
-            ));
+            let rid = RecordId::from(("item", item.identifier.to_string().as_str()));
+            let body = serde_json::to_value(item).map_err(|e| {
+                AppError::InternalServerError(format!("Failed to encode item: {}", e))
+            })?;
+            db.query("UPDATE $rid CONTENT $body")
+                .bind(("rid", rid))
+                .bind(("body", body))
+                .await
+                .map_err(|e| {
+                    AppError::InternalServerError(format!("Failed to update item: {}", e))
+                })?;
         }
 
-        let bulk_query = query_parts.join(";\n");
-        db.query(&bulk_query).await.map_err(|e| {
-            AppError::InternalServerError(format!("Failed to batch update items: {}", e))
-        })?;
-
-        // Batch insert relations
+        // Batch insert relations. Hyphenated UUIDs must be wrapped in
+        // ⟨angle brackets⟩ or Surreal's SQL parser splits them on `-`.
         let mut relation_parts = Vec::new();
         for item in &items_to_update {
             relation_parts.push(format!(


### PR DESCRIPTION
## Summary

Two more SurrealDB SDK serializer issues that surfaced after wiping the dev DB on the freshly-merged PR 143:

1. **Item updates dropped `rarity`** — `save_area_items` and `save_tribute_items` used a hand-rolled `UPDATE item:⟨{id}⟩ CONTENT { ... }` block that listed fields explicitly. `rarity` (recently added to `Item`) wasn't in the list, so the first save_game silently blew the field away and the next read tripped `Serialization error: missing field rarity`.
2. **Game-area RELATE returned an array** — `create_game_area` did `db.insert::<Option<GameAreaEdge>>(rid).relation(GameAreaEdge { .. })`. Surreal's RELATE always returns an array; the SDK's typed `Option<T>` path then bailed with `expected an object-like struct named GameAreaEdge, found [{...}]`.

## Changes

- `api/src/games.rs` `save_area_items` / `save_tribute_items`: switch the per-item update from a hand-built CONTENT string to `serde_json::to_value(item)` bound into `UPDATE $rid CONTENT $body` — same pattern PR 143 used for tribute and area saves. Round-trips every field on `Item` automatically; no more per-field maintenance.
- `api/src/games.rs` `create_game_area`: replace the typed `.insert::<Option<GameAreaEdge>>(...).relation(...)` with a raw `RELATE $game->areas->$area` query. The `(game, area)` unique index already prevents duplicates; we just don't need the SDK to deserialize the response.

## Verification

- `cargo check --package api` clean.
- Manual: wiped the dev DB, ran `just dev`, registered, used Quickstart to create a game, played day 1 — both errors are gone.

## Follow-ups

- bd `hangrier_games-bbl` already tracks the broader audit of remaining `db.update/create.content()` call sites; today's two were not in that list because they were hand-rolled queries, not `.content()` calls. Will note this pattern in that issue.