### PR TITLE
chore(deps): upgrade fake 4.x -> 5.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,13 +2585,13 @@ dependencies = [
 
 [[package]]
 name = "fake"
-version = "4.4.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b0902eb36fbab51c14eda1c186bda119fcff91e5e4e7fc2dd2077298197ce8"
+checksum = "ea6be833b323a56361118a747470a45a1bcd5c52a2ec9b1e40c83dafe687e453"
 dependencies = [
  "deunicode",
  "either",
- "rand 0.9.4",
+ "rand 0.10.1",
 ]
 
 [[package]]

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
-fake = "4.3.0"
+fake = "5"
 indefinite = "0.1.11"
 once_cell = "1.21.4"
 rand = { version = "0.9.1", features = ["small_rng"] }


### PR DESCRIPTION
## Summary

- Bumps `fake` in `game` from 4.4.0 to 5.1.0.
- The `Name(EN).fake()` API used in `tributes::mod` is source-compatible; no code changes.

## Verification

- `cargo check -p game` — clean.
- `cargo clippy -p game --all-targets -- -D warnings` — clean.
- `cargo test -p game --tests --lib` — all pass.