### PR TITLE
fix(web): show Live Events in chronological order

### DIFF
--- a/web/src/components/game_detail.rs
+++ b/web/src/components/game_detail.rs
@@ -143,7 +143,7 @@ pub fn GamePage(identifier: String) -> Element {
                 div {
                     class: "bg-gray-100 p-4 rounded-lg max-h-64 overflow-y-auto",
                     h3 { class: "font-bold mb-2", "Live Events" }
-                    for event in ws_events.read().iter().rev() {
+                    for event in ws_events.read().iter() {
                         div { class: "text-sm py-1 border-b border-gray-200",
                             {format_game_event(event)}
                         }


### PR DESCRIPTION
## Summary

The Live Events feed was rendering reverse-chronologically: end-of-night at the top, start-of-day at the bottom. The websocket hook appends events chronologically; the bug was a stray `.rev()` on the render iterator.

## Change

`web/src/components/game_detail.rs:146`: drop `.rev()` so events render oldest-to-newest top-down.

## Verification

`cargo check -p web --target wasm32-unknown-unknown` — clean.