### PR TITLE
chore(deps): upgrade rstest 0.25 -> 0.26 (game tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5934,21 +5934,20 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { version = "1.23.1", features = ["v4", "js", "serde"] }
 
 [dev-dependencies]
 criterion = "0.5"
-rstest = "0.25.0"
+rstest = "0.26"
 tokio = { version = "1.52.1", features = ["macros", "rt"] }
 
 [[bench]]


### PR DESCRIPTION
## Summary

- Bumps `rstest` dev-dep in `game` from 0.25.0 to 0.26.1.
- No source changes; `#[rstest]` / `#[fixture]` API is compatible.

## Verification

- `cargo test -p game --tests --lib` — all pass.
- `cargo clippy -p game --all-targets -- -D warnings` — clean.