### PR TITLE
fix(game,web): drop contradictory move event and uncap Live Events list

### DIFF
--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -444,7 +444,11 @@ impl Tribute {
                                     self.area = destination;
                                     self.stamina = self.stamina.saturating_sub(info.stamina_cost);
                                 } else {
-                                    // Insufficient stamina - exhausted
+                                    // Insufficient stamina - exhausted. travels() already
+                                    // pushed a TributeMoves event optimistically; remove it
+                                    // so the log doesn't contradict itself ("moves from X"
+                                    // immediately followed by "too exhausted to move from X").
+                                    events.pop();
                                     self.short_rests();
                                     let line = GameOutput::TributeTravelExhausted(
                                         self.name.as_str(),

--- a/web/src/components/game_detail.rs
+++ b/web/src/components/game_detail.rs
@@ -203,7 +203,7 @@ pub fn GamePage(identifier: String) -> Element {
                 div {
                     class: "bg-gray-100 p-4 rounded-lg max-h-64 overflow-y-auto",
                     h3 { class: "font-bold mb-2", "Live Events" }
-                    for event in ws_events.read().iter().rev().take(10) {
+                    for event in ws_events.read().iter().rev() {
                         div { class: "text-sm py-1 border-b border-gray-200",
                             {format_game_event(event)}
                         }


### PR DESCRIPTION
## Summary

Closes hangrier_games-wbo. Two unrelated symptoms reported in the same bug:

- **Live Events panel only ever showed 10 entries.** The render loop in `web/src/components/game_detail.rs` was `.iter().rev().take(10)` even though `use_game_websocket` already buffers up to 200 events and the container has `max-h-64 overflow-y-auto`. The `take(10)` was just throwing data on the floor. Drop it; the scroll container handles overflow.
- **Logs contained contradictory pairs** like `Sandy Spencer is too exhausted to move from North, lacks stamina` immediately followed by `Sandy Spencer moves from North to Cornucopia`. Root cause: `Tribute::travels()` optimistically pushes the `TributeMoves` event when it returns `Success(destination)`, but the caller in `tributes/mod.rs::handle_action` then re-checks stamina against the per-destination `stamina_cost` and aborts the move on failure — leaving the move event in the log. Pop the trailing event when the stamina check fails so only the exhausted message remains.

## Changes

- `web/src/components/game_detail.rs`: drop `.take(10)` on Live Events render loop
- `game/src/tributes/mod.rs`: `events.pop()` before pushing `TributeTravelExhausted` so the previously-pushed `TributeMoves` doesn't survive

## Verification

- `cargo fmt --check` clean
- `cargo check -p game -p api` clean
- `cargo clippy -p game -p api -- -D warnings` clean
- `cargo test -p game` passes
- Web wasm target not installed locally; CI will cover

## Follow-ups

The optimistic-emit pattern in `Tribute::travels()` is the actual design smell here — `events.pop()` works because the success branches always push the move event last, but a future refactor should move event emission out of `travels()` entirely so the caller owns it. Not in scope for this fix.