### PR TITLE
chore(deps): upgrade rand 0.9 -> 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
 dependencies = [
  "chrono",
  "derive_builder",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -2833,7 +2833,7 @@ dependencies = [
  "fake",
  "indefinite",
  "once_cell",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rstest",
  "serde",
  "serde_json",

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -9,7 +9,7 @@ chrono = { version = "0.4.44", features = ["serde"] }
 fake = "4.3.0"
 indefinite = "0.1.11"
 once_cell = "1.21.4"
-rand = { version = "0.9.1", features = ["small_rng"] }
+rand = "0.10"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 shared = { path = "../shared" }

--- a/game/src/areas/events.rs
+++ b/game/src/areas/events.rs
@@ -1,4 +1,5 @@
 use crate::terrain::BaseTerrain;
+use rand::RngExt;
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;

--- a/game/src/districts.rs
+++ b/game/src/districts.rs
@@ -1,5 +1,6 @@
 use crate::terrain::BaseTerrain;
 use rand::Rng;
+use rand::RngExt;
 
 /// Represents a district's industry and terrain preferences
 #[derive(Debug, Clone, Copy)]

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -8,6 +8,7 @@ use crate::tributes::statuses::TributeStatus;
 use crate::tributes::{
     ActionSuggestion, EncounterContext, EnvironmentContext, Tribute, calculate_stamina_cost,
 };
+use rand::RngExt;
 use rand::prelude::*;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};

--- a/game/src/items/mod.rs
+++ b/game/src/items/mod.rs
@@ -2,6 +2,7 @@ mod name_generator;
 
 use crate::items::name_generator::{generate_shield_name, generate_weapon_name};
 use crate::terrain::BaseTerrain;
+use rand::RngExt;
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;

--- a/game/src/terrain/assignment.rs
+++ b/game/src/terrain/assignment.rs
@@ -1,5 +1,6 @@
 use crate::terrain::config::Harshness;
 use crate::terrain::{BaseTerrain, TerrainDescriptor, TerrainType};
+use rand::RngExt;
 use rand::prelude::*;
 use strum::IntoEnumIterator;
 
@@ -68,7 +69,7 @@ impl TerrainType {
 
         // Pick 0-2 descriptors randomly
         let count = rng.random_range(0..=2);
-        compatible.choose_multiple(rng, count).copied().collect()
+        compatible.sample(rng, count).copied().collect()
     }
 }
 
@@ -90,10 +91,7 @@ pub fn enforce_balance_constraint(terrains: &mut [TerrainType], rng: &mut impl R
 
         // Reroll extras to Moderate terrains
         let to_reroll = harsh_count - 3;
-        let reroll_indices: Vec<usize> = harsh_indices
-            .choose_multiple(rng, to_reroll)
-            .copied()
-            .collect();
+        let reroll_indices: Vec<usize> = harsh_indices.sample(rng, to_reroll).copied().collect();
 
         for idx in reroll_indices {
             // Reroll to Moderate harshness terrain

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -5,6 +5,7 @@
 //! `Tribute` mutation lives here; later phases wire these helpers into
 //! the simulation loop.
 
+use rand::RngExt;
 use uuid::Uuid;
 
 use crate::tributes::traits::{REFUSERS, Trait, geometric_mean_affinity};

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -4,6 +4,7 @@ use crate::tributes::Tribute;
 use crate::tributes::actions::Action;
 use crate::tributes::traits::{ThresholdDelta, Trait};
 use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
 const LOW_ENEMY_LIMIT: u32 = 6;

--- a/game/src/tributes/combat.rs
+++ b/game/src/tributes/combat.rs
@@ -11,6 +11,7 @@ use crate::messages::{CombatEngagement, CombatOutcome, MessagePayload, TaggedEve
 use crate::output::GameOutput;
 use crate::tributes::Tribute;
 use crate::tributes::actions::{AttackOutcome, AttackResult};
+use rand::RngExt;
 use rand::prelude::*;
 use std::cmp::Ordering;
 
@@ -561,8 +562,9 @@ pub fn update_stats(attacker: &mut Tribute, defender: &mut Tribute, result: Atta
 mod tests {
     use super::*;
     use crate::tributes::Tribute;
-    use rand::RngCore;
+    use core::convert::Infallible;
     use rand::SeedableRng;
+    use rand::TryRng;
     use rand::rngs::SmallRng;
     use rstest::*;
 
@@ -705,17 +707,19 @@ mod tests {
         // Use a custom RNG that always returns the high bits needed for
         // `random_range(1..=20)` to produce 20 under rand 0.9's algorithm.
         struct CritRng;
-        impl RngCore for CritRng {
-            fn next_u32(&mut self) -> u32 {
-                0xF333_3334
+        impl TryRng for CritRng {
+            type Error = Infallible;
+            fn try_next_u32(&mut self) -> Result<u32, Infallible> {
+                Ok(0xF333_3334)
             }
-            fn next_u64(&mut self) -> u64 {
-                ((self.next_u32() as u64) << 32) | self.next_u32() as u64
+            fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+                Ok((0xF333_3334u64 << 32) | 0xF333_3334u64)
             }
-            fn fill_bytes(&mut self, dest: &mut [u8]) {
+            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {
                 for byte in dest.iter_mut() {
                     *byte = 0xFF;
                 }
+                Ok(())
             }
         }
 
@@ -734,17 +738,19 @@ mod tests {
     fn test_critical_fumble() {
         // Use a custom RNG that returns 0 so `random_range(1..=20)` yields 1.
         struct FumbleRng;
-        impl RngCore for FumbleRng {
-            fn next_u32(&mut self) -> u32 {
-                0
+        impl TryRng for FumbleRng {
+            type Error = Infallible;
+            fn try_next_u32(&mut self) -> Result<u32, Infallible> {
+                Ok(0)
             }
-            fn next_u64(&mut self) -> u64 {
-                0
+            fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+                Ok(0)
             }
-            fn fill_bytes(&mut self, dest: &mut [u8]) {
+            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {
                 for byte in dest.iter_mut() {
                     *byte = 0;
                 }
+                Ok(())
             }
         }
 
@@ -770,19 +776,21 @@ mod tests {
                 }
             }
         }
-        impl RngCore for BlockRng {
-            fn next_u32(&mut self) -> u32 {
+        impl TryRng for BlockRng {
+            type Error = Infallible;
+            fn try_next_u32(&mut self) -> Result<u32, Infallible> {
                 let count = self.call_count.get();
                 self.call_count.set(count + 1);
-                if count == 0 { 0x7333_3334 } else { 0xF333_3334 }
+                Ok(if count == 0 { 0x7333_3334 } else { 0xF333_3334 })
             }
-            fn next_u64(&mut self) -> u64 {
-                self.next_u32() as u64
+            fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+                Ok(self.try_next_u32().unwrap() as u64)
             }
-            fn fill_bytes(&mut self, dest: &mut [u8]) {
+            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {
                 for byte in dest.iter_mut() {
-                    *byte = self.next_u32() as u8;
+                    *byte = self.try_next_u32().unwrap() as u8;
                 }
+                Ok(())
             }
         }
 

--- a/game/src/tributes/events.rs
+++ b/game/src/tributes/events.rs
@@ -1,4 +1,5 @@
 use crate::threats::animals::Animal;
+use rand::RngExt;
 use rand::prelude::SmallRng;
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/game/src/tributes/inventory.rs
+++ b/game/src/tributes/inventory.rs
@@ -10,6 +10,7 @@
 use crate::areas::AreaDetails;
 use crate::items::{Attribute, Item, ItemError, OwnsItems};
 use crate::tributes::Tribute;
+use rand::RngExt;
 use rand::prelude::*;
 use rand::rngs::SmallRng;
 

--- a/game/src/tributes/lifecycle.rs
+++ b/game/src/tributes/lifecycle.rs
@@ -13,6 +13,7 @@ use crate::messages::{MessagePayload, TaggedEvent, TributeRef};
 use crate::output::GameOutput;
 use crate::tributes::Tribute;
 use crate::tributes::statuses::TributeStatus;
+use rand::RngExt;
 use rand::prelude::*;
 use rand::rngs::SmallRng;
 

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -23,6 +23,7 @@ use brains::Brain;
 use fake::Fake;
 use fake::faker::name::raw::*;
 use fake::locales::*;
+use rand::RngExt;
 use rand::prelude::*;
 use rand::rngs::SmallRng;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeSeq};

--- a/game/src/tributes/traits.rs
+++ b/game/src/tributes/traits.rs
@@ -2,6 +2,7 @@
 //! `docs/superpowers/specs/2026-04-25-tribute-alliances-design.md` §5.
 
 use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/game/src/witty_phrase_generator/mod.rs
+++ b/game/src/witty_phrase_generator/mod.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use rand::prelude::*;
 use rand::seq::SliceRandom;
 
@@ -84,7 +84,7 @@ impl WPGen {
         }
 
         let pool = pool[0..upper_bound]
-            .choose_multiple(&mut *self.rng.borrow_mut(), upper_bound)
+            .sample(&mut *self.rng.borrow_mut(), upper_bound)
             .collect::<Vec<&&&str>>();
 
         for selected in pool {


### PR DESCRIPTION
## Summary

- Bumps `rand` in `game` from 0.9.1 to 0.10.1.
- Removes the now-removed `small_rng` feature flag (SmallRng is always available in 0.10).
- Adds `use rand::RngExt;` in 14 modules for `random_range` / `random_bool` (moved to the `RngExt` extension trait in 0.10).
- Renames deprecated `choose_multiple` calls to `sample`.
- Rewrites the 3 custom test RNGs in `tributes::combat` (CritRng, FumbleRng, BlockRng) to impl `rand_core::TryRng<Error = Infallible>` (the new path to satisfy `Rng`).

## Verification

- `cargo check -p game` — clean.
- `cargo clippy -p game --all-targets -- -D warnings` — clean.
- `cargo test -p game --tests --lib` — all pass.