### PR TITLE
fix(api): migrate remaining .content() call sites to bound CONTENT queries

### DIFF
--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -75,10 +75,15 @@ pub async fn store_refresh_token(
     state: &AppState,
     refresh_token: &RefreshToken,
 ) -> Result<(), AppError> {
-    let _: Option<RefreshToken> = state
+    // Bind via serde_json::Value to bypass the SurrealDB SDK's bespoke
+    // type serializer (same workaround as save_game in games.rs), which
+    // can collapse externally-tagged enums and Option fields.
+    let body = serde_json::to_value(refresh_token)
+        .map_err(|e| AppError::DbError(format!("Failed to encode refresh token: {}", e)))?;
+    state
         .db
-        .create("refresh_token")
-        .content(refresh_token.clone())
+        .query("CREATE refresh_token CONTENT $body")
+        .bind(("body", body))
         .await
         .map_err(|e| AppError::DbError(format!("Failed to store refresh token: {}", e)))?;
     Ok(())

--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -84,36 +84,27 @@ pub struct GameAreaEdge {
     area: RecordId,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct AreaItemEdge {
-    #[serde(rename = "in")]
-    area: RecordId,
-    #[serde(rename = "out")]
-    item: RecordId,
-}
-
 async fn create_game_area(area: Area, db: &Surreal<Any>) -> Result<GameArea, AppError> {
     let identifier = Uuid::new_v4().to_string();
     let area_id: RecordId = RecordId::from(("area", identifier.to_string()));
 
-    // create the `area` record
-    let game_area: Option<GameArea> = db
-        .insert::<Option<GameArea>>(area_id.clone())
-        .content(GameArea {
-            identifier: identifier.to_string(),
-            name: area.to_string(),
-            area: area.to_string(),
-        })
+    // create the `area` record. Bind via serde_json::Value + a raw
+    // UPDATE...CONTENT query so the SDK's bespoke serializer can't drop
+    // optional fields or collapse externally-tagged enums (see save_game).
+    let game_area = GameArea {
+        identifier: identifier.to_string(),
+        name: area.to_string(),
+        area: area.to_string(),
+    };
+    let body = serde_json::to_value(&game_area)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to encode area: {}", e)))?;
+    db.query("UPDATE $rid CONTENT $body")
+        .bind(("rid", area_id.clone()))
+        .bind(("body", body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create area: {}", e)))?;
 
-    if let Some(game_area) = game_area {
-        Ok(game_area)
-    } else {
-        Err(AppError::InternalServerError(
-            "Failed to create game area".into(),
-        ))
-    }
+    Ok(game_area)
 }
 
 async fn create_game_area_edge(
@@ -202,16 +193,21 @@ pub async fn create_game(
         ..Default::default()
     };
 
-    let created_game: Option<Game> = state
+    // Use serde_json::Value + bound CONTENT to bypass the SurrealDB SDK's
+    // bespoke serializer (which collapses externally-tagged enums and drops
+    // Option fields like `day`). Same pattern as save_game.
+    let game_rid = RecordId::from(("game", game_identifier.as_str()));
+    let body = serde_json::to_value(&game)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to encode game: {}", e)))?;
+    state
         .db
-        .create(("game", &game_identifier))
-        .content(game)
+        .query("UPDATE $rid CONTENT $body")
+        .bind(("rid", game_rid))
+        .bind(("body", body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create game: {}", e)))?;
 
-    let created_game = created_game.ok_or_else(|| {
-        AppError::InternalServerError("Game creation returned empty result".into())
-    })?;
+    let created_game = game;
 
     // Create tributes concurrently
     let tribute_futures =
@@ -297,9 +293,12 @@ pub async fn add_item_to_area(
         None => Item::new_random(None),
     };
     let new_item_id: RecordId = RecordId::from(("item", &new_item.identifier));
+    let body = serde_json::to_value(&new_item)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to encode item: {}", e)))?;
     if let Err(e) = db
-        .insert::<Option<Item>>(new_item_id.clone())
-        .content(new_item.clone())
+        .query("UPDATE $rid CONTENT $body")
+        .bind(("rid", new_item_id.clone()))
+        .bind(("body", body))
         .await
     {
         return Err(AppError::InternalServerError(format!(
@@ -308,14 +307,13 @@ pub async fn add_item_to_area(
         )));
     }
 
-    // Insert an area-item relationship
-    let area_item: AreaItemEdge = AreaItemEdge {
-        area: game_area_edge.area.clone(),
-        item: new_item_id.clone(),
-    };
+    // Insert an area-item relationship via a raw RELATE query. RELATE always
+    // returns an array, so the SDK's typed insert::<Vec<_>>().relation() path
+    // is fragile; the raw query with bound params sidesteps that.
     if let Err(e) = db
-        .insert::<Vec<AreaItemEdge>>("items")
-        .relation([area_item])
+        .query("RELATE $area->items->$item")
+        .bind(("area", game_area_edge.area.clone()))
+        .bind(("item", new_item_id.clone()))
         .await
     {
         Err(AppError::InternalServerError(format!(

--- a/api/src/tributes.rs
+++ b/api/src/tributes.rs
@@ -37,14 +37,6 @@ pub struct TributeItemEdge {
     pub item: RecordId,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct TributeGameEdge {
-    #[serde(rename = "in")]
-    tribute: RecordId,
-    #[serde(rename = "out")]
-    game: RecordId,
-}
-
 pub async fn create_tribute(
     tribute: Option<Tribute>,
     game_identifier: &str,
@@ -67,17 +59,22 @@ pub async fn create_tribute(
 
     let id = RecordId::from(("tribute", &tribute.identifier));
 
-    let new_tribute: Option<Tribute> =
-        db.create(&id).content(tribute).await.map_err(|e| {
-            AppError::InternalServerError(format!("Failed to create tribute: {}", e))
-        })?;
+    // Bind via serde_json::Value to bypass the SurrealDB SDK's bespoke type
+    // serializer, which collapses externally-tagged enums and Option fields.
+    // The generic JSON bind path round-trips cleanly. Mirrors the pattern in
+    // save_game in api/src/games.rs.
+    let body = serde_json::to_value(&tribute)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to encode tribute: {}", e)))?;
+    db.query("UPDATE $rid CONTENT $body")
+        .bind(("rid", id.clone()))
+        .bind(("body", body))
+        .await
+        .map_err(|e| AppError::InternalServerError(format!("Failed to create tribute: {}", e)))?;
+    let new_tribute = Some(tribute);
 
-    let _: Vec<TributeGameEdge> = db
-        .insert("playing_in")
-        .relation(TributeGameEdge {
-            tribute: id.clone(),
-            game: game_id.clone(),
-        })
+    db.query("RELATE $tribute->playing_in->$game")
+        .bind(("tribute", id.clone()))
+        .bind(("game", game_id.clone()))
         .await
         .map_err(|e| {
             AppError::InternalServerError(format!("Failed to connect tribute to game: {}", e))
@@ -85,17 +82,16 @@ pub async fn create_tribute(
 
     let new_object: Item = Item::new_random(None);
     let new_object_id: RecordId = RecordId::from(("item", &new_object.identifier));
-    let _: Option<Item> = db
-        .insert(new_object_id.clone())
-        .content(new_object.clone())
+    let item_body = serde_json::to_value(&new_object)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to encode item: {}", e)))?;
+    db.query("UPDATE $rid CONTENT $body")
+        .bind(("rid", new_object_id.clone()))
+        .bind(("body", item_body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create item: {}", e)))?;
-    let _: Vec<TributeItemEdge> = db
-        .insert("owns")
-        .relation(TributeItemEdge {
-            tribute: id.clone(),
-            item: new_object_id.clone(),
-        })
+    db.query("RELATE $tribute->owns->$item")
+        .bind(("tribute", id.clone()))
+        .bind(("item", new_object_id.clone()))
         .await
         .map_err(|e| {
             AppError::InternalServerError(format!("Failed to create owns relation: {}", e))


### PR DESCRIPTION
## Summary

Audit follow-up to PR #143 / #144. Closes hangrier_games-bbl.

The remaining `db.update/create/insert(...).content(...)` and hand-rolled `{table}:⟨{uuid}⟩ CONTENT { ... }` call sites in `api/` would silently drop newly added struct fields, because the SurrealDB SDK's bespoke serializer collapses externally-tagged enums and `Option` fields. Same root cause as the `Item.rarity` regression fixed in #144. This PR migrates every remaining site to the safe pattern: build the body via `serde_json::to_value(&record)` and execute a bound `UPDATE $rid CONTENT $body` (or `CREATE table CONTENT $body`) query, which round-trips through the generic JSON path. RELATE edges are switched to raw query strings for the same reason.

## Changes

- `api/src/games.rs`
  - `create_game_area` (GameArea), `create_game` (Game), `add_item_to_area` (Item create)
  - `add_item_to_area` edge: raw `RELATE $area->items->$item`
  - Removed now-unused `AreaItemEdge` struct
- `api/src/tributes.rs`
  - `create_tribute` (Tribute), Item create
  - `playing_in` and `owns` edges: raw `RELATE` queries (consistency)
  - Removed now-unused `TributeGameEdge` struct
- `api/src/auth.rs`
  - `store_refresh_token`: bound `CREATE refresh_token CONTENT $body`

## Verification

- `cargo fmt --check` clean
- `cargo check -p api` clean
- `cargo clippy -p api -- -D warnings` clean
- `cargo test -p game` passes

## Follow-ups

None — this closes hangrier_games-bbl. The risk pattern (hand-rolled `CONTENT { ... }` queries that name fields explicitly) is documented in the issue notes as a thing to avoid going forward.