### PR TITLE
chore(deps): upgrade strum/strum_macros 0.27 -> 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shared",
- "strum",
+ "strum 0.28.0",
  "surrealdb",
  "surrealdb-migrations",
  "thiserror 2.0.18",
@@ -358,7 +358,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "strum",
+ "strum 0.27.2",
  "syn 2.0.117",
  "thiserror 2.0.18",
 ]
@@ -2795,8 +2795,8 @@ dependencies = [
  "serde",
  "serde_json",
  "shared",
- "strum",
- "strum_macros",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6517,7 +6517,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -6525,6 +6534,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,7 +15,7 @@ jsonwebtoken = { version = "10.0", default-features = false, features = ["aws_lc
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 shared = { path = "../shared" }
-strum = { version = "0.27.1", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 surrealdb = "2.3.2"
 surrealdb-migrations = "2.2.2"
 thiserror = "2.0.18"

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -13,8 +13,8 @@ rand = { version = "0.9.1", features = ["small_rng"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 shared = { path = "../shared" }
-strum = { version = "0.27.1", features = ["derive"] }
-strum_macros = "0.27.1"
+strum = { version = "0.28", features = ["derive"] }
+strum_macros = "0.28"
 thiserror = "2.0.18"
 tracing = "0.1.44"
 uuid = { version = "1.23.1", features = ["v4", "js", "serde"] }


### PR DESCRIPTION
## Summary

- Bumps `strum` and `strum_macros` from 0.27.1 to 0.28.0 in `game` and `api`.
- No source changes required.

## Verification

- `cargo check -p game -p api` — clean.
- `cargo clippy -p game -p api --all-targets -- -D warnings` — clean.
- `cargo test -p game --tests --lib` — all pass.