### PR TITLE
chore(web): upgrade dioxus 0.6->0.7 and dioxus-query 0.7->0.9

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,6 +27,6 @@ RUN rustup target add wasm32-unknown-unknown \
     && rustup component add clippy rustfmt rust-src
 
 # Pre-install Dioxus CLI (matches justfile pin)
-RUN cargo install dioxus-cli@0.6.2 --locked
+RUN cargo install dioxus-cli@0.7.7 --locked
 
 USER root

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tungstenite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee88b4c88ac8c9ea446ad43498955750a4bbe64c4392f21ccfe5d952865e318f"
+dependencies = [
+ "atomic-waker",
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tungstenite 0.27.0",
+]
+
+[[package]]
 name = "async_io_stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +635,12 @@ dependencies = [
  "rustc-demangle",
  "windows-link",
 ]
+
+[[package]]
+name = "base16"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
 name = "base16ct"
@@ -914,6 +936,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +973,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "charset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
+dependencies = [
+ "base64 0.22.1",
+ "encoding_rs",
 ]
 
 [[package]]
@@ -1102,22 +1151,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1148,24 +1197,51 @@ dependencies = [
 
 [[package]]
 name = "const-serialize"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08259976d62c715c4826cb4a3d64a3a9e5c5f68f964ff6087319857f569f93a6"
+checksum = "ad7154afa56de2f290e3c82c2c6dc4f5b282b6870903f56ef3509aba95866edc"
 dependencies = [
- "const-serialize-macro",
+ "const-serialize-macro 0.7.2",
+]
+
+[[package]]
+name = "const-serialize"
+version = "0.8.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e42cd5aabba86f128b3763da1fec1491c0f728ce99245062cd49b6f9e6d235b"
+dependencies = [
+ "const-serialize 0.7.2",
+ "const-serialize-macro 0.8.0-alpha.0",
  "serde",
 ]
 
 [[package]]
 name = "const-serialize-macro"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04382d0d9df7434af6b1b49ea1a026ef39df1b0738b1cc373368cf175354f6eb"
+checksum = "4f160aad86b4343e8d4e261fee9965c3005b2fd6bc117d172ab65948779e4acf"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "const-serialize-macro"
+version = "0.8.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42571ed01eb46d2e1adcf99c8ca576f081e46f2623d13500eba70d1d99a4c439"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "const-str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0664d2867b4a32697dfe655557f5c3b187e9b605b38612a748e5ec99811d160"
 
 [[package]]
 name = "const_format"
@@ -1195,10 +1271,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "convert_case"
-version = "0.6.0"
+name = "content_disposition"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "ebc14a88e1463ddd193906285abe5c360c7e8564e05ccc5d501755f7fbc9ca9c"
+dependencies = [
+ "charset",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1209,8 +1303,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna 1.1.0",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1572,6 +1685,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,12 +1742,14 @@ dependencies = [
 
 [[package]]
 name = "dioxus"
-version = "0.6.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a247114500f1a78e87022defa8173de847accfada8e8809dfae23a118a580c"
+checksum = "daed3da3e7678d7267bc8523c607dbd19c970f4154cef30b9a58acf35e0a44d5"
 dependencies = [
+ "dioxus-asset-resolver",
  "dioxus-cli-config",
  "dioxus-config-macro",
+ "dioxus-config-macros",
  "dioxus-core",
  "dioxus-core-macro",
  "dioxus-devtools",
@@ -1623,58 +1761,88 @@ dependencies = [
  "dioxus-logger",
  "dioxus-router",
  "dioxus-signals",
+ "dioxus-stores",
  "dioxus-web",
  "manganis",
+ "subsecond",
  "warnings",
 ]
 
 [[package]]
-name = "dioxus-cli-config"
-version = "0.6.3"
+name = "dioxus-asset-resolver"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd16948f1ffdb068dd9a64812158073a4250e2af4e98ea31fdac0312e6bce86"
+checksum = "d28cf8859bac5946200df9dc0de8bdc3df60bec007e465dbd3684dbd05fc3ac7"
+dependencies = [
+ "dioxus-cli-config",
+ "http",
+ "infer",
+ "jni",
+ "js-sys",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "percent-encoding",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "dioxus-cli-config"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef4c22f0a239158f77966d7e7d39b637a10cb374cbd85f881704a336fd3f5c8"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "dioxus-config-macro"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cbf582fbb1c32d34a1042ea675469065574109c95154468710a4d73ee98b49"
+checksum = "b7a57abdf7bf60e22732a76588e75274ca4eb5d6399b716c735d187d743060b9"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "dioxus-core"
-version = "0.6.3"
+name = "dioxus-config-macros"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c03f451a119e47433c16e2d8eb5b15bf7d6e6734eb1a4c47574e6711dadff8d"
+checksum = "b571d361abed46996a489e88ced2a335f0ca608305e238859a1a6cca1d85fb15"
+
+[[package]]
+name = "dioxus-core"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1ff62d7073a4dd48670093469e2c099ef3c895345998a064554274eb39dc91"
 dependencies = [
+ "anyhow",
  "const_format",
  "dioxus-core-types",
  "futures-channel",
  "futures-util",
  "generational-box",
  "longest-increasing-subsequence",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.2",
  "rustversion",
  "serde",
  "slab",
  "slotmap",
+ "subsecond",
  "tracing",
- "warnings",
 ]
 
 [[package]]
 name = "dioxus-core-macro"
-version = "0.6.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105c954caaaedf8cd10f3d1ba576b01e18aa8d33ad435182125eefe488cf0064"
+checksum = "5e22483ccaaf037e600683f25a6114754b9610e85e6fafb11adf45ccc2bd7116"
 dependencies = [
- "convert_case",
+ "convert_case 0.8.0",
  "dioxus-rsx",
  "proc-macro2",
  "quote",
@@ -1683,44 +1851,44 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-types"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a82fccfa48574eb7aa183e297769540904694844598433a9eb55896ad9f93b"
-dependencies = [
- "once_cell",
-]
+checksum = "a1a47a4908cc9680a27b314aa8c3832a517274f896a31b0cce7d7adee57eacbb"
 
 [[package]]
 name = "dioxus-devtools"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a7300f1e8181218187b03502044157eef04e0a25b518117c5ef9ae1096880"
+checksum = "58abe580e75d1e6bbab658681b126d4a79df3e9c9fd66d0a0627206d1669f65d"
 dependencies = [
+ "dioxus-cli-config",
  "dioxus-core",
  "dioxus-devtools-types",
  "dioxus-signals",
  "serde",
  "serde_json",
+ "subsecond",
+ "thiserror 2.0.18",
  "tracing",
- "tungstenite 0.23.0",
- "warnings",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
 name = "dioxus-devtools-types"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62434973c0c9c5a3bc42e9cd5e7070401c2062a437fb5528f318c3e42ebf4ff"
+checksum = "5678f9f53962936765d0d767c13200bc6911a943492b8614d666425da62662d2"
 dependencies = [
  "dioxus-core",
  "serde",
+ "subsecond-types",
 ]
 
 [[package]]
 name = "dioxus-document"
-version = "0.6.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802a2014d1662b6615eec0a275745822ee4fc66aacd9d0f2fb33d6c8da79b8f2"
+checksum = "28eea4bea227f6eb0852ab67ed97a20474f234e8bb2a6abab17401d443aa746c"
 dependencies = [
  "dioxus-core",
  "dioxus-core-macro",
@@ -1737,33 +1905,108 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack"
-version = "0.6.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe99b48a1348eec385b5c4bd3e80fd863b0d3b47257d34e2ddc58754dec5d128"
+checksum = "a75d9db5bb54c6305ed3f1cd71ea245a9935126f7586faf92950b40be76be5ae"
 dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-tungstenite",
+ "axum",
+ "axum-core",
  "base64 0.22.1",
  "bytes",
  "ciborium",
- "dioxus-devtools",
+ "const-str",
+ "const_format",
+ "content_disposition",
+ "derive_more",
+ "dioxus-asset-resolver",
+ "dioxus-cli-config",
+ "dioxus-core",
+ "dioxus-fullstack-core",
+ "dioxus-fullstack-macro",
+ "dioxus-hooks",
+ "dioxus-html",
+ "dioxus-signals",
+ "form_urlencoded",
+ "futures",
+ "futures-channel",
+ "futures-util",
+ "gloo-net",
+ "headers",
+ "http",
+ "http-body",
+ "http-body-util",
+ "js-sys",
+ "mime",
+ "pin-project",
+ "reqwest",
+ "rustversion",
+ "send_wrapper",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio-util",
+ "tracing",
+ "tungstenite 0.27.0",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "dioxus-fullstack-core"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a1d1f1ff784a78709f95b5021888bcd6bb2a4acf972213acd23c1a8a69701b1"
+dependencies = [
+ "anyhow",
+ "axum-core",
+ "base64 0.22.1",
+ "ciborium",
+ "dioxus-core",
+ "dioxus-document",
  "dioxus-history",
- "dioxus-lib",
- "dioxus-web",
- "dioxus_server_macro",
+ "dioxus-hooks",
+ "dioxus-signals",
  "futures-channel",
  "futures-util",
  "generational-box",
- "once_cell",
+ "http",
+ "inventory",
+ "parking_lot",
  "serde",
- "server_fn",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing",
- "web-sys",
+]
+
+[[package]]
+name = "dioxus-fullstack-macro"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8927db4a9d939677a921eccf2ed36762f05b2e624787f2ef3c095fabc6e6c1c4"
+dependencies = [
+ "const_format",
+ "convert_case 0.8.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "dioxus-history"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae4e22616c698f35b60727313134955d885de2d32e83689258e586ebc9b7909"
+checksum = "5e304644c2131e00c4a58ecd91e8f7f86dba007532732bd1a391506b75a974a9"
 dependencies = [
  "dioxus-core",
  "tracing",
@@ -1771,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-hooks"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948e2b3f20d9d4b2c300aaa60281b1755f3298684448920b27106da5841896d0"
+checksum = "50506e568a9786247993a29dd3b06fd84f30605312beea2b5f4e51f4ab543b0c"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -1783,16 +2026,16 @@ dependencies = [
  "rustversion",
  "slab",
  "tracing",
- "warnings",
 ]
 
 [[package]]
 name = "dioxus-html"
-version = "0.6.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c9a40e6fee20ce7990095492dedb6a753eebe05e67d28271a249de74dc796d"
+checksum = "84c52bdcc2355437ca8bd9986aa1c43c5439af459a2c16012d949b6a35092ae2"
 dependencies = [
  "async-trait",
+ "bytes",
  "dioxus-core",
  "dioxus-core-macro",
  "dioxus-core-types",
@@ -1801,6 +2044,7 @@ dependencies = [
  "enumset",
  "euclid",
  "futures-channel",
+ "futures-util",
  "generational-box",
  "keyboard-types",
  "lazy-js-bundle",
@@ -1810,11 +2054,11 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html-internal-macro"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ba87b53688a2c9f619ecdf4b3b955bc1f08bd0570a80a0d626c405f6d14a76"
+checksum = "f4a48657a6a20a65894abba7e7876937e37e924ecaed63e8b654b364c4ffa133"
 dependencies = [
- "convert_case",
+ "convert_case 0.8.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1822,13 +2066,13 @@ dependencies = [
 
 [[package]]
 name = "dioxus-interpreter-js"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330707b10ca75cb0eb05f9e5f8d80217cd0d7e62116a8277ae363c1a09b57a22"
+checksum = "56a36364418afcb181e19c67d9dbea766dbc2e6bfc0751365a60727ebe665362"
 dependencies = [
  "js-sys",
  "lazy-js-bundle",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.2",
  "sledgehammer_bindgen",
  "sledgehammer_utils",
  "wasm-bindgen",
@@ -1837,30 +2081,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "dioxus-lib"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5405b71aa9b8b0c3e0d22728f12f34217ca5277792bd315878cc6ecab7301b72"
-dependencies = [
- "dioxus-config-macro",
- "dioxus-core",
- "dioxus-core-macro",
- "dioxus-document",
- "dioxus-history",
- "dioxus-hooks",
- "dioxus-html",
- "dioxus-rsx",
- "dioxus-signals",
- "warnings",
-]
-
-[[package]]
 name = "dioxus-logger"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545961e752f6c8bf59c274951b3c8b18a106db6ad2f9e2035b29e1f2a3e899b1"
+checksum = "32720fddff9b73266502b15b2c36b139bd8fbfd5b85b67d29ba06d5b4ed60669"
 dependencies = [
- "console_error_panic_hook",
  "dioxus-cli-config",
  "tracing",
  "tracing-subscriber",
@@ -1869,81 +2094,112 @@ dependencies = [
 
 [[package]]
 name = "dioxus-query"
-version = "0.7.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3096937c513bc133a7dfb162db216fa1af75d8416b2ec88a1067f128cc1b8ef8"
+checksum = "1687bf3395690b561faa1452dba2c7e428b5d8c616d4e8622c33316c689d7697"
 dependencies = [
- "dioxus-lib",
+ "dioxus",
+ "dioxus-core",
  "futures-util",
- "instant",
- "warnings",
+ "tokio",
+ "wasmtimer 0.4.3",
+ "web-time",
 ]
 
 [[package]]
 name = "dioxus-router"
-version = "0.6.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7266a76fc9e4a91f56499d1d1aecfff7168952b6627a6008b4e9748d6bf863e4"
+checksum = "74cbe73ab4e815aacaa41726d25b84a2debacade3f35db357495dd1d5ed14949"
 dependencies = [
  "dioxus-cli-config",
+ "dioxus-core",
+ "dioxus-core-macro",
  "dioxus-history",
- "dioxus-lib",
+ "dioxus-hooks",
+ "dioxus-html",
  "dioxus-router-macro",
+ "dioxus-signals",
+ "percent-encoding",
  "rustversion",
  "tracing",
  "url",
- "urlencoding",
 ]
 
 [[package]]
 name = "dioxus-router-macro"
-version = "0.6.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2743ffb79e9a7d33d779c87d6deea2a6c047d0736012f95d63b909b83f0a6fd2"
+checksum = "74b91aa613f584c2dd598436c33d22b94b85b132b449eae8f81e538300980222"
 dependencies = [
+ "base16",
+ "digest",
  "proc-macro2",
  "quote",
+ "sha2",
  "slab",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "dioxus-rsx"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb588e05800b5a7eb90b2f40fca5bbd7626e823fb5e1ba21e011de649b45aa1"
+checksum = "767e37207d120b978643f5d1f68675984dfa68d44ceb4dab3d4337b36695d339"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
+ "rustversion",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "dioxus-signals"
-version = "0.6.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10e032dbb3a2c0386ec8b8ee59bc20b5aeb67038147c855801237b45b13d72ac"
+checksum = "0ef8e274214375597ad26a2e4407b681de4f876785724171ab605a51b272c51e"
 dependencies = [
  "dioxus-core",
  "futures-channel",
  "futures-util",
  "generational-box",
- "once_cell",
  "parking_lot",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.2",
  "tracing",
  "warnings",
 ]
 
 [[package]]
-name = "dioxus-web"
-version = "0.6.3"
+name = "dioxus-stores"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7c12475c3d360058b8afe1b68eb6dfc9cbb7dcd760aed37c5f85c561c83ed1"
+checksum = "96a6a8e92a6df3b3e875f268a2f20d2aeaf017fc952af86810b4d4e435b9a8c1"
 dependencies = [
- "async-trait",
- "ciborium",
+ "dioxus-core",
+ "dioxus-signals",
+ "dioxus-stores-macro",
+ "generational-box",
+]
+
+[[package]]
+name = "dioxus-stores-macro"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb44211a301fd4ddcb21b9c46807658690c2d5a52a7313393001090764ca1ab"
+dependencies = [
+ "convert_case 0.8.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dioxus-web"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e3fcfea97e9a1755d06a38c05e9d8b19fd09228ede36f2c9cfab69891c628"
+dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
  "dioxus-core-types",
@@ -1956,28 +2212,19 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
+ "gloo-timers",
  "js-sys",
  "lazy-js-bundle",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.2",
+ "send_wrapper",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "dioxus_server_macro"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "371a5b21989a06b53c5092e977b3f75d0e60a65a4c15a2aa1d07014c3b2dda97"
-dependencies = [
- "proc-macro2",
- "quote",
- "server_fn_macro",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2029,6 +2276,15 @@ checksum = "bb2dfc7a18dffd3ef60a442b72a827126f1557d914620f8fc4d1049916da43c1"
 dependencies = [
  "trice",
  "urlencoding",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2549,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "generational-box"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a673cf4fb0ea6a91aa86c08695756dfe875277a912cdbf33db9a9f62d47ed82b"
+checksum = "155c81d7c7cae205289a26248ede524fdb1b7266b1fdb0a479b57bd3a6db2235"
 dependencies = [
  "parking_lot",
  "tracing",
@@ -2719,6 +2975,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-utils"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,6 +3136,30 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heapless"
@@ -3307,24 +3599,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array 0.14.9",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3407,6 +3696,50 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -3557,9 +3890,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-js-bundle"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49596223b9d9d4947a14a25c142a6e7d8ab3f27eb3ade269d238bb8b5c267e2"
+checksum = "76317b9348f1c069d7e652722c3fa86683ec047ba4c1551bde1daa576ce3807e"
 
 [[package]]
 name = "lazy_static"
@@ -3601,6 +3934,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,6 +3981,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -3682,35 +4031,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
-name = "manganis"
-version = "0.6.2"
+name = "macro-string"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317af44b15e7605b85f04525449a3bb631753040156c9b318e6cba8a3ea4ef73"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
- "const-serialize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "manganis"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652dba76564ebccd550649b3db9ed608bb5cabfccbe90113c56783649f324eab"
+dependencies = [
+ "const-serialize 0.7.2",
+ "const-serialize 0.8.0-alpha.0",
+ "jni",
  "manganis-core",
  "manganis-macro",
+ "ndk-context",
+ "objc2",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "manganis-core"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38bee65cc725b2bba23b5dbb290f57c8be8fadbe2043fb7e2ce73022ea06519"
+checksum = "d7d13cbb4dc790c31565bf49a418e6f441e66130d66aefe9239636e02ab3ebd4"
 dependencies = [
- "const-serialize",
+ "const-serialize 0.7.2",
+ "const-serialize 0.8.0-alpha.0",
  "dioxus-cli-config",
  "dioxus-core-types",
  "serde",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "manganis-macro"
-version = "0.6.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f4f71310913c40174d9f0cfcbcb127dad0329ecdb3945678a120db22d3d065"
+checksum = "b234972a38639be3b753809ba1d8060ef08b548d07d07cc0c3030aab0c30c132"
 dependencies = [
  "dunce",
+ "macro-string",
  "manganis-core",
  "proc-macro2",
  "quote",
@@ -3785,6 +4153,24 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miette"
@@ -3906,6 +4292,36 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.6",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -4078,6 +4494,43 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object"
@@ -4687,6 +5140,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna 1.1.0",
+ "psl-types",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4904,6 +5367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5033,6 +5502,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -5651,9 +6122,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.5.0"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
 dependencies = [
  "js-sys",
  "serde",
@@ -5718,13 +6189,13 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.12.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
+checksum = "f3faaf9e727533a19351a43cc5a8de957372163c7d35cc48c90b75cdda13c352"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5767,58 +6238,6 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "server_fn"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fae7a3038a32e5a34ba32c6c45eb4852f8affaf8b794ebfcd4b1099e2d62ebe"
-dependencies = [
- "bytes",
- "const_format",
- "dashmap 5.5.3",
- "futures",
- "gloo-net",
- "http",
- "js-sys",
- "once_cell",
- "send_wrapper",
- "serde",
- "serde_json",
- "serde_qs",
- "server_fn_macro_default",
- "thiserror 1.0.69",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "xxhash-rust",
-]
-
-[[package]]
-name = "server_fn_macro"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaaf648c6967aef78177c0610478abb5a3455811f401f3c62d10ae9bd3901a1"
-dependencies = [
- "const_format",
- "convert_case",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "xxhash-rust",
-]
-
-[[package]]
-name = "server_fn_macro_default"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2aa8119b558a17992e0ac1fd07f080099564f24532858811ce04f742542440"
-dependencies = [
- "server_fn_macro",
  "syn 2.0.117",
 ]
 
@@ -6126,6 +6545,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "subsecond"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a046b8921cd8a8b3bbeba6339d4ea8cc687653b30c73a158ed4d730d402199db"
+dependencies = [
+ "js-sys",
+ "libc",
+ "libloading",
+ "memfd",
+ "memmap2",
+ "serde",
+ "subsecond-types",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "subsecond-types"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3c20eb7361e08d071ee249a687cddf16a1ae9d36f9bcd92481f31d6ac17eee"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6188,7 +6635,7 @@ dependencies = [
  "url",
  "uuid",
  "wasm-bindgen-futures",
- "wasmtimer",
+ "wasmtimer 0.2.1",
  "ws_stream_wasm",
 ]
 
@@ -6281,7 +6728,7 @@ dependencies = [
  "uuid",
  "vart 0.8.1",
  "wasm-bindgen-futures",
- "wasmtimer",
+ "wasmtimer 0.2.1",
  "ws_stream_wasm",
 ]
 
@@ -6707,6 +7154,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -6729,7 +7177,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6738,7 +7186,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6985,6 +7433,40 @@ name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -7435,12 +7917,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web"
 version = "0.1.19"
 dependencies = [
  "chrono",
  "dioxus",
- "dioxus-logger",
  "dioxus-query",
  "dotenvy",
  "futures-util",
@@ -7664,6 +8159,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7687,6 +8191,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7724,6 +8243,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7736,6 +8261,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7745,6 +8276,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7772,6 +8309,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7781,6 +8324,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7796,6 +8345,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7808,6 +8363,12 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -7817,6 +8378,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/justfile
+++ b/justfile
@@ -118,7 +118,7 @@ quality: fmt check clippy test
 
 # Install Dioxus CLI
 setup-dx:
-    cargo install dioxus-cli@0.6.2 --locked
+    cargo install dioxus-cli@0.7.7 --locked
 
 # Create Ollama announcer model
 setup-ollama:

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -124,11 +124,11 @@ pub struct CreateGame {
 }
 
 pub type DeleteTribute = String;
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct DeleteGame(pub String, pub String); // Identifier, name
 
 /// Used to edit a tribute. Contains the identifier, name, avatar, and game identifier of the tribute.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize, Validate)]
 pub struct EditTribute {
     #[validate(custom(function = "validate_uuid"))]
     pub identifier: String,
@@ -164,7 +164,7 @@ impl EditTribute {
 
 /// This struct is used to edit a game
 /// It contains the identifier, name, and a boolean indicating if the game is private
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Validate)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, Hash, PartialEq, Validate)]
 pub struct EditGame {
     #[validate(custom(function = "validate_uuid"))]
     pub identifier: String,
@@ -180,7 +180,7 @@ pub struct GameArea {
     pub area: String,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize, Validate)]
 pub struct RegistrationUser {
     #[validate(length(min = 3, max = 50, message = "Username must be 3-50 characters"))]
     pub username: String,

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -5,9 +5,8 @@ edition = "2024"
 
 [dependencies]
 chrono = "0.4.44"
-dioxus = { version = "0.6.3", features = ["web", "router"] }
-dioxus-logger = "0.6.2"
-dioxus-query = "0.7.0"
+dioxus = { version = "0.7.0", features = ["web", "router"] }
+dioxus-query = "0.9.2"
 futures-util = { version = "0.3.32", features = ["sink"] }
 game = { path = "../game" }
 gloo-net = "0.6"

--- a/web/src/auth.rs
+++ b/web/src/auth.rs
@@ -67,7 +67,7 @@ pub async fn maybe_refresh_token(storage: &mut UsePersistent<AppState>) -> Optio
     let remaining = match token_seconds_remaining(&jwt) {
         Some(r) => r,
         None => {
-            dioxus_logger::tracing::warn!("could not decode stored JWT; clearing session");
+            tracing::warn!("could not decode stored JWT; clearing session");
             clear_session(storage);
             return None;
         }
@@ -78,7 +78,7 @@ pub async fn maybe_refresh_token(storage: &mut UsePersistent<AppState>) -> Optio
     }
 
     let Some(refresh) = state.refresh_token.clone() else {
-        dioxus_logger::tracing::info!(
+        tracing::info!(
             "access token expiring (remaining={}s) but no refresh token; clearing session",
             remaining
         );
@@ -92,11 +92,11 @@ pub async fn maybe_refresh_token(storage: &mut UsePersistent<AppState>) -> Optio
             new_state.jwt = Some(new_access.clone());
             new_state.refresh_token = Some(new_refresh);
             storage.set(new_state);
-            dioxus_logger::tracing::debug!("rotated access token");
+            tracing::debug!("rotated access token");
             Some(new_access)
         }
         Err(e) => {
-            dioxus_logger::tracing::warn!("refresh failed: {e}; clearing session");
+            tracing::warn!("refresh failed: {e}; clearing session");
             clear_session(storage);
             None
         }

--- a/web/src/cache.rs
+++ b/web/src/cache.rs
@@ -1,28 +1,5 @@
-use game::areas::AreaDetails;
-use game::games::Game;
-use game::messages::GameMessage;
-use game::tributes::Tribute;
-use shared::{AuthenticatedUser, DisplayGame};
-
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) enum QueryKey {
-    AllGames,
-    DisplayGame(String),
-    _DisplayGames,
-    Game(String),
-    Games,
-    Tributes(String),
-    Areas(String),
-    Tribute(String, String),     // Game identifier, tribute identifier
-    GameDayLog(String, u32),     // Game identifier, day (PR2: timeline UI)
-    TributeLog(String),          // Tribute identifier
-    _TributeDayLog(String, u32), // Tribute identifier, day
-    TimelineSummary(String),     // Game identifier (PR2: timeline UI)
-    User,
-    ServerVersion,
-}
-
-#[derive(PartialEq, Debug)]
+#[allow(dead_code)]
+#[derive(PartialEq, Debug, Clone)]
 pub(crate) enum QueryError {
     BadJson,
     GameNotFound(String),
@@ -35,41 +12,7 @@ pub(crate) enum QueryError {
 }
 
 #[allow(dead_code)]
-#[derive(PartialEq, Debug)]
-pub(crate) enum QueryValue {
-    Areas(Vec<AreaDetails>),
-    DisplayGame(Box<DisplayGame>),
-    DisplayGames(Vec<DisplayGame>),
-    Game(Box<Game>),
-    Games(Vec<Game>),
-    Tribute(Box<Tribute>),
-    Tributes(Vec<Tribute>),
-    Logs(Vec<GameMessage>),
-    ServerVersion(String),
-    TimelineSummary(shared::messages::TimelineSummary),
-    // Pagination variants
-    PaginatedGames(super::components::games_list::PaginatedGamesResponse),
-    PaginatedTributes(super::components::game_tributes::PaginatedTributesResponse),
-}
-
-#[allow(dead_code)]
-#[allow(clippy::large_enum_variant)]
-#[derive(PartialEq, Debug)]
-pub(crate) enum MutationValue {
-    NewGame(Game),
-    GameDeleted(String, String), // Identifier, name
-    TributeDeleted(String),
-    TributeUpdated(String),
-    GameUpdated(String),
-    GameFinished(String),
-    GameStarted(String),
-    GameAdvanced(String),
-    User(AuthenticatedUser),
-    GamePublished(String),
-    GameUnpublished(String),
-}
-
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub(crate) enum MutationError {
     UnableToCreateGame,
     Unknown,

--- a/web/src/components/accounts.rs
+++ b/web/src/components/accounts.rs
@@ -1,59 +1,74 @@
-use crate::cache::{MutationError, MutationValue, QueryError, QueryKey, QueryValue};
+use crate::cache::MutationError;
 use crate::components::{Input, ThemedButton};
 use crate::env::APP_API_HOST;
 use crate::routes::Routes;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::{MutationResult, MutationState, use_mutation, use_query_client};
+use dioxus_query::prelude::*;
 use shared::{AuthenticatedUser, RegistrationUser};
-use std::ops::Deref;
 
-async fn register_user(user: RegistrationUser) -> MutationResult<MutationValue, MutationError> {
-    let client = reqwest::Client::new();
-    let json_body = serde_json::json!({
-        "username": user.username,
-        "password": user.password,
-    });
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RegisterUserM;
 
-    let response = client
-        .post(format!("{}/api/users", APP_API_HOST))
-        .json(&json_body)
-        .send()
-        .await;
+impl MutationCapability for RegisterUserM {
+    type Ok = AuthenticatedUser;
+    type Err = MutationError;
+    type Keys = RegistrationUser;
 
-    match response {
-        Ok(response) => match response.json::<AuthenticatedUser>().await {
-            Ok(user) => MutationResult::Ok(MutationValue::User(user)),
-            Err(_) => MutationResult::Err(MutationError::UnableToRegisterUser),
-        },
-        Err(e) => {
-            dioxus_logger::tracing::error!("error creating user: {:?}", e);
-            MutationResult::Err(MutationError::UnableToRegisterUser)
+    async fn run(&self, user: &RegistrationUser) -> Result<AuthenticatedUser, MutationError> {
+        let client = reqwest::Client::new();
+        let json_body = serde_json::json!({
+            "username": user.username,
+            "password": user.password,
+        });
+
+        match client
+            .post(format!("{}/api/users", APP_API_HOST))
+            .json(&json_body)
+            .send()
+            .await
+        {
+            Ok(response) => match response.json::<AuthenticatedUser>().await {
+                Ok(user) => Ok(user),
+                Err(_) => Err(MutationError::UnableToRegisterUser),
+            },
+            Err(e) => {
+                tracing::error!("error creating user: {:?}", e);
+                Err(MutationError::UnableToRegisterUser)
+            }
         }
     }
 }
 
-async fn authenticate_user(user: RegistrationUser) -> MutationResult<MutationValue, MutationError> {
-    let client = reqwest::Client::new();
-    let json_body = serde_json::json!({
-        "username": user.username,
-        "password": user.password,
-    });
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct LoginUserM;
 
-    let response = client
-        .post(format!("{}/api/users/authenticate", APP_API_HOST))
-        .json(&json_body)
-        .send()
-        .await;
+impl MutationCapability for LoginUserM {
+    type Ok = AuthenticatedUser;
+    type Err = MutationError;
+    type Keys = RegistrationUser;
 
-    match response {
-        Ok(response) => match response.json::<AuthenticatedUser>().await {
-            Ok(user) => MutationResult::Ok(MutationValue::User(user)),
-            Err(_) => MutationResult::Err(MutationError::UnableToAuthenticateUser),
-        },
-        Err(e) => {
-            dioxus_logger::tracing::error!("error authenticating user: {:?}", e);
-            MutationResult::Err(MutationError::UnableToAuthenticateUser)
+    async fn run(&self, user: &RegistrationUser) -> Result<AuthenticatedUser, MutationError> {
+        let client = reqwest::Client::new();
+        let json_body = serde_json::json!({
+            "username": user.username,
+            "password": user.password,
+        });
+
+        match client
+            .post(format!("{}/api/users/authenticate", APP_API_HOST))
+            .json(&json_body)
+            .send()
+            .await
+        {
+            Ok(response) => match response.json::<AuthenticatedUser>().await {
+                Ok(user) => Ok(user),
+                Err(_) => Err(MutationError::UnableToAuthenticateUser),
+            },
+            Err(e) => {
+                tracing::error!("error authenticating user: {:?}", e);
+                Err(MutationError::UnableToAuthenticateUser)
+            }
         }
     }
 }
@@ -103,17 +118,16 @@ pub fn AccountsPage() -> Element {
 
 #[component]
 fn LoginForm() -> Element {
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
-
     let mut username_signal = use_signal(String::default);
     let mut password_signal = use_signal(String::default);
     let mut disabled_signal = use_signal(|| false);
     let mut username_error_signal = use_signal(String::default);
     let mut password_error_signal = use_signal(String::default);
 
-    let mutate = use_mutation(authenticate_user);
+    let mutate = use_mutation(Mutation::new(LoginUserM));
 
     let mut storage = use_persistent("hangry-games", AppState::default);
+    let navigator = use_navigator();
 
     rsx! {
         div {
@@ -157,31 +171,30 @@ fn LoginForm() -> Element {
                                 username: username.clone(),
                                 password: password.clone(),
                             };
-                            mutate.mutate_async(user).await;
-                            if let MutationState::Settled(Ok(result)) = mutate.result().deref() {
-                                if let MutationValue::User(user) = result {
-                                        client.invalidate_queries(&[QueryKey::User]);
-                                        disabled_signal.set(false);
-                                        username_signal.set(String::default());
-                                        password_signal.set(String::default());
-                                        password_error_signal.set(String::default());
-                                        username_error_signal.set(String::default());
+                            let reader = mutate.mutate_async(user).await;
+                            let state = reader.state();
+                            match &*state {
+                                MutationStateData::Settled { res: Ok(user), .. } => {
+                                    disabled_signal.set(false);
+                                    username_signal.set(String::default());
+                                    password_signal.set(String::default());
+                                    password_error_signal.set(String::default());
+                                    username_error_signal.set(String::default());
 
-                                        let mut state = storage.get();
-                                        state.jwt = Some(user.jwt.clone());
-                                        state.refresh_token = user.refresh_token.clone();
-                                        state.username = Some(username.clone());
-                                        storage.set(state);
+                                    let mut state = storage.get();
+                                    state.jwt = Some(user.jwt.clone());
+                                    state.refresh_token = user.refresh_token.clone();
+                                    state.username = Some(username.clone());
+                                    storage.set(state);
 
-                                        let navigator = use_navigator();
-                                        navigator.replace(Routes::GamesList {});
+                                    navigator.replace(Routes::GamesList {});
                                 }
-                            } else if let MutationState::Settled(Err(err)) = mutate.result().deref()
-                                && let MutationError::UnableToAuthenticateUser = err {
-                                        username_error_signal.set("Unable to authenticate user".to_string());
-                                        disabled_signal.set(false);
-
+                                MutationStateData::Settled { res: Err(MutationError::UnableToAuthenticateUser), .. } => {
+                                    username_error_signal.set("Unable to authenticate user".to_string());
+                                    disabled_signal.set(false);
                                 }
+                                _ => {}
+                            }
                         });
                     }
                 },
@@ -237,8 +250,6 @@ fn LoginForm() -> Element {
 
 #[component]
 fn RegisterForm() -> Element {
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
-
     let mut username_signal = use_signal(String::default);
     let mut password_signal = use_signal(String::default);
     let mut password2_signal = use_signal(String::default);
@@ -246,9 +257,10 @@ fn RegisterForm() -> Element {
     let mut username_error_signal = use_signal(String::default);
     let mut password_error_signal = use_signal(String::default);
 
-    let mutate = use_mutation(register_user);
+    let mutate = use_mutation(Mutation::new(RegisterUserM));
 
     let mut storage = use_persistent("hangry-games", AppState::default);
+    let navigator = use_navigator();
 
     rsx! {
         div {
@@ -296,10 +308,10 @@ fn RegisterForm() -> Element {
                                 username: username.clone(),
                                 password: password.clone(),
                             };
-                            mutate.mutate_async(user).await;
-                            match mutate.result().deref() {
-                                MutationState::Settled(Ok(MutationValue::User(user))) => {
-                                    client.invalidate_queries(&[QueryKey::User]);
+                            let reader = mutate.mutate_async(user).await;
+                            let state = reader.state();
+                            match &*state {
+                                MutationStateData::Settled { res: Ok(user), .. } => {
                                     disabled_signal.set(false);
                                     username_signal.set(String::default());
                                     password_signal.set(String::default());
@@ -313,15 +325,14 @@ fn RegisterForm() -> Element {
                                     state.username = Some(username.clone());
                                     storage.set(state);
 
-                                    let navigator = use_navigator();
                                     navigator.replace(Routes::GamesList {});
-                                },
-                                MutationState::Settled(Err(err)) => {
+                                }
+                                MutationStateData::Settled { res: Err(err), .. } => {
                                     if let MutationError::UnableToRegisterUser = err {
                                         username_error_signal.set("Unable to register user".to_string());
                                     }
                                     disabled_signal.set(false);
-                                },
+                                }
                                 _ => {}
                             }
                         });
@@ -393,6 +404,7 @@ fn LogoutButton() -> Element {
         .username
         .clone()
         .unwrap_or("whoever you are".to_string());
+    let navigator = use_navigator();
 
     rsx! {
         form {
@@ -405,9 +417,6 @@ fn LogoutButton() -> Element {
                 state.refresh_token = None;
                 storage.set(state);
 
-                // Best-effort revoke the refresh token on the server so it
-                // can't be reused if it leaks. Failures here are intentionally
-                // ignored — the local session is gone either way.
                 if let Some(token) = prior_refresh {
                     spawn(async move {
                         let _ = reqwest::Client::new()
@@ -418,7 +427,6 @@ fn LogoutButton() -> Element {
                     });
                 }
 
-                let navigator = use_navigator();
                 navigator.replace(Routes::Home {});
             },
             p {

--- a/web/src/components/app.rs
+++ b/web/src/components/app.rs
@@ -1,5 +1,4 @@
 use crate::LoadingState;
-use crate::cache::{QueryError, QueryKey, QueryValue};
 use crate::components::game_edit::EditGameModal;
 use crate::components::icons::svg_icon::SpriteSheetLoader;
 use crate::components::loading_modal::LoadingModal;
@@ -8,14 +7,11 @@ use crate::components::tribute_edit::EditTributeModal;
 use crate::routes::Routes;
 use crate::storage::{AppState, Colorscheme, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::use_init_query_client;
 use game::games::Game;
 use shared::{DeleteGame, EditGame, EditTribute};
 
 #[component]
 pub fn App() -> Element {
-    use_init_query_client::<QueryValue, QueryError, QueryKey>();
-
     let storage = use_persistent("hangry-games", AppState::default);
 
     let loading_signal: Signal<LoadingState> = use_signal(LoadingState::default);

--- a/web/src/components/create_game.rs
+++ b/web/src/components/create_game.rs
@@ -1,65 +1,64 @@
 use crate::LoadingState;
-use crate::cache::{MutationError, MutationValue, QueryError, QueryKey, QueryValue};
+use crate::cache::MutationError;
+use crate::components::games_list::GamesListQ;
 use crate::components::{Input, ThemedButton};
 use crate::env::APP_API_HOST;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::{MutationResult, MutationState, use_mutation, use_query_client};
+use dioxus_query::prelude::*;
 use game::games::Game;
 use shared::CreateGame;
-use std::ops::Deref;
 
-// TODO: Game Customization Enhancement
-// To add ItemQuantity and EventFrequency dropdowns:
-// 1. Import: use shared::{ItemQuantity, EventFrequency};
-// 2. Add signals in CreateGameForm:
-//    let mut item_quantity: Signal<ItemQuantity> = use_signal(|| ItemQuantity::Normal);
-//    let mut event_frequency: Signal<EventFrequency> = use_signal(|| EventFrequency::Normal);
-// 3. Create dropdown components for each option
-// 4. Modify create_game() to accept and send these parameters to the API
-// 5. Update Game::new() to accept CreateGame DTO instead of just name
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CreateGameM;
 
-async fn create_game(
-    args: (Option<String>, String),
-) -> MutationResult<MutationValue, MutationError> {
-    let name = args.0.clone();
-    let token = args.1.clone();
-    let client = reqwest::Client::new();
-    let json_body = CreateGame {
-        name,
-        item_quantity: Default::default(),
-        event_frequency: Default::default(),
-        starting_health_range: None,
-    };
+impl MutationCapability for CreateGameM {
+    type Ok = Game;
+    type Err = MutationError;
+    type Keys = (Option<String>, String);
 
-    let response = client
-        .request(reqwest::Method::POST, format!("{}/api/games", APP_API_HOST))
-        .bearer_auth(token)
-        .json(&json_body);
+    async fn run(&self, args: &Self::Keys) -> Result<Game, MutationError> {
+        let name = args.0.clone();
+        let token = args.1.clone();
+        let client = reqwest::Client::new();
+        let json_body = CreateGame {
+            name,
+            item_quantity: Default::default(),
+            event_frequency: Default::default(),
+            starting_health_range: None,
+        };
 
-    match response.send().await {
-        Ok(response) => {
-            let status = response.status();
-            if !status.is_success() {
-                let body = response.text().await.unwrap_or_default();
-                dioxus_logger::tracing::error!(
-                    "create_game failed: status={} body={}",
-                    status,
-                    body
-                );
-                return MutationResult::Err(MutationError::UnableToCreateGame);
-            }
-            match response.json::<Game>().await {
-                Ok(game) => MutationResult::Ok(MutationValue::NewGame(game)),
-                Err(e) => {
-                    dioxus_logger::tracing::error!("create_game parse error: {:?}", e);
-                    MutationResult::Err(MutationError::UnableToCreateGame)
+        let response = client
+            .request(reqwest::Method::POST, format!("{}/api/games", APP_API_HOST))
+            .bearer_auth(token)
+            .json(&json_body);
+
+        match response.send().await {
+            Ok(response) => {
+                let status = response.status();
+                if !status.is_success() {
+                    let body = response.text().await.unwrap_or_default();
+                    tracing::error!("create_game failed: status={} body={}", status, body);
+                    return Err(MutationError::UnableToCreateGame);
+                }
+                match response.json::<Game>().await {
+                    Ok(game) => Ok(game),
+                    Err(e) => {
+                        tracing::error!("create_game parse error: {:?}", e);
+                        Err(MutationError::UnableToCreateGame)
+                    }
                 }
             }
+            Err(e) => {
+                tracing::error!("error creating game: {:?}", e);
+                Err(MutationError::UnableToCreateGame)
+            }
         }
-        Err(e) => {
-            dioxus_logger::tracing::error!("error creating game: {:?}", e);
-            MutationResult::Err(MutationError::UnableToCreateGame)
+    }
+
+    async fn on_settled(&self, _keys: &Self::Keys, result: &Result<Game, MutationError>) {
+        if result.is_ok() {
+            QueriesStorage::<GamesListQ>::invalidate_all().await;
         }
     }
 }
@@ -67,20 +66,14 @@ async fn create_game(
 #[component]
 pub fn CreateGameButton() -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
-    let mutate = use_mutation(create_game);
+    let mutate = use_mutation(Mutation::new(CreateGameM));
     let mut loading_signal = use_context::<Signal<LoadingState>>();
 
     let onclick = move |_| {
         loading_signal.set(LoadingState::Loading);
         let token = storage.get().jwt.expect("No JWT found");
         spawn(async move {
-            mutate.mutate_async((None, token)).await;
-            if let MutationState::Settled(Ok(result)) = mutate.result().deref()
-                && let MutationValue::NewGame(_game) = result
-            {
-                client.invalidate_queries(&[QueryKey::Games]);
-            };
+            let _ = mutate.mutate_async((None, token)).await;
             loading_signal.set(LoadingState::Loaded);
         });
     };
@@ -97,9 +90,8 @@ pub fn CreateGameButton() -> Element {
 pub fn CreateGameForm() -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
 
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
     let mut game_name_signal: Signal<String> = use_signal(String::default);
-    let mutate = use_mutation(create_game);
+    let mutate = use_mutation(Mutation::new(CreateGameM));
     let mut loading_signal = use_context::<Signal<LoadingState>>();
 
     let onsubmit = move |_| {
@@ -111,11 +103,8 @@ pub fn CreateGameForm() -> Element {
         loading_signal.set(LoadingState::Loading);
 
         spawn(async move {
-            mutate.mutate_async((Some(name), token)).await;
-            if let MutationState::Settled(Ok(result)) = mutate.result().deref()
-                && let MutationValue::NewGame(_game) = result
-            {
-                client.invalidate_queries(&[QueryKey::Games]);
+            let reader = mutate.mutate_async((Some(name), token)).await;
+            if reader.state().is_ok() {
                 game_name_signal.set(String::default());
             }
             loading_signal.set(LoadingState::Loaded);

--- a/web/src/components/game_areas.rs
+++ b/web/src/components/game_areas.rs
@@ -1,4 +1,4 @@
-use crate::cache::{QueryError, QueryKey, QueryValue};
+use crate::cache::QueryError;
 use crate::components::icons::lock_closed::LockClosedIcon;
 use crate::components::icons::lock_open::LockOpenIcon;
 use crate::components::item_icon::ItemIcon;
@@ -6,30 +6,35 @@ use crate::components::map::Map;
 use crate::env::APP_API_HOST;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::{QueryResult, QueryState, use_get_query};
+use dioxus_query::prelude::*;
 use game::areas::AreaDetails;
 use shared::DisplayGame;
 
-async fn fetch_areas(keys: Vec<QueryKey>, token: String) -> QueryResult<QueryValue, QueryError> {
-    if let Some(QueryKey::Areas(identifier)) = keys.first() {
-        let client = reqwest::Client::new();
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct GameAreasQ {
+    pub token: String,
+}
 
+impl QueryCapability for GameAreasQ {
+    type Ok = Vec<AreaDetails>;
+    type Err = QueryError;
+    type Keys = String;
+
+    async fn run(&self, identifier: &String) -> Result<Vec<AreaDetails>, QueryError> {
+        let client = reqwest::Client::new();
         let request = client
             .request(
                 reqwest::Method::GET,
                 format!("{}/api/games/{}/areas", APP_API_HOST, identifier),
             )
-            .bearer_auth(token);
-
+            .bearer_auth(&self.token);
         match request.send().await {
             Ok(response) => match response.json::<Vec<AreaDetails>>().await {
-                Ok(areas) => Ok(QueryValue::Areas(areas)),
+                Ok(areas) => Ok(areas),
                 Err(_) => Err(QueryError::GameNotFound(identifier.to_string())),
             },
             Err(_) => Err(QueryError::GameNotFound(identifier.to_string())),
         }
-    } else {
-        Err(QueryError::Unknown)
     }
 }
 
@@ -40,17 +45,12 @@ pub fn GameAreaList(game: DisplayGame) -> Element {
 
     let identifier = game.identifier.clone();
 
-    let area_query = use_get_query(
-        [
-            QueryKey::Areas(identifier.clone()),
-            QueryKey::Game(identifier.clone()),
-            QueryKey::Games,
-        ],
-        move |keys: Vec<QueryKey>| fetch_areas(keys, token.clone()),
-    );
+    let area_query = use_query(Query::new(identifier.clone(), GameAreasQ { token }));
+    let reader = area_query.read();
+    let state = reader.state();
 
-    match area_query.result().value() {
-        QueryState::Settled(Ok(QueryValue::Areas(areas))) => {
+    match &*state {
+        QueryStateData::Settled { res: Ok(areas), .. } => {
             rsx! {
                 ul {
                     class: "grid grid-cols-2 gap-4",
@@ -194,10 +194,10 @@ pub fn GameAreaList(game: DisplayGame) -> Element {
                 }
             }
         }
-        QueryState::Settled(Err(_)) => {
+        QueryStateData::Settled { res: Err(_), .. } => {
             rsx! { p { "Something went wrong" } }
         }
-        QueryState::Loading(_) => {
+        QueryStateData::Loading { .. } => {
             rsx! { p { "Loading..." } }
         }
         _ => {

--- a/web/src/components/game_delete.rs
+++ b/web/src/components/game_delete.rs
@@ -1,27 +1,39 @@
-use crate::cache::{MutationError, MutationValue, QueryError, QueryKey, QueryValue};
+use crate::cache::MutationError;
 use crate::components::Button;
+use crate::components::games_list::GamesListQ;
 use crate::components::icons::delete::DeleteIcon;
 use crate::env::APP_API_HOST;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::{MutationResult, MutationState, use_mutation, use_query_client};
+use dioxus_query::prelude::*;
 use gloo_storage::Storage;
 use shared::DeleteGame;
-use std::ops::Deref;
 
-async fn delete_game(args: (DeleteGame, String)) -> MutationResult<MutationValue, MutationError> {
-    let identifier = args.0.0;
-    let name = args.0.1;
-    let token = args.1;
-    let client = reqwest::Client::new();
-    let url: String = format!("{}/api/games/{}", APP_API_HOST, identifier);
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DeleteGameM;
 
-    let response = client.delete(url).bearer_auth(token).send().await;
+impl MutationCapability for DeleteGameM {
+    type Ok = (String, String);
+    type Err = MutationError;
+    type Keys = (DeleteGame, String);
 
-    if response.unwrap().status().is_success() {
-        MutationResult::Ok(MutationValue::GameDeleted(identifier, name))
-    } else {
-        MutationResult::Err(MutationError::Unknown)
+    async fn run(&self, args: &(DeleteGame, String)) -> Result<(String, String), MutationError> {
+        let identifier = args.0.0.clone();
+        let name = args.0.1.clone();
+        let token = args.1.clone();
+        let client = reqwest::Client::new();
+        let url: String = format!("{}/api/games/{}", APP_API_HOST, identifier);
+        let response = client.delete(url).bearer_auth(token).send().await;
+        match response {
+            Ok(r) if r.status().is_success() => Ok((identifier, name)),
+            _ => Err(MutationError::Unknown),
+        }
+    }
+
+    async fn on_settled(&self, _keys: &Self::Keys, result: &Result<Self::Ok, Self::Err>) {
+        if result.is_ok() {
+            QueriesStorage::<GamesListQ>::invalidate_all().await;
+        }
     }
 }
 
@@ -57,7 +69,7 @@ pub fn DeleteGameModal() -> Element {
 
     let mut delete_game_signal: Signal<Option<DeleteGame>> = use_context();
     let delete_game_info = delete_game_signal.read().clone();
-    let mutate = use_mutation(delete_game);
+    let mutate = use_mutation(Mutation::new(DeleteGameM));
 
     let name = {
         if let Some(details) = delete_game_info.clone() {
@@ -71,19 +83,18 @@ pub fn DeleteGameModal() -> Element {
         delete_game_signal.set(None);
     };
 
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
-
     let delete = move |_| {
         if let Some(dg) = delete_game_info.clone() {
             let token = storage.get().jwt.expect("No JWT found");
             spawn(async move {
-                mutate.mutate_async((dg.clone(), token)).await;
-                if let MutationState::Settled(Ok(MutationValue::GameDeleted(id, _))) =
-                    mutate.result().deref()
+                let reader = mutate.mutate_async((dg.clone(), token)).await;
+                let state = reader.state();
+                if let MutationStateData::Settled {
+                    res: Ok((id, _)), ..
+                } = &*state
                 {
                     gloo_storage::LocalStorage::delete(format!("recap_collapsed:{id}"));
                     gloo_storage::LocalStorage::delete(format!("period_filters:{id}"));
-                    client.invalidate_queries(&[QueryKey::Games]);
                     delete_game_signal.set(None);
                 }
             });

--- a/web/src/components/game_detail.rs
+++ b/web/src/components/game_detail.rs
@@ -1,9 +1,10 @@
 use crate::LoadingState;
-use crate::cache::{MutationError, MutationValue, QueryError, QueryKey, QueryValue};
+use crate::cache::{MutationError, QueryError};
 use crate::components::ThemedButton;
 use crate::components::game_areas::GameAreaList;
 use crate::components::game_edit::GameEdit;
 use crate::components::game_tributes::GameTributes;
+use crate::components::games_list::GamesListQ;
 use crate::components::info_detail::InfoDetail;
 use crate::components::period_grid::PeriodGrid;
 use crate::components::recap_card::RecapCard;
@@ -13,38 +14,34 @@ use crate::hooks::{ConnectionState, use_game_websocket};
 use crate::routes::Routes;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::{
-    MutationResult, MutationState, QueryResult, QueryState, UseMutation, UseQueryClient,
-    use_get_query, use_mutation, use_query_client,
-};
-use game::games::Game;
+use dioxus_query::prelude::*;
 use reqwest::StatusCode;
 use shared::{DisplayGame, GameEvent, GameStatus};
-use std::ops::Deref;
 
-async fn fetch_display_game(
-    keys: Vec<QueryKey>,
-    token: String,
-) -> QueryResult<QueryValue, QueryError> {
-    if let Some(QueryKey::DisplayGame(identifier)) = keys.first() {
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DisplayGameQ {
+    pub token: String,
+}
+
+impl QueryCapability for DisplayGameQ {
+    type Ok = Box<DisplayGame>;
+    type Err = QueryError;
+    type Keys = String;
+
+    async fn run(&self, identifier: &String) -> Result<Box<DisplayGame>, QueryError> {
         let client = reqwest::Client::new();
-
         let request = client
             .request(
                 reqwest::Method::GET,
                 format!("{}/api/games/{}/display", APP_API_HOST, identifier),
             )
-            .bearer_auth(token);
-
+            .bearer_auth(&self.token);
         match request.send().await {
             Ok(response) => match response.error_for_status() {
-                Ok(response) => {
-                    if let Ok(game) = response.json::<DisplayGame>().await {
-                        Ok(QueryValue::DisplayGame(Box::new(game)))
-                    } else {
-                        Err(QueryError::BadJson)
-                    }
-                }
+                Ok(response) => match response.json::<DisplayGame>().await {
+                    Ok(game) => Ok(Box::new(game)),
+                    Err(_) => Err(QueryError::BadJson),
+                },
                 Err(e) => {
                     if e.status() == Some(StatusCode::UNAUTHORIZED) {
                         Err(QueryError::Unauthorized)
@@ -61,116 +58,61 @@ async fn fetch_display_game(
                 }
             }
         }
-    } else {
-        Err(QueryError::Unknown)
     }
 }
 
-async fn _fetch_full_game(
-    keys: Vec<QueryKey>,
-    token: String,
-) -> QueryResult<QueryValue, QueryError> {
-    if let Some(QueryKey::Game(identifier)) = keys.first() {
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct NextStepM;
+
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) enum NextStepResult {
+    Started(String),
+    Finished(String),
+    Advanced(String),
+}
+
+impl NextStepResult {
+    pub fn identifier(&self) -> &String {
+        match self {
+            NextStepResult::Started(s)
+            | NextStepResult::Finished(s)
+            | NextStepResult::Advanced(s) => s,
+        }
+    }
+}
+
+impl MutationCapability for NextStepM {
+    type Ok = NextStepResult;
+    type Err = MutationError;
+    type Keys = (String, String);
+
+    async fn run(&self, args: &(String, String)) -> Result<NextStepResult, MutationError> {
+        let identifier = args.0.clone();
+        let token = args.1.clone();
         let client = reqwest::Client::new();
-
-        let request = client
-            .request(
-                reqwest::Method::GET,
-                format!("{}/api/games/{}", APP_API_HOST, identifier),
-            )
-            .bearer_auth(token);
-
+        let url: String = format!("{}/api/games/{}/next", APP_API_HOST, identifier);
+        let request = client.request(reqwest::Method::PUT, url).bearer_auth(token);
         match request.send().await {
-            Ok(response) => match response.error_for_status() {
-                Ok(response) => {
-                    if let Ok(game) = response.json::<Game>().await {
-                        QueryResult::Ok(QueryValue::Game(Box::new(game)))
-                    } else {
-                        QueryResult::Err(QueryError::BadJson)
-                    }
-                }
-                Err(e) => {
-                    if e.status() == Some(StatusCode::UNAUTHORIZED) {
-                        QueryResult::Err(QueryError::Unauthorized)
-                    } else {
-                        QueryResult::Err(QueryError::GameNotFound(identifier.to_string()))
-                    }
-                }
+            Ok(response) => match response.status() {
+                StatusCode::NO_CONTENT => Ok(NextStepResult::Finished(identifier)),
+                StatusCode::CREATED => Ok(NextStepResult::Started(identifier)),
+                StatusCode::OK => Ok(NextStepResult::Advanced(identifier)),
+                _ => Err(MutationError::UnableToAdvanceGame),
             },
-            Err(e) => {
-                if e.status() == Some(StatusCode::UNAUTHORIZED) {
-                    QueryResult::Err(QueryError::Unauthorized)
-                } else {
-                    QueryResult::Err(QueryError::GameNotFound(identifier.to_string()))
-                }
-            }
+            Err(_) => Err(MutationError::UnableToAdvanceGame),
         }
-    } else {
-        QueryResult::Err(QueryError::Unknown)
     }
-}
 
-async fn next_step(args: (String, String)) -> MutationResult<MutationValue, MutationError> {
-    let identifier = args.0.clone();
-    let token = args.1.clone();
-    let client = reqwest::Client::new();
-    let url: String = format!("{}/api/games/{}/next", APP_API_HOST, identifier);
-
-    let request = client.request(reqwest::Method::PUT, url).bearer_auth(token);
-
-    match request.send().await {
-        Ok(response) => match response.status() {
-            StatusCode::NO_CONTENT => Ok(MutationValue::GameFinished(identifier)),
-            StatusCode::CREATED => Ok(MutationValue::GameStarted(identifier)),
-            StatusCode::OK => Ok(MutationValue::GameAdvanced(identifier)),
-            _ => Err(MutationError::UnableToAdvanceGame),
-        },
-        Err(_) => Err(MutationError::UnableToAdvanceGame),
-    }
-}
-
-async fn handle_next_step(
-    game_id: String,
-    token: String,
-    mutate: UseMutation<MutationValue, MutationError, (String, String)>,
-    client: UseQueryClient<QueryValue, QueryError, QueryKey>,
-    mut loading_signal: Signal<LoadingState>,
-    mut filters: Signal<PeriodFilters>,
-) {
-    loading_signal.set(LoadingState::Loading);
-    mutate.mutate_async((game_id.clone(), token)).await;
-
-    match mutate.result().deref() {
-        MutationState::Settled(Ok(result)) => {
-            match result {
-                MutationValue::GameStarted(game_identifier)
-                | MutationValue::GameFinished(game_identifier)
-                | MutationValue::GameAdvanced(game_identifier) => {
-                    filters.write().bump(game_identifier);
-                    client.invalidate_queries(&[
-                        QueryKey::DisplayGame(game_identifier.clone()),
-                        QueryKey::Games,
-                    ]);
-                    loading_signal.set(LoadingState::Loaded);
-                }
-                _ => {
-                    loading_signal.set(LoadingState::Loaded); // Or an error state
-                }
-            }
+    async fn on_settled(&self, _keys: &Self::Keys, result: &Result<Self::Ok, Self::Err>) {
+        if result.is_ok() {
+            QueriesStorage::<DisplayGameQ>::invalidate_all().await;
+            QueriesStorage::<GamesListQ>::invalidate_all().await;
         }
-        MutationState::Settled(Err(MutationError::UnableToAdvanceGame)) => {
-            loading_signal.set(LoadingState::Loaded); // Or an error state
-        }
-        MutationState::Settled(Err(_)) => {
-            loading_signal.set(LoadingState::Loaded); // Or an error state
-        }
-        _ => {}
     }
 }
 
 #[component]
 pub fn GamePage(identifier: String) -> Element {
-    // WebSocket for real-time updates
     let (ws_events, ws_connection) = use_game_websocket(identifier.clone());
 
     rsx! {
@@ -182,7 +124,6 @@ pub fn GamePage(identifier: String) -> Element {
             gap-4
             "#,
 
-            // Connection status indicator
             {match ws_connection() {
                 ConnectionState::Connected => rsx! {
                     div { class: "text-sm text-green-600", "Live updates connected" }
@@ -198,7 +139,6 @@ pub fn GamePage(identifier: String) -> Element {
                 },
             }}
 
-            // Real-time event feed
             if !ws_events.read().is_empty() {
                 div {
                     class: "bg-gray-100 p-4 rounded-lg max-h-64 overflow-y-auto",
@@ -218,7 +158,6 @@ pub fn GamePage(identifier: String) -> Element {
     }
 }
 
-/// Format a GameEvent for display
 fn format_game_event(event: &GameEvent) -> String {
     match event {
         GameEvent::GameStarted { day } => format!("Game started - Day {}", day),
@@ -231,12 +170,8 @@ fn format_game_event(event: &GameEvent) -> String {
         }
         GameEvent::DayStarted { day } => format!("Day {} started", day),
         GameEvent::NightStarted { day } => format!("Night {} started", day),
-        GameEvent::TributeDied { name, cause, .. } => {
-            format!("{} died: {}", name, cause)
-        }
-        GameEvent::AreaEvent { area, event } => {
-            format!("{} in {}", event, area)
-        }
+        GameEvent::TributeDied { name, cause, .. } => format!("{} died: {}", name, cause),
+        GameEvent::AreaEvent { area, event } => format!("{} in {}", event, area),
         GameEvent::Combat {
             attacker,
             defender,
@@ -253,20 +188,27 @@ fn GameState(identifier: String) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
     let token = storage.get().jwt.unwrap_or_default();
 
-    let loading_signal = use_context::<Signal<LoadingState>>();
-    let filters = use_context::<Signal<PeriodFilters>>();
+    let mut loading_signal = use_context::<Signal<LoadingState>>();
+    let mut filters = use_context::<Signal<PeriodFilters>>();
 
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
+    let token_for_query = token.clone();
+    let game_query = use_query(Query::new(
+        identifier.clone(),
+        DisplayGameQ {
+            token: token_for_query,
+        },
+    ));
 
-    let token_clone = token.clone();
-    let game_query = use_get_query(
-        [QueryKey::DisplayGame(identifier.clone()), QueryKey::Games],
-        move |keys: Vec<QueryKey>| fetch_display_game(keys, token.clone()),
-    );
+    let mutate = use_mutation(Mutation::new(NextStepM));
 
-    match game_query.result().value() {
-        QueryState::Settled(Ok(QueryValue::DisplayGame(game_data))) => {
-            let game = *game_data.clone();
+    let reader = game_query.read();
+    let state = reader.state();
+
+    match &*state {
+        QueryStateData::Settled {
+            res: Ok(game_data), ..
+        } => {
+            let game = (**game_data).clone();
             let game_id = game.identifier.clone();
             let g_id = game_id.clone();
             let game_name = game.name.clone();
@@ -278,8 +220,6 @@ fn GameState(identifier: String) -> Element {
             let creator = game.created_by.username.clone();
             let day = game.day.unwrap_or(0);
 
-            let mutate = use_mutation(next_step);
-
             let game_next_step = match game_status {
                 GameStatus::NotStarted => if is_ready { "Start" } else { "Wait" }.to_string(),
                 GameStatus::InProgress => format!("Play day {}", day + 1),
@@ -288,22 +228,22 @@ fn GameState(identifier: String) -> Element {
 
             let next_step_handler = move |_| {
                 let game_id_clone = game_id.clone();
-                let token_clone = token_clone.clone();
-                let mutate_clone = mutate;
-                let client_clone = client;
-                let loading_signal_clone = loading_signal;
-                let filters_clone = filters;
-
+                let token_clone = token.clone();
                 spawn(async move {
-                    handle_next_step(
-                        game_id_clone,
-                        token_clone,
-                        mutate_clone,
-                        client_clone,
-                        loading_signal_clone,
-                        filters_clone,
-                    )
-                    .await;
+                    loading_signal.set(LoadingState::Loading);
+                    let reader = mutate.mutate_async((game_id_clone, token_clone)).await;
+                    let state = reader.state();
+                    match &*state {
+                        MutationStateData::Settled {
+                            res: Ok(result), ..
+                        } => {
+                            filters.write().bump(result.identifier());
+                            loading_signal.set(LoadingState::Loaded);
+                        }
+                        _ => {
+                            loading_signal.set(LoadingState::Loaded);
+                        }
+                    }
                 });
             };
 
@@ -378,7 +318,10 @@ fn GameState(identifier: String) -> Element {
                 }
             }
         }
-        QueryState::Settled(Err(QueryError::GameNotFound(_))) => {
+        QueryStateData::Settled {
+            res: Err(QueryError::GameNotFound(_)),
+            ..
+        } => {
             rsx! {
                 p {
                     class: r#"
@@ -391,7 +334,10 @@ fn GameState(identifier: String) -> Element {
                 }
             }
         }
-        QueryState::Settled(Err(QueryError::Unauthorized)) => {
+        QueryStateData::Settled {
+            res: Err(QueryError::Unauthorized),
+            ..
+        } => {
             rsx! {
                 p {
                     class: r#"
@@ -429,7 +375,7 @@ fn GameState(identifier: String) -> Element {
                 }
             }
         }
-        QueryState::Settled(Err(e)) => {
+        QueryStateData::Settled { res: Err(e), .. } => {
             rsx! {
                 p {
                     class: r#"
@@ -442,7 +388,7 @@ fn GameState(identifier: String) -> Element {
                 }
             }
         }
-        QueryState::Loading(_) => {
+        QueryStateData::Loading { .. } => {
             rsx! {
                 p {
                     class: r#"
@@ -466,13 +412,12 @@ fn GameStats(identifier: String) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
     let token = storage.get().jwt.unwrap_or_default();
 
-    let game_query = use_get_query(
-        [QueryKey::DisplayGame(identifier.clone()), QueryKey::Games],
-        move |keys: Vec<QueryKey>| fetch_display_game(keys, token.clone()),
-    );
+    let game_query = use_query(Query::new(identifier.clone(), DisplayGameQ { token }));
+    let reader = game_query.read();
+    let state = reader.state();
 
-    match game_query.result().value() {
-        QueryState::Settled(Ok(QueryValue::DisplayGame(game))) => {
+    match &*state {
+        QueryStateData::Settled { res: Ok(game), .. } => {
             let game_day = game.day.unwrap_or(0);
             let tribute_count = game.living_count;
 
@@ -561,10 +506,10 @@ fn GameStats(identifier: String) -> Element {
                 }
             }
         }
-        QueryState::Settled(Err(_)) => {
+        QueryStateData::Settled { res: Err(_), .. } => {
             rsx! {}
         }
-        QueryState::Loading(_) => {
+        QueryStateData::Loading { .. } => {
             rsx! {
                 p {
                     class: r#"
@@ -588,14 +533,18 @@ fn GameDetails(identifier: String) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
     let display_token = storage.get().jwt.unwrap_or_default();
 
-    let display_game_query = use_get_query(
-        [QueryKey::DisplayGame(identifier.clone()), QueryKey::Games],
-        move |keys: Vec<QueryKey>| fetch_display_game(keys, display_token.clone()),
-    );
+    let display_game_query = use_query(Query::new(
+        identifier.clone(),
+        DisplayGameQ {
+            token: display_token,
+        },
+    ));
+    let reader = display_game_query.read();
+    let state = reader.state();
 
-    match display_game_query.result().value() {
-        QueryState::Settled(Ok(QueryValue::DisplayGame(game))) => {
-            let display_game = *game.clone();
+    match &*state {
+        QueryStateData::Settled { res: Ok(game), .. } => {
+            let display_game = (**game).clone();
             let day = display_game.clone().day.unwrap_or(0);
 
             let xl_display = match day {
@@ -638,7 +587,7 @@ fn GameDetails(identifier: String) -> Element {
                 }
             }
         }
-        QueryState::Settled(Err(_)) => {
+        QueryStateData::Settled { res: Err(_), .. } => {
             rsx! {}
         }
         _ => {

--- a/web/src/components/game_edit.rs
+++ b/web/src/components/game_edit.rs
@@ -1,36 +1,45 @@
-use crate::cache::{MutationError, MutationValue, QueryError, QueryKey, QueryValue};
+use crate::cache::MutationError;
+use crate::components::game_detail::DisplayGameQ;
+use crate::components::games_list::GamesListQ;
 use crate::components::icons::edit::EditIcon;
 use crate::components::modal::{Modal, Props as ModalProps};
 use crate::components::{Button, Input};
 use crate::env::APP_API_HOST;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::{MutationResult, MutationState, use_mutation, use_query_client};
+use dioxus_query::prelude::*;
 use shared::EditGame;
-use std::ops::Deref;
 
-async fn edit_game(args: (EditGame, String)) -> MutationResult<MutationValue, MutationError> {
-    let identifier = args.0.identifier.clone();
-    let token = args.1.clone();
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct EditGameM;
 
-    let client = reqwest::Client::new();
-    let url: String = format!("{}/api/games/{}", APP_API_HOST, identifier);
+impl MutationCapability for EditGameM {
+    type Ok = String;
+    type Err = MutationError;
+    type Keys = (EditGame, String);
 
-    let response = client
-        .put(url)
-        .bearer_auth(token)
-        .json(&args.0.clone())
-        .send()
-        .await;
+    async fn run(&self, args: &(EditGame, String)) -> Result<String, MutationError> {
+        let identifier = args.0.identifier.clone();
+        let token = args.1.clone();
+        let client = reqwest::Client::new();
+        let url: String = format!("{}/api/games/{}", APP_API_HOST, identifier);
+        let response = client
+            .put(url)
+            .bearer_auth(token)
+            .json(&args.0.clone())
+            .send()
+            .await;
+        match response {
+            Ok(r) if r.status().is_success() => Ok(identifier),
+            _ => Err(MutationError::Unknown),
+        }
+    }
 
-    if response
-        .expect("Failed to update game")
-        .status()
-        .is_success()
-    {
-        Ok(MutationValue::GameUpdated(identifier))
-    } else {
-        Err(MutationError::Unknown)
+    async fn on_settled(&self, _keys: &Self::Keys, result: &Result<Self::Ok, Self::Err>) {
+        if result.is_ok() {
+            QueriesStorage::<DisplayGameQ>::invalidate_all().await;
+            QueriesStorage::<GamesListQ>::invalidate_all().await;
+        }
     }
 }
 
@@ -95,26 +104,24 @@ pub fn EditGameForm() -> Element {
     let identifier = game_details.identifier.clone();
     let private = game_details.private;
 
-    let mutate = use_mutation(edit_game);
+    let mutate = use_mutation(Mutation::new(EditGameM));
 
     let dismiss = move |_| {
         edit_game_signal.set(None);
     };
 
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
-
     let save = move |e: Event<FormData>| {
         let identifier = identifier.clone();
         let token = storage.get().jwt.expect("No JWT found");
 
-        let data = e.data().values();
-        let name = data.get("name").expect("No name value").0[0].clone();
-        let private = matches!(
-            data.get("private").expect("No private value").0[0]
-                .clone()
-                .as_str(),
-            "on"
-        );
+        let name = match e.data().get_first("name") {
+            Some(FormValue::Text(s)) => s,
+            _ => return,
+        };
+        let private = match e.data().get_first("private") {
+            Some(FormValue::Text(s)) => s == "on",
+            _ => false,
+        };
 
         if !name.is_empty() {
             let edit_game = EditGame {
@@ -123,17 +130,9 @@ pub fn EditGameForm() -> Element {
                 private,
             };
             spawn(async move {
-                mutate.mutate_async((edit_game.clone(), token)).await;
-                edit_game_signal.set(Some(edit_game.clone()));
-
-                if let MutationState::Settled(MutationResult::Ok(MutationValue::GameUpdated(
-                    identifier,
-                ))) = mutate.result().deref()
-                {
-                    client.invalidate_queries(&[
-                        QueryKey::DisplayGame(identifier.clone()),
-                        QueryKey::Games,
-                    ]);
+                let reader = mutate.mutate_async((edit_game.clone(), token)).await;
+                let state = reader.state();
+                if matches!(&*state, MutationStateData::Settled { res: Ok(_), .. }) {
                     edit_game_signal.set(None);
                 }
             });

--- a/web/src/components/game_period_page.rs
+++ b/web/src/components/game_period_page.rs
@@ -4,30 +4,38 @@
 //! day log via `/api/games/{id}/log/{day}`, filters down to the requested
 //! phase, and renders [`FilterChips`] + [`Timeline`].
 
-use crate::cache::{QueryError, QueryKey, QueryValue};
+use crate::cache::QueryError;
 use crate::components::filter_chips::FilterChips;
 use crate::components::timeline::{PeriodFilters, Timeline};
 use crate::env::APP_API_HOST;
+use crate::hooks::use_timeline_summary::use_timeline_summary;
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
 use reqwest::StatusCode;
 use shared::messages::{GameMessage, Phase};
 
-async fn fetch_day_log(keys: Vec<QueryKey>) -> QueryResult<QueryValue, QueryError> {
-    let Some(QueryKey::GameDayLog(id, day)) = keys.first() else {
-        return Err(QueryError::Unknown);
-    };
-    let url = format!("{APP_API_HOST}/api/games/{id}/log/{day}");
-    match reqwest::get(&url).await {
-        Ok(resp) => match resp.status() {
-            StatusCode::OK => match resp.json::<Vec<GameMessage>>().await {
-                Ok(v) => Ok(QueryValue::Logs(v)),
-                Err(_) => Err(QueryError::BadJson),
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct DayLogQ;
+
+impl QueryCapability for DayLogQ {
+    type Ok = Vec<GameMessage>;
+    type Err = QueryError;
+    type Keys = (String, u32);
+
+    async fn run(&self, keys: &(String, u32)) -> Result<Vec<GameMessage>, QueryError> {
+        let (id, day) = keys;
+        let url = format!("{APP_API_HOST}/api/games/{id}/log/{day}");
+        match reqwest::get(&url).await {
+            Ok(resp) => match resp.status() {
+                StatusCode::OK => match resp.json::<Vec<GameMessage>>().await {
+                    Ok(v) => Ok(v),
+                    Err(_) => Err(QueryError::BadJson),
+                },
+                StatusCode::NOT_FOUND => Err(QueryError::GameNotFound(id.clone())),
+                _ => Err(QueryError::Unknown),
             },
-            StatusCode::NOT_FOUND => Err(QueryError::GameNotFound(id.clone())),
-            _ => Err(QueryError::Unknown),
-        },
-        Err(_) => Err(QueryError::ServerNotFound),
+            Err(_) => Err(QueryError::ServerNotFound),
+        }
     }
 }
 
@@ -36,17 +44,18 @@ pub fn GamePeriodPage(identifier: String, day: u32, phase: Phase) -> Element {
     let filters: Signal<PeriodFilters> = use_context();
     let filter = filters.read().filter_for(&identifier);
 
-    let summary_q = use_get_query(
-        [QueryKey::TimelineSummary(identifier.clone())],
-        crate::hooks::use_timeline_summary::fetch_timeline_summary,
-    );
+    let summary_q = use_timeline_summary(identifier.clone());
 
-    let valid = match summary_q.result().value() {
-        QueryState::Settled(Ok(QueryValue::TimelineSummary(s))) => {
-            s.periods.iter().any(|p| p.day == day && p.phase == phase)
+    let valid = {
+        let reader = summary_q.read();
+        let state = reader.state();
+        match &*state {
+            QueryStateData::Settled { res: Ok(s), .. } => {
+                s.periods.iter().any(|p| p.day == day && p.phase == phase)
+            }
+            QueryStateData::Settled { res: Err(_), .. } => false,
+            _ => true,
         }
-        QueryState::Settled(Err(_)) => false,
-        _ => true,
     };
 
     if !valid {
@@ -58,17 +67,16 @@ pub fn GamePeriodPage(identifier: String, day: u32, phase: Phase) -> Element {
         };
     }
 
-    let log_q = use_get_query(
-        [QueryKey::GameDayLog(identifier.clone(), day)],
-        fetch_day_log,
-    );
+    let log_q = use_query(Query::new((identifier.clone(), day), DayLogQ));
+    let reader = log_q.read();
+    let state = reader.state();
 
     rsx! {
         div { class: "space-y-4",
             h1 { class: "text-2xl font-semibold", "Day {day} — {phase}" }
             FilterChips { game_identifier: identifier.clone() }
-            match log_q.result().value() {
-                QueryState::Settled(Ok(QueryValue::Logs(msgs))) => {
+            match &*state {
+                QueryStateData::Settled { res: Ok(msgs), .. } => {
                     let filtered: Vec<GameMessage> = msgs
                         .iter()
                         .filter(|m| m.phase == phase)
@@ -82,7 +90,7 @@ pub fn GamePeriodPage(identifier: String, day: u32, phase: Phase) -> Element {
                         }
                     }
                 }
-                QueryState::Settled(Err(_)) => rsx! {
+                QueryStateData::Settled { res: Err(_), .. } => rsx! {
                     p { class: "text-red-600", "Failed to load events." }
                 },
                 _ => rsx! {

--- a/web/src/components/game_tributes.rs
+++ b/web/src/components/game_tributes.rs
@@ -1,4 +1,4 @@
-use crate::cache::{QueryError, QueryKey, QueryValue};
+use crate::cache::QueryError;
 use crate::components::icons::loading::LoadingIcon;
 use crate::components::icons::map_pin::MapPinIcon;
 use crate::components::item_icon::ItemIcon;
@@ -8,9 +8,8 @@ use crate::env::APP_API_HOST;
 use crate::routes::Routes;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::{QueryResult, QueryState, use_get_query};
+use dioxus_query::prelude::*;
 use game::items::Item;
-use game::messages::GameMessage;
 use game::tributes::Tribute;
 use serde::{Deserialize, Serialize};
 use shared::{DisplayGame, GameStatus, PaginationMetadata};
@@ -21,10 +20,18 @@ pub struct PaginatedTributesResponse {
     pub pagination: PaginationMetadata,
 }
 
-async fn fetch_tributes(keys: Vec<QueryKey>, token: String) -> QueryResult<QueryValue, QueryError> {
-    if let Some(QueryKey::Tributes(game_identifier)) = keys.first() {
-        let client = reqwest::Client::new();
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct GameTributesQ {
+    pub token: String,
+}
 
+impl QueryCapability for GameTributesQ {
+    type Ok = PaginatedTributesResponse;
+    type Err = QueryError;
+    type Keys = String;
+
+    async fn run(&self, game_identifier: &String) -> Result<PaginatedTributesResponse, QueryError> {
+        let client = reqwest::Client::new();
         let request = client
             .request(
                 reqwest::Method::GET,
@@ -33,60 +40,14 @@ async fn fetch_tributes(keys: Vec<QueryKey>, token: String) -> QueryResult<Query
                     APP_API_HOST, game_identifier
                 ),
             )
-            .bearer_auth(token);
-
+            .bearer_auth(&self.token);
         match request.send().await {
-            Ok(response) => {
-                if let Ok(tributes) = response.json::<PaginatedTributesResponse>().await {
-                    Ok(QueryValue::PaginatedTributes(tributes))
-                } else {
-                    Err(QueryError::BadJson)
-                }
-            }
+            Ok(response) => match response.json::<PaginatedTributesResponse>().await {
+                Ok(tributes) => Ok(tributes),
+                Err(_) => Err(QueryError::BadJson),
+            },
             Err(_) => Err(QueryError::GameNotFound(game_identifier.to_string())),
         }
-    } else {
-        Err(QueryError::Unknown)
-    }
-}
-
-async fn _fetch_tribute_log(
-    keys: Vec<QueryKey>,
-    token: String,
-) -> QueryResult<QueryValue, QueryError> {
-    if let Some(QueryKey::_TributeDayLog(identifier, day)) = keys.first() {
-        if let Some(QueryKey::DisplayGame(game_identifier)) = keys.last() {
-            let client = reqwest::Client::new();
-
-            let request = client
-                .request(
-                    reqwest::Method::GET,
-                    format!(
-                        "{}/api/games/{}/log/{}/{}",
-                        APP_API_HOST, game_identifier, day, identifier
-                    ),
-                )
-                .bearer_auth(token);
-
-            match request.send().await {
-                Ok(response) => {
-                    if response.status().is_success() {
-                        let messages = response.json::<Vec<GameMessage>>().await;
-                        match messages {
-                            Ok(messages) => Ok(QueryValue::Logs(messages)),
-                            Err(_) => Err(QueryError::BadJson),
-                        }
-                    } else {
-                        Err(QueryError::TributeNotFound(identifier.to_string()))
-                    }
-                }
-                Err(_) => Err(QueryError::GameNotFound(identifier.to_string())),
-            }
-        } else {
-            Err(QueryError::Unknown)
-        }
-    } else {
-        Err(QueryError::Unknown)
     }
 }
 
@@ -97,16 +58,14 @@ pub fn GameTributes(game: DisplayGame) -> Element {
 
     let identifier = game.identifier.clone();
 
-    let tribute_query = use_get_query(
-        [
-            QueryKey::Tributes(identifier.clone()),
-            QueryKey::DisplayGame(identifier.clone()),
-        ],
-        move |keys: Vec<QueryKey>| fetch_tributes(keys, token.clone()),
-    );
+    let tribute_query = use_query(Query::new(identifier.clone(), GameTributesQ { token }));
+    let reader = tribute_query.read();
+    let state = reader.state();
 
-    match tribute_query.result().value() {
-        QueryState::Settled(Ok(QueryValue::PaginatedTributes(response))) => {
+    match &*state {
+        QueryStateData::Settled {
+            res: Ok(response), ..
+        } => {
             let tributes = response.tributes.clone();
             rsx! {
                 ul {
@@ -156,10 +115,10 @@ pub fn GameTributes(game: DisplayGame) -> Element {
                 }
             }
         }
-        QueryState::Settled(Err(_)) => {
+        QueryStateData::Settled { res: Err(_), .. } => {
             rsx! { p { "Something went wrong" } }
         }
-        QueryState::Loading(_) => {
+        QueryStateData::Loading { .. } => {
             rsx! {
                 div {
                     class: "flex justify-center",

--- a/web/src/components/games_list.rs
+++ b/web/src/components/games_list.rs
@@ -1,4 +1,4 @@
-use crate::cache::{QueryError, QueryKey, QueryValue};
+use crate::cache::QueryError;
 use crate::components::game_edit::GameEdit;
 use crate::components::icons::eye_closed::EyeClosedIcon;
 use crate::components::icons::eye_open::EyeOpenIcon;
@@ -7,7 +7,7 @@ use crate::env::APP_API_HOST;
 use crate::routes::Routes;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::{QueryResult, QueryState, use_get_query, use_query_client};
+use dioxus_query::prelude::*;
 use serde::{Deserialize, Serialize};
 use shared::{GameStatus, ListDisplayGame, PaginationMetadata};
 
@@ -17,28 +17,32 @@ pub struct PaginatedGamesResponse {
     pub pagination: PaginationMetadata,
 }
 
-async fn fetch_games(keys: Vec<QueryKey>, token: String) -> QueryResult<QueryValue, QueryError> {
-    if let Some(QueryKey::AllGames) = keys.first() {
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct GamesListQ {
+    pub token: String,
+}
+
+impl QueryCapability for GamesListQ {
+    type Ok = PaginatedGamesResponse;
+    type Err = QueryError;
+    type Keys = ();
+
+    async fn run(&self, _keys: &()) -> Result<PaginatedGamesResponse, QueryError> {
         let client = reqwest::Client::new();
         let request = client
             .request(
                 reqwest::Method::GET,
                 format!("{}/api/games?limit=20&offset=0", APP_API_HOST),
             )
-            .bearer_auth(token);
+            .bearer_auth(&self.token);
 
         match request.send().await {
-            Ok(request) => {
-                if let Ok(response) = request.json::<PaginatedGamesResponse>().await {
-                    Ok(QueryValue::PaginatedGames(response))
-                } else {
-                    Err(QueryError::BadJson)
-                }
-            }
+            Ok(response) => match response.json::<PaginatedGamesResponse>().await {
+                Ok(r) => Ok(r),
+                Err(_) => Err(QueryError::BadJson),
+            },
             Err(_) => Err(QueryError::NoGames),
         }
-    } else {
-        Err(QueryError::Unknown)
     }
 }
 
@@ -56,10 +60,62 @@ fn NoGames() -> Element {
 pub fn GamesList() -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
     let token = storage.get().jwt.expect("No JWT found");
-    let games_query = use_get_query(
-        [QueryKey::AllGames, QueryKey::Games],
-        move |keys: Vec<QueryKey>| fetch_games(keys, token.clone()),
-    );
+    let games_query = use_query(Query::new((), GamesListQ { token }));
+
+    let reader = games_query.read();
+    let body = match &*reader.state() {
+        QueryStateData::Settled {
+            res: Ok(response), ..
+        }
+        | QueryStateData::Loading {
+            res: Some(Ok(response)),
+        } => {
+            let games = response.games.clone();
+            let pagination = response.pagination.clone();
+            rsx! {
+                if games.is_empty() {
+                    NoGames {}
+                } else {
+                    ul {
+                        class: r#"
+                        xl:grid
+                        xl:grid-cols-2
+                        xl:gap-4
+                        "#,
+                        for game in games {
+                            GameListMember { game: game.clone() }
+                        }
+                    }
+
+                    if pagination.has_more {
+                        div {
+                            class: "flex justify-center gap-2 mt-4",
+                            LoadMoreButton {
+                                current_offset: pagination.offset,
+                                limit: pagination.limit,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        QueryStateData::Loading { .. } | QueryStateData::Pending => rsx! { p {
+            class: "pb-4 text-center theme1:text-stone-200 theme2:text-green-200 theme3:text-stone-700",
+            "Loading..."
+        } },
+        QueryStateData::Settled {
+            res: Err(QueryError::NoGames),
+            ..
+        } => rsx! { NoGames {} },
+        QueryStateData::Settled {
+            res: Err(QueryError::BadJson),
+            ..
+        } => rsx! { p {
+            class: "pb-4 text-center theme1:text-stone-200 theme2:text-green-200 theme3:text-stone-700",
+            "Bad JSON response"
+        } },
+        QueryStateData::Settled { res: Err(_), .. } => rsx! { p { "Something went wrong" } },
+    };
 
     rsx! {
         div {
@@ -80,48 +136,7 @@ pub fn GamesList() -> Element {
             CreateGameForm {}
         }
 
-        match games_query.result().value() {
-            QueryState::Settled(Ok(QueryValue::PaginatedGames(response))) => {
-                let games = response.games.clone();
-                rsx! {
-                    if games.is_empty() {
-                        NoGames {}
-                    } else {
-                        ul {
-                            class: r#"
-                            xl:grid
-                            xl:grid-cols-2
-                            xl:gap-4
-                            "#,
-                            for game in games {
-                                GameListMember { game: game.clone() }
-                            }
-                        }
-
-                        // Pagination controls
-                        if response.pagination.has_more {
-                            div {
-                                class: "flex justify-center gap-2 mt-4",
-                                LoadMoreButton {
-                                    current_offset: response.pagination.offset,
-                                    limit: response.pagination.limit,
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            QueryState::Loading(_) => rsx! { p {
-                class: "pb-4 text-center theme1:text-stone-200 theme2:text-green-200 theme3:text-stone-700",
-                "Loading..."
-            } },
-            QueryState::Settled(Err(QueryError::NoGames)) => rsx! { NoGames {} },
-            QueryState::Settled(Err(QueryError::BadJson)) => rsx! { p {
-                class: "pb-4 text-center theme1:text-stone-200 theme2:text-green-200 theme3:text-stone-700",
-                "Bad JSON response"
-            } },
-            _ => rsx! { p { "Something went wrong" } },
-        }
+        {body}
 
         div {
             class: "mt-4",
@@ -134,10 +149,10 @@ pub fn GamesList() -> Element {
 
 #[component]
 fn RefreshButton() -> Element {
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
-
     let onclick = move |_| {
-        client.invalidate_queries(&[QueryKey::Games]);
+        spawn(async move {
+            QueriesStorage::<GamesListQ>::invalidate_all().await;
+        });
     };
 
     rsx! {
@@ -302,15 +317,12 @@ pub fn GameListMember(game: ListDisplayGame) -> Element {
 
 #[component]
 fn LoadMoreButton(current_offset: u32, limit: u32) -> Element {
-    let storage = use_persistent("hangry-games", AppState::default);
-    let _token = storage.get().jwt.expect("No JWT found");
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
-
     let _next_offset = current_offset + limit;
 
     let onclick = move |_| {
-        // TODO: Implement actual loading - for now just refresh to get next page
-        client.invalidate_queries(&[QueryKey::Games]);
+        spawn(async move {
+            QueriesStorage::<GamesListQ>::invalidate_all().await;
+        });
     };
 
     rsx! {

--- a/web/src/components/period_grid.rs
+++ b/web/src/components/period_grid.rs
@@ -3,12 +3,12 @@
 //! Loads via `use_timeline_summary`. Surfaces empty/error states through
 //! `PeriodGridEmpty`. Distinguishes 404 (game not found) from other failures.
 
-use crate::cache::{QueryError, QueryValue};
+use crate::cache::QueryError;
 use crate::components::period_card::PeriodCard;
 use crate::components::period_grid_empty::{EmptyKind, PeriodGridEmpty};
 use crate::hooks::use_timeline_summary;
 use dioxus::prelude::*;
-use dioxus_query::prelude::QueryState;
+use dioxus_query::prelude::*;
 
 #[derive(Props, PartialEq, Clone)]
 pub struct PeriodGridProps {
@@ -18,8 +18,10 @@ pub struct PeriodGridProps {
 #[component]
 pub fn PeriodGrid(props: PeriodGridProps) -> Element {
     let query = use_timeline_summary(props.game_identifier.clone());
-    match query.result().value() {
-        QueryState::Settled(Ok(QueryValue::TimelineSummary(s))) => {
+    let reader = query.read();
+    let state = reader.state();
+    match &*state {
+        QueryStateData::Settled { res: Ok(s), .. } => {
             if s.periods.is_empty() {
                 rsx! { PeriodGridEmpty { kind: EmptyKind::NotStarted } }
             } else {
@@ -40,13 +42,13 @@ pub fn PeriodGrid(props: PeriodGridProps) -> Element {
                 }
             }
         }
-        QueryState::Settled(Ok(_)) => {
-            rsx! { PeriodGridEmpty { kind: EmptyKind::LoadFailed } }
-        }
-        QueryState::Settled(Err(QueryError::GameNotFound(_))) => {
+        QueryStateData::Settled {
+            res: Err(QueryError::GameNotFound(_)),
+            ..
+        } => {
             rsx! { PeriodGridEmpty { kind: EmptyKind::NotFound } }
         }
-        QueryState::Settled(Err(_)) => {
+        QueryStateData::Settled { res: Err(_), .. } => {
             rsx! { PeriodGridEmpty { kind: EmptyKind::LoadFailed } }
         }
         _ => rsx! { div { class: "animate-pulse h-32 rounded-lg bg-gray-200" } },

--- a/web/src/components/server_version.rs
+++ b/web/src/components/server_version.rs
@@ -1,38 +1,36 @@
-use crate::cache::{QueryError, QueryKey, QueryValue};
 use crate::env::APP_API_HOST;
 use dioxus::prelude::*;
-use dioxus_query::prelude::{QueryResult, QueryState, use_get_query};
+use dioxus_query::prelude::*;
 
-async fn fetch_server_version(keys: Vec<QueryKey>) -> QueryResult<QueryValue, QueryError> {
-    if let Some(QueryKey::ServerVersion) = keys.first() {
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ServerVersionQ;
+
+impl QueryCapability for ServerVersionQ {
+    type Ok = String;
+    type Err = ();
+    type Keys = ();
+
+    async fn run(&self, _keys: &()) -> Result<String, ()> {
         let client = reqwest::Client::new();
-
         let request = client.request(reqwest::Method::GET, APP_API_HOST.to_string());
-
         match request.send().await {
             Ok(response) => match response.json::<String>().await {
-                Ok(version) => Ok(QueryValue::ServerVersion(version.to_string())),
-                Err(_) => Err(QueryError::ServerVersionNotFound),
+                Ok(version) => Ok(version),
+                Err(_) => Err(()),
             },
-            Err(_) => Err(QueryError::ServerNotFound),
+            Err(_) => Err(()),
         }
-    } else {
-        Err(QueryError::Unknown)
     }
 }
 
 #[component]
 pub fn ServerVersion() -> Element {
-    let version_query = use_get_query([QueryKey::ServerVersion], move |keys: Vec<QueryKey>| {
-        fetch_server_version(keys)
-    });
-
-    match version_query.result().value() {
-        QueryState::Settled(Ok(QueryValue::ServerVersion(version))) => {
-            rsx! { "Server: v{version}" }
-        }
-        _ => {
-            rsx! { "Server unavailable" }
-        }
+    let version_query = use_query(Query::new((), ServerVersionQ));
+    let reader = version_query.read();
+    let state = reader.state();
+    if let Some(version) = state.ok() {
+        rsx! { "Server: v{version}" }
+    } else {
+        rsx! { "Server unavailable" }
     }
 }

--- a/web/src/components/tribute_delete.rs
+++ b/web/src/components/tribute_delete.rs
@@ -1,26 +1,38 @@
-use crate::cache::{MutationError, MutationValue, QueryError, QueryKey, QueryValue};
+use crate::cache::MutationError;
+use crate::components::game_tributes::GameTributesQ;
 use crate::env::APP_API_HOST;
 use dioxus::prelude::*;
-use dioxus_query::prelude::{use_mutation, use_query_client, MutationResult};
+use dioxus_query::prelude::*;
 use game::games::GAME;
 use shared::DeleteTribute;
-use std::ops::Deref;
 
 #[allow(dead_code)]
-async fn delete_tribute(name: String) -> MutationResult<MutationValue, MutationError> {
-    let game_name = GAME.with_borrow(|g| { g.name.clone() });
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DeleteTributeM;
 
-    let client = reqwest::Client::new();
-    let url: String = format!("{}/api/games/{}/tributes/{}", APP_API_HOST.clone(), game_name, name);
+impl MutationCapability for DeleteTributeM {
+    type Ok = String;
+    type Err = MutationError;
+    type Keys = String;
 
-    let response = client
-        .delete(url)
-        .send().await;
+    async fn run(&self, name: &String) -> Result<String, MutationError> {
+        let game_name = GAME.with_borrow(|g| g.name.clone());
+        let client = reqwest::Client::new();
+        let url: String = format!(
+            "{}/api/games/{}/tributes/{}",
+            APP_API_HOST, game_name, name
+        );
+        let response = client.delete(url).send().await;
+        match response {
+            Ok(r) if r.status().is_success() => Ok(name.clone()),
+            _ => Err(MutationError::Unknown),
+        }
+    }
 
-    if response.unwrap().status().is_success() {
-        MutationResult::Ok(MutationValue::TributeDeleted(name))
-    } else {
-        MutationResult::Err(MutationError::Unknown)
+    async fn on_settled(&self, _keys: &Self::Keys, result: &Result<Self::Ok, Self::Err>) {
+        if result.is_ok() {
+            QueriesStorage::<GameTributesQ>::invalidate_all().await;
+        }
     }
 }
 
@@ -43,11 +55,9 @@ pub fn TributeDelete(tribute_name: String) -> Element {
 #[component]
 pub fn DeleteTributeModal() -> Element {
     let mut delete_tribute_signal: Signal<Option<DeleteTribute>> = use_context();
-    let game_name = GAME.with_borrow(|g| { g.name.clone() });
-    let tribute_name  = delete_tribute_signal.peek().clone();
+    let tribute_name = delete_tribute_signal.peek().clone();
     let name = tribute_name.clone().unwrap_or_default().clone();
-    let mutate = use_mutation(delete_tribute);
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
+    let mutate = use_mutation(Mutation::new(DeleteTributeM));
 
     let dismiss = move |_| {
         delete_tribute_signal.set(None);
@@ -55,11 +65,10 @@ pub fn DeleteTributeModal() -> Element {
 
     let delete = move |_| {
         if let Some(tribute_name) = tribute_name.clone() {
-            let game_name = game_name.clone();
             spawn(async move {
-                mutate.mutate_async(tribute_name.clone()).await;
-                if let MutationResult::Ok(MutationValue::TributeDeleted(_tribute_name)) = mutate.result().deref() {
-                    client.invalidate_queries(&[QueryKey::Tributes(game_name.clone())]);
+                let reader = mutate.mutate_async(tribute_name.clone()).await;
+                let state = reader.state();
+                if matches!(&*state, MutationStateData::Settled { res: Ok(_), .. }) {
                     delete_tribute_signal.set(None);
                 }
             });

--- a/web/src/components/tribute_detail.rs
+++ b/web/src/components/tribute_detail.rs
@@ -1,5 +1,5 @@
-use crate::cache::{QueryError, QueryKey, QueryValue};
-use crate::components::game_tributes::PaginatedTributesResponse;
+use crate::cache::QueryError;
+use crate::components::game_tributes::GameTributesQ;
 use crate::components::icons::uturn::UTurnIcon;
 use crate::components::info_detail::InfoDetail;
 use crate::components::item_icon::ItemIcon;
@@ -8,81 +8,79 @@ use crate::env::APP_API_HOST;
 use crate::routes::Routes;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::{QueryResult, QueryState, use_get_query};
+use dioxus_query::prelude::*;
 use game::messages::GameMessage;
 use game::tributes::statuses::TributeStatus;
 use game::tributes::traits::Trait;
 use game::tributes::{Attributes, Tribute};
 
-async fn fetch_tribute(keys: Vec<QueryKey>, token: String) -> QueryResult<QueryValue, QueryError> {
-    if let Some(QueryKey::Tribute(_game_identifier, tribute_identifier)) = keys.first() {
-        if let Some(QueryKey::DisplayGame(game_identifier)) = keys.last() {
-            let client = reqwest::Client::new();
-
-            let request = client
-                .request(
-                    reqwest::Method::GET,
-                    format!(
-                        "{}/api/games/{}/tributes/{}",
-                        APP_API_HOST, game_identifier, tribute_identifier
-                    ),
-                )
-                .bearer_auth(token);
-
-            match request.send().await {
-                Ok(response) => {
-                    if response.status().is_success() {
-                        match response.json::<Option<Tribute>>().await {
-                            Ok(Some(tribute)) => {
-                                QueryResult::Ok(QueryValue::Tribute(Box::new(tribute)))
-                            }
-                            _ => QueryResult::Err(QueryError::TributeNotFound(
-                                tribute_identifier.to_string(),
-                            )),
-                        }
-                    } else {
-                        QueryResult::Err(QueryError::TributeNotFound(
-                            tribute_identifier.to_string(),
-                        ))
-                    }
-                }
-                Err(_) => QueryResult::Err(QueryError::Unknown),
-            }
-        } else {
-            QueryResult::Err(QueryError::Unknown)
-        }
-    } else {
-        QueryResult::Err(QueryError::Unknown)
-    }
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct TributeQ {
+    pub token: String,
 }
 
-/// Fetch the paginated tribute roster for a game (used to resolve ally UUIDs
-/// to names client-side without a new endpoint). Standard rosters are exactly
-/// 24 tributes (12 districts × 2), matching the API's default page size.
-async fn fetch_tribute_roster(
-    keys: Vec<QueryKey>,
-    token: String,
-) -> QueryResult<QueryValue, QueryError> {
-    if let Some(QueryKey::Tributes(game_identifier)) = keys.first() {
+impl QueryCapability for TributeQ {
+    type Ok = Box<Tribute>;
+    type Err = QueryError;
+    type Keys = (String, String);
+
+    async fn run(&self, keys: &(String, String)) -> Result<Box<Tribute>, QueryError> {
+        let (game_identifier, tribute_identifier) = keys;
         let client = reqwest::Client::new();
         let request = client
             .request(
                 reqwest::Method::GET,
                 format!(
-                    "{}/api/games/{}/tributes?limit=24&offset=0",
-                    APP_API_HOST, game_identifier
+                    "{}/api/games/{}/tributes/{}",
+                    APP_API_HOST, game_identifier, tribute_identifier
                 ),
             )
-            .bearer_auth(token);
+            .bearer_auth(&self.token);
         match request.send().await {
-            Ok(response) => match response.json::<PaginatedTributesResponse>().await {
-                Ok(tributes) => Ok(QueryValue::PaginatedTributes(tributes)),
-                Err(_) => Err(QueryError::BadJson),
-            },
-            Err(_) => Err(QueryError::GameNotFound(game_identifier.to_string())),
+            Ok(response) => {
+                if response.status().is_success() {
+                    match response.json::<Option<Tribute>>().await {
+                        Ok(Some(tribute)) => Ok(Box::new(tribute)),
+                        _ => Err(QueryError::TributeNotFound(tribute_identifier.to_string())),
+                    }
+                } else {
+                    Err(QueryError::TributeNotFound(tribute_identifier.to_string()))
+                }
+            }
+            Err(_) => Err(QueryError::Unknown),
         }
-    } else {
-        Err(QueryError::Unknown)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct TributeLogQ {
+    pub token: String,
+}
+
+impl QueryCapability for TributeLogQ {
+    type Ok = Vec<GameMessage>;
+    type Err = QueryError;
+    type Keys = (String, String);
+
+    async fn run(&self, keys: &(String, String)) -> Result<Vec<GameMessage>, QueryError> {
+        let (game_identifier, identifier) = keys;
+        let client = reqwest::Client::new();
+        let request = client
+            .request(
+                reqwest::Method::GET,
+                format!(
+                    "{}/api/games/{}/tributes/{}/log",
+                    APP_API_HOST, game_identifier, identifier
+                ),
+            )
+            .bearer_auth(&self.token);
+        match request.send().await {
+            Ok(response) => match response.json::<Vec<GameMessage>>().await {
+                Ok(logs) => Ok(logs),
+                Err(_) => Err(QueryError::TributeNotFound(identifier.to_string())),
+            },
+            Err(_) => Err(QueryError::TributeNotFound(identifier.to_string())),
+        }
     }
 }
 
@@ -115,55 +113,22 @@ fn trait_chip_classes(t: &Trait) -> &'static str {
     }
 }
 
-async fn fetch_tribute_log(
-    keys: Vec<QueryKey>,
-    token: String,
-) -> QueryResult<QueryValue, QueryError> {
-    if let Some(QueryKey::TributeLog(identifier)) = keys.first() {
-        if let Some(QueryKey::DisplayGame(game_identifier)) = keys.last() {
-            let client = reqwest::Client::new();
-
-            let request = client
-                .request(
-                    reqwest::Method::GET,
-                    format!(
-                        "{}/api/games/{}/tributes/{}/log",
-                        APP_API_HOST, game_identifier, identifier
-                    ),
-                )
-                .bearer_auth(token);
-
-            match request.send().await {
-                Ok(response) => match response.json::<Vec<GameMessage>>().await {
-                    Ok(logs) => QueryResult::Ok(QueryValue::Logs(logs)),
-                    Err(_) => QueryResult::Err(QueryError::TributeNotFound(identifier.to_string())),
-                },
-                Err(_) => QueryResult::Err(QueryError::TributeNotFound(identifier.to_string())),
-            }
-        } else {
-            QueryResult::Err(QueryError::Unknown)
-        }
-    } else {
-        QueryResult::Err(QueryError::Unknown)
-    }
-}
-
 #[component]
 pub fn TributeDetail(game_identifier: String, tribute_identifier: String) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
     let token = storage.get().jwt.expect("No JWT found");
 
-    let tribute_query = use_get_query(
-        [
-            QueryKey::Tribute(game_identifier.clone(), tribute_identifier.clone()),
-            QueryKey::Tributes(game_identifier.clone()),
-            QueryKey::DisplayGame(game_identifier.clone()),
-        ],
-        move |keys: Vec<QueryKey>| fetch_tribute(keys, token.clone()),
-    );
+    let tribute_query = use_query(Query::new(
+        (game_identifier.clone(), tribute_identifier.clone()),
+        TributeQ { token },
+    ));
+    let reader = tribute_query.read();
+    let state = reader.state();
 
-    match tribute_query.result().value() {
-        QueryState::Settled(Ok(QueryValue::Tribute(tribute))) => {
+    match &*state {
+        QueryStateData::Settled {
+            res: Ok(tribute), ..
+        } => {
             rsx! {
                 div {
                     class: "flex flex-row gap-4 mb-4 place-items-center place-content-between",
@@ -323,10 +288,13 @@ pub fn TributeDetail(game_identifier: String, tribute_identifier: String) -> Ele
                 }
             }
         }
-        QueryState::Settled(Err(QueryError::TributeNotFound(identifier))) => {
+        QueryStateData::Settled {
+            res: Err(QueryError::TributeNotFound(identifier)),
+            ..
+        } => {
             rsx! { p { "{identifier} not found." } }
         }
-        QueryState::Loading(_) => {
+        QueryStateData::Loading { .. } => {
             rsx! { p { "Loading..." } }
         }
         _ => {
@@ -340,16 +308,15 @@ fn TributeLog(game_identifier: String, identifier: String) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
     let token = storage.get().jwt.expect("No JWT found");
 
-    let log_query = use_get_query(
-        [
-            QueryKey::TributeLog(identifier.clone()),
-            QueryKey::DisplayGame(game_identifier.clone()),
-        ],
-        move |keys: Vec<QueryKey>| fetch_tribute_log(keys, token.clone()),
-    );
+    let log_query = use_query(Query::new(
+        (game_identifier.clone(), identifier.clone()),
+        TributeLogQ { token },
+    ));
+    let reader = log_query.read();
+    let state = reader.state();
 
-    match log_query.result().value() {
-        QueryState::Settled(Ok(QueryValue::Logs(logs))) => {
+    match &*state {
+        QueryStateData::Settled { res: Ok(logs), .. } => {
             rsx! {
                 ul {
                     class: "theme1:text-stone-200 theme2:text-green-200 theme3:text-stone-800",
@@ -365,10 +332,10 @@ fn TributeLog(game_identifier: String, identifier: String) -> Element {
                 }
             }
         }
-        QueryState::Settled(Err(_)) => {
+        QueryStateData::Settled { res: Err(_), .. } => {
             rsx! { p { "Failed to load." }  }
         }
-        QueryState::Loading(_) => {
+        QueryStateData::Loading { .. } => {
             rsx! { p { "Loading..." }  }
         }
         _ => {
@@ -443,16 +410,14 @@ fn TributeAllies(game_identifier: String, ally_ids: Vec<uuid::Uuid>) -> Element 
     let storage = use_persistent("hangry-games", AppState::default);
     let token = storage.get().jwt.expect("No JWT found");
 
-    let roster_query = use_get_query(
-        [
-            QueryKey::Tributes(game_identifier.clone()),
-            QueryKey::DisplayGame(game_identifier.clone()),
-        ],
-        move |keys: Vec<QueryKey>| fetch_tribute_roster(keys, token.clone()),
-    );
+    let roster_query = use_query(Query::new(game_identifier.clone(), GameTributesQ { token }));
+    let reader = roster_query.read();
+    let state = reader.state();
 
-    match roster_query.result().value() {
-        QueryState::Settled(Ok(QueryValue::PaginatedTributes(response))) => {
+    match &*state {
+        QueryStateData::Settled {
+            res: Ok(response), ..
+        } => {
             let roster = response.tributes.clone();
             rsx! {
                 ul {
@@ -501,13 +466,13 @@ fn TributeAllies(game_identifier: String, ally_ids: Vec<uuid::Uuid>) -> Element 
                 }
             }
         }
-        QueryState::Settled(Err(_)) => rsx! {
+        QueryStateData::Settled { res: Err(_), .. } => rsx! {
             p {
                 class: "text-sm italic opacity-75",
                 "Failed to load allies."
             }
         },
-        QueryState::Loading(_) => rsx! {
+        QueryStateData::Loading { .. } => rsx! {
             p {
                 class: "text-sm italic opacity-75",
                 "Loading allies..."

--- a/web/src/components/tribute_edit.rs
+++ b/web/src/components/tribute_edit.rs
@@ -1,43 +1,50 @@
-use crate::cache::{MutationError, MutationValue, QueryError, QueryKey, QueryValue};
+use crate::cache::MutationError;
+use crate::components::game_tributes::GameTributesQ;
 use crate::components::icons::edit::EditIcon;
 use crate::components::modal::{Modal, Props as ModalProps};
+use crate::components::tribute_detail::TributeQ;
 use crate::components::{Button, Input};
 use crate::env::APP_API_HOST;
 use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
-use dioxus_query::prelude::{MutationResult, MutationState, use_mutation, use_query_client};
+use dioxus_query::prelude::*;
 use shared::EditTribute;
-use std::ops::Deref;
 
-async fn edit_tribute(
-    args: (EditTribute, String, String),
-) -> MutationResult<MutationValue, MutationError> {
-    let tribute = args.clone().0;
-    let identifier = args.clone().0.identifier.clone();
-    let game_identifier = args.clone().1;
-    let token = args.clone().2;
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct EditTributeM;
 
-    let client = reqwest::Client::new();
-    let url: String = format!(
-        "{}/api/games/{}/tributes/{}",
-        APP_API_HOST, game_identifier, identifier
-    );
+impl MutationCapability for EditTributeM {
+    type Ok = String;
+    type Err = MutationError;
+    type Keys = (EditTribute, String, String);
 
-    let response = client
-        .put(url)
-        .bearer_auth(token)
-        .json(&tribute.clone())
-        .send()
-        .await;
+    async fn run(&self, args: &(EditTribute, String, String)) -> Result<String, MutationError> {
+        let tribute = args.0.clone();
+        let identifier = tribute.identifier.clone();
+        let game_identifier = args.1.clone();
+        let token = args.2.clone();
+        let client = reqwest::Client::new();
+        let url: String = format!(
+            "{}/api/games/{}/tributes/{}",
+            APP_API_HOST, game_identifier, identifier
+        );
+        let response = client
+            .put(url)
+            .bearer_auth(token)
+            .json(&tribute)
+            .send()
+            .await;
+        match response {
+            Ok(r) if r.status().is_success() => Ok(identifier),
+            _ => Err(MutationError::Unknown),
+        }
+    }
 
-    if response
-        .expect("Failed to update tribute")
-        .status()
-        .is_success()
-    {
-        Ok(MutationValue::TributeUpdated(identifier))
-    } else {
-        Err(MutationError::Unknown)
+    async fn on_settled(&self, _keys: &Self::Keys, result: &Result<Self::Ok, Self::Err>) {
+        if result.is_ok() {
+            QueriesStorage::<TributeQ>::invalidate_all().await;
+            QueriesStorage::<GameTributesQ>::invalidate_all().await;
+        }
     }
 }
 
@@ -118,13 +125,11 @@ pub fn EditTributeForm() -> Element {
     let mut avatar_preview = use_signal(|| avatar.clone());
     let mut upload_status = use_signal(String::new);
 
-    let mutate = use_mutation(edit_tribute);
+    let mutate = use_mutation(Mutation::new(EditTributeM));
 
     let dismiss = move |_| {
         edit_tribute_signal.set(None);
     };
-
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
 
     let game_identifier_for_upload = game_identifier.clone();
 
@@ -138,8 +143,10 @@ pub fn EditTributeForm() -> Element {
         let identifier = tribute_details.identifier.clone();
         let current_avatar = avatar_preview.read().clone();
 
-        let data = e.data().values();
-        let name = data.get("name").expect("No name value").0[0].clone();
+        let name = match e.data().get_first("name") {
+            Some(FormValue::Text(s)) => s,
+            _ => return,
+        };
 
         if !name.is_empty() {
             let edit_tribute = EditTribute {
@@ -149,18 +156,11 @@ pub fn EditTributeForm() -> Element {
                 game_identifier: game_identifier.clone(),
             };
             spawn(async move {
-                mutate
+                let reader = mutate
                     .mutate_async((edit_tribute.clone(), game_identifier.clone(), token))
                     .await;
-                edit_tribute_signal.set(Some(edit_tribute));
-
-                if let MutationState::Settled(Ok(MutationValue::TributeUpdated(identifier))) =
-                    mutate.result().deref()
-                {
-                    client.invalidate_queries(&[QueryKey::Tribute(
-                        game_identifier.clone(),
-                        identifier.clone(),
-                    )]);
+                let state = reader.state();
+                if matches!(&*state, MutationStateData::Settled { res: Ok(_), .. }) {
                     edit_tribute_signal.set(None);
                 }
             });
@@ -177,11 +177,14 @@ pub fn EditTributeForm() -> Element {
         spawn(async move {
             let files = e.files();
 
-            if let Some(file_engine) = files
-                && let Some(file_name) = file_engine.files().into_iter().next()
-                && let Some(file_data) = file_engine.read_file(&file_name).await
-            {
-                // Upload file using multipart/form-data
+            if let Some(file) = files.into_iter().next() {
+                let file_name = file.name();
+                let Ok(bytes) = file.read_bytes().await else {
+                    upload_status.set("Upload error: failed to read file".to_string());
+                    return;
+                };
+                let file_data = bytes.to_vec();
+
                 let client = reqwest::Client::new();
                 let url = format!(
                     "{}/api/games/{}/tributes/{}/avatar",

--- a/web/src/hooks/use_timeline_summary.rs
+++ b/web/src/hooks/use_timeline_summary.rs
@@ -1,30 +1,34 @@
-use crate::cache::{QueryError, QueryKey, QueryValue};
+use crate::cache::QueryError;
 use crate::env::APP_API_HOST;
 use dioxus_query::prelude::*;
 use reqwest::StatusCode;
 use shared::messages::TimelineSummary;
 
-pub(crate) async fn fetch_timeline_summary(
-    keys: Vec<QueryKey>,
-) -> QueryResult<QueryValue, QueryError> {
-    let Some(QueryKey::TimelineSummary(id)) = keys.first() else {
-        return Err(QueryError::Unknown);
-    };
-    let url = format!("{APP_API_HOST}/api/games/{id}/timeline-summary");
-    match reqwest::get(&url).await {
-        Ok(resp) => match resp.status() {
-            StatusCode::OK => match resp.json::<TimelineSummary>().await {
-                Ok(s) => Ok(QueryValue::TimelineSummary(s)),
-                Err(_) => Err(QueryError::BadJson),
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct TimelineSummaryQ;
+
+impl QueryCapability for TimelineSummaryQ {
+    type Ok = TimelineSummary;
+    type Err = QueryError;
+    type Keys = String;
+
+    async fn run(&self, id: &String) -> Result<TimelineSummary, QueryError> {
+        let url = format!("{APP_API_HOST}/api/games/{id}/timeline-summary");
+        match reqwest::get(&url).await {
+            Ok(resp) => match resp.status() {
+                StatusCode::OK => match resp.json::<TimelineSummary>().await {
+                    Ok(s) => Ok(s),
+                    Err(_) => Err(QueryError::BadJson),
+                },
+                StatusCode::NOT_FOUND => Err(QueryError::GameNotFound(id.clone())),
+                _ => Err(QueryError::Unknown),
             },
-            StatusCode::NOT_FOUND => Err(QueryError::GameNotFound(id.clone())),
-            _ => Err(QueryError::Unknown),
-        },
-        Err(_) => Err(QueryError::ServerNotFound),
+            Err(_) => Err(QueryError::ServerNotFound),
+        }
     }
 }
 
 #[allow(dead_code)]
-pub(crate) fn use_timeline_summary(game_id: String) -> UseQuery<QueryValue, QueryError, QueryKey> {
-    use_get_query([QueryKey::TimelineSummary(game_id)], fetch_timeline_summary)
+pub(crate) fn use_timeline_summary(game_id: String) -> UseQuery<TimelineSummaryQ> {
+    use_query(Query::new(game_id, TimelineSummaryQ))
 }


### PR DESCRIPTION
## Summary

- Migrates the `web` crate from dioxus 0.6.3 → 0.7.7, dioxus-query 0.7 → 0.9.2, and dioxus-cli 0.6 → 0.7.7.
- Replaces the old keyed `QueryKey`/`QueryValue` cache with per-capability struct types (one `QueryCapability`/`MutationCapability` per query family) and uses `on_settled` for invalidation.
- Updates form/file event handling to the new `FormData`/`FileData` APIs and hoists `use_navigator()` out of spawned async blocks (required in 0.7).
- Adds `Eq + Hash` to shared mutation key structs (`DeleteGame`, `EditGame`, `EditTribute`, `RegistrationUser`) so they satisfy the new `MutationCapability::Keys` bound.

## Verification

- `cargo check -p web --target wasm32-unknown-unknown` (with `RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"'`) — clean.
- `cargo clippy -p web --target wasm32-unknown-unknown` — clean.
- `cargo test -p shared -p game` — all pass.
- `cargo fmt` applied.

## Manual testing notes

- `just build-css` to regenerate `web/assets/dist/main.css` (a placeholder is checked in for type checking).
- `dx serve` (or `just dev`) and verify: login/register flow, create game, advance game (next step), edit game, delete game, edit tribute (especially file upload — most-rewritten path), view tributes/areas/timeline, server version footer.
- Confirm form submissions don't navigate, and that mutation invalidation refreshes lists/detail after create/delete/next-step.