### PR TITLE
fix(web): send bearer token on timeline-summary and day-log fetches

### DIFF
--- a/web/src/components/game_period_page.rs
+++ b/web/src/components/game_period_page.rs
@@ -9,13 +9,16 @@ use crate::components::filter_chips::FilterChips;
 use crate::components::timeline::{PeriodFilters, Timeline};
 use crate::env::APP_API_HOST;
 use crate::hooks::use_timeline_summary::use_timeline_summary;
+use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
 use reqwest::StatusCode;
 use shared::messages::{GameMessage, Phase};
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-struct DayLogQ;
+struct DayLogQ {
+    token: String,
+}
 
 impl QueryCapability for DayLogQ {
     type Ok = Vec<GameMessage>;
@@ -25,12 +28,18 @@ impl QueryCapability for DayLogQ {
     async fn run(&self, keys: &(String, u32)) -> Result<Vec<GameMessage>, QueryError> {
         let (id, day) = keys;
         let url = format!("{APP_API_HOST}/api/games/{id}/log/{day}");
-        match reqwest::get(&url).await {
+        let resp = reqwest::Client::new()
+            .get(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .await;
+        match resp {
             Ok(resp) => match resp.status() {
                 StatusCode::OK => match resp.json::<Vec<GameMessage>>().await {
                     Ok(v) => Ok(v),
                     Err(_) => Err(QueryError::BadJson),
                 },
+                StatusCode::UNAUTHORIZED => Err(QueryError::Unauthorized),
                 StatusCode::NOT_FOUND => Err(QueryError::GameNotFound(id.clone())),
                 _ => Err(QueryError::Unknown),
             },
@@ -44,7 +53,10 @@ pub fn GamePeriodPage(identifier: String, day: u32, phase: Phase) -> Element {
     let filters: Signal<PeriodFilters> = use_context();
     let filter = filters.read().filter_for(&identifier);
 
-    let summary_q = use_timeline_summary(identifier.clone());
+    let storage = use_persistent("hangry-games", AppState::default);
+    let token = storage.get().jwt.unwrap_or_default();
+
+    let summary_q = use_timeline_summary(identifier.clone(), token.clone());
 
     let valid = {
         let reader = summary_q.read();
@@ -67,7 +79,12 @@ pub fn GamePeriodPage(identifier: String, day: u32, phase: Phase) -> Element {
         };
     }
 
-    let log_q = use_query(Query::new((identifier.clone(), day), DayLogQ));
+    let log_q = use_query(Query::new(
+        (identifier.clone(), day),
+        DayLogQ {
+            token: token.clone(),
+        },
+    ));
     let reader = log_q.read();
     let state = reader.state();
 

--- a/web/src/components/period_grid.rs
+++ b/web/src/components/period_grid.rs
@@ -7,6 +7,7 @@ use crate::cache::QueryError;
 use crate::components::period_card::PeriodCard;
 use crate::components::period_grid_empty::{EmptyKind, PeriodGridEmpty};
 use crate::hooks::use_timeline_summary;
+use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
 
@@ -17,7 +18,9 @@ pub struct PeriodGridProps {
 
 #[component]
 pub fn PeriodGrid(props: PeriodGridProps) -> Element {
-    let query = use_timeline_summary(props.game_identifier.clone());
+    let storage = use_persistent("hangry-games", AppState::default);
+    let token = storage.get().jwt.unwrap_or_default();
+    let query = use_timeline_summary(props.game_identifier.clone(), token);
     let reader = query.read();
     let state = reader.state();
     match &*state {

--- a/web/src/hooks/use_timeline_summary.rs
+++ b/web/src/hooks/use_timeline_summary.rs
@@ -5,7 +5,9 @@ use reqwest::StatusCode;
 use shared::messages::TimelineSummary;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub(crate) struct TimelineSummaryQ;
+pub(crate) struct TimelineSummaryQ {
+    pub token: String,
+}
 
 impl QueryCapability for TimelineSummaryQ {
     type Ok = TimelineSummary;
@@ -14,12 +16,18 @@ impl QueryCapability for TimelineSummaryQ {
 
     async fn run(&self, id: &String) -> Result<TimelineSummary, QueryError> {
         let url = format!("{APP_API_HOST}/api/games/{id}/timeline-summary");
-        match reqwest::get(&url).await {
+        let resp = reqwest::Client::new()
+            .get(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .await;
+        match resp {
             Ok(resp) => match resp.status() {
                 StatusCode::OK => match resp.json::<TimelineSummary>().await {
                     Ok(s) => Ok(s),
                     Err(_) => Err(QueryError::BadJson),
                 },
+                StatusCode::UNAUTHORIZED => Err(QueryError::Unauthorized),
                 StatusCode::NOT_FOUND => Err(QueryError::GameNotFound(id.clone())),
                 _ => Err(QueryError::Unknown),
             },
@@ -29,6 +37,6 @@ impl QueryCapability for TimelineSummaryQ {
 }
 
 #[allow(dead_code)]
-pub(crate) fn use_timeline_summary(game_id: String) -> UseQuery<TimelineSummaryQ> {
-    use_query(Query::new(game_id, TimelineSummaryQ))
+pub(crate) fn use_timeline_summary(game_id: String, token: String) -> UseQuery<TimelineSummaryQ> {
+    use_query(Query::new(game_id, TimelineSummaryQ { token }))
 }


### PR DESCRIPTION
## Summary

Closes hangrier_games-u75: 401 on `/api/games/<id>/timeline-summary`.

`use_timeline_summary` and `DayLogQ` (in `game_period_page.rs`) called `reqwest::get(url)` with **no `Authorization` header**, while every other game fetcher uses `.bearer_auth(token)`. The router-level `surreal_jwt` middleware returned 401 for these requests; the fetchers collapsed all non-200/404 statuses to `QueryError::Unknown`, surfacing the failure as a generic "couldn't load" state. The intermittence came from dioxus-query serving stale cached values when present.

## Changes

- `web/src/hooks/use_timeline_summary.rs`: `TimelineSummaryQ` carries a `token` field; uses `bearer_auth`; maps 401 to `QueryError::Unauthorized`. `use_timeline_summary` takes `token: String`.
- `web/src/components/period_grid.rs`: pulls JWT from `AppState` storage and threads it into the hook call.
- `web/src/components/game_period_page.rs`: same fix for `DayLogQ`; threads the token to both the timeline-summary hook and the day-log query.

## Verification

- `cargo check -p web --target wasm32-unknown-unknown` — clean
- `cargo fmt --all -- --check` — clean

## Repro (before fix)

1. Log in to a game with at least one period.
2. Navigate to `/games/:id` (PeriodGrid mounts).
3. DevTools Network: `GET /api/games/<id>/timeline-summary` shows no `Authorization` header → 401.

## Notes

Did not add a regression test on the API side; the existing `api/tests/games_tests.rs::timeline_summary_*` cases use `user.auth_header()` so the auth path is exercised. A frontend integration test would catch this class of bug, but the test harness for that doesn't exist yet (covered separately by hangrier_games-333).