### PR TITLE
chore(deps): upgrade getrandom 0.3 -> 0.4 (web wasm)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2970,11 +2970,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -8158,7 +8160,7 @@ dependencies = [
  "dotenvy",
  "futures-util",
  "game",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "gloo-net 0.7.0",
  "gloo-storage",
  "jwt-rustcrypto",

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -29,4 +29,4 @@ web = ["dioxus/web"]
 
 [dependencies.getrandom]
 features = ["wasm_js"]
-version = "0.3"
+version = "0.4"


### PR DESCRIPTION
## Summary

Bumps the `web` crate's direct `getrandom` dep from 0.3 to 0.4. `rand 0.10` and `uuid 1.23.1` already pull in getrandom 0.4.2; `web`'s explicit dep was the only thing keeping 0.3 in the wasm bundle.

## Changes

- `web/Cargo.toml`: `getrandom = { version = "0.3", features = ["wasm_js"] }` → `version = "0.4"`
- `Cargo.lock`: regenerated

## Verification

- `cargo check -p web --target wasm32-unknown-unknown` with `RUSTFLAGS='--cfg getrandom_backend="wasm_js"'` — clean

## Notes

getrandom 0.4 has no breaking API/cfg/feature changes vs 0.3.4: the `wasm_js` feature flag and `--cfg getrandom_backend="wasm_js"` both still work. MSRV bumped to 1.85 (Edition 2024); current toolchain meets it. The `RUSTFLAGS` prefixes in the justfile are now technically optional (the feature alone is sufficient since 0.3.4) but left in place for backwards compatibility — separate cleanup if desired.

Closes hangrier_games-v4n.