### PR TITLE
fix(web): surface registration validation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8170,6 +8170,7 @@ dependencies = [
  "shared",
  "tracing",
  "uuid",
+ "validator",
  "web-sys",
 ]
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.13", features = ["json", "multipart"] }
 serde_json = "1.0.149"
 tracing = "0.1.44"
 uuid = { version = "1.23.1", features = ["v4", "js", "serde"] }
+validator = { version = "0.20", features = ["derive"] }
 web-sys = { version = "0.3.97", features = ["console"] }
 
 [build-dependencies]

--- a/web/src/cache.rs
+++ b/web/src/cache.rs
@@ -18,6 +18,7 @@ pub(crate) enum MutationError {
     Unknown,
     UnableToAdvanceGame,
     UnableToRegisterUser,
+    RegistrationFailed { message: String },
     UnableToAuthenticateUser,
     _UnableToPublishGame,
     _UnableToUnpublishGame,

--- a/web/src/components/accounts.rs
+++ b/web/src/components/accounts.rs
@@ -363,10 +363,6 @@ fn RegisterForm() -> Element {
                                             let lowered = message.to_lowercase();
                                             if lowered.contains("password") {
                                                 password_error_signal.set(message.clone());
-                                            } else if lowered.contains("username")
-                                                || lowered.contains("already taken")
-                                            {
-                                                username_error_signal.set(message.clone());
                                             } else if !message.is_empty() {
                                                 username_error_signal.set(message.clone());
                                             } else {

--- a/web/src/components/accounts.rs
+++ b/web/src/components/accounts.rs
@@ -6,6 +6,7 @@ use crate::storage::{AppState, use_persistent};
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
 use shared::{AuthenticatedUser, RegistrationUser};
+use validator::Validate;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub(crate) struct RegisterUserM;
@@ -28,10 +29,23 @@ impl MutationCapability for RegisterUserM {
             .send()
             .await
         {
-            Ok(response) => match response.json::<AuthenticatedUser>().await {
-                Ok(user) => Ok(user),
-                Err(_) => Err(MutationError::UnableToRegisterUser),
-            },
+            Ok(response) => {
+                if response.status().is_success() {
+                    match response.json::<AuthenticatedUser>().await {
+                        Ok(user) => Ok(user),
+                        Err(_) => Err(MutationError::UnableToRegisterUser),
+                    }
+                } else {
+                    let body: serde_json::Value =
+                        response.json().await.unwrap_or(serde_json::Value::Null);
+                    let message = body
+                        .get("error")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    Err(MutationError::RegistrationFailed { message })
+                }
+            }
             Err(e) => {
                 tracing::error!("error creating user: {:?}", e);
                 Err(MutationError::UnableToRegisterUser)
@@ -289,12 +303,28 @@ fn RegisterForm() -> Element {
                     password_error_signal.set(String::default());
 
                     let username = username_signal.read().clone();
-                    if username.is_empty() {
-                        username_error_signal.set("Username is required".to_string());
-                    }
-
                     let password = password_signal.read().clone();
                     let password2 = password2_signal.read().clone();
+
+                    let user = RegistrationUser {
+                        username: username.clone(),
+                        password: password.clone(),
+                    };
+                    if let Err(errs) = user.validate() {
+                        for (field, ferrs) in errs.field_errors() {
+                            let msg = ferrs
+                                .iter()
+                                .filter_map(|e| e.message.as_ref())
+                                .next()
+                                .map(|c| c.to_string())
+                                .unwrap_or_else(|| format!("{field} is invalid"));
+                            match field.as_ref() {
+                                "username" => username_error_signal.set(msg),
+                                "password" => password_error_signal.set(msg),
+                                _ => {}
+                            }
+                        }
+                    }
 
                     if password != password2 {
                         password_error_signal.set("Passwords do not match".to_string());
@@ -328,8 +358,26 @@ fn RegisterForm() -> Element {
                                     navigator.replace(Routes::GamesList {});
                                 }
                                 MutationStateData::Settled { res: Err(err), .. } => {
-                                    if let MutationError::UnableToRegisterUser = err {
-                                        username_error_signal.set("Unable to register user".to_string());
+                                    match err {
+                                        MutationError::RegistrationFailed { message } => {
+                                            let lowered = message.to_lowercase();
+                                            if lowered.contains("password") {
+                                                password_error_signal.set(message.clone());
+                                            } else if lowered.contains("username")
+                                                || lowered.contains("already taken")
+                                            {
+                                                username_error_signal.set(message.clone());
+                                            } else if !message.is_empty() {
+                                                username_error_signal.set(message.clone());
+                                            } else {
+                                                username_error_signal
+                                                    .set("Unable to register user".to_string());
+                                            }
+                                        }
+                                        _ => {
+                                            username_error_signal
+                                                .set("Unable to register user".to_string());
+                                        }
                                     }
                                     disabled_signal.set(false);
                                 }


### PR DESCRIPTION
## Summary

Closes hangrier_games-62x. Registration form previously gave a silent / generic failure when the server rejected a too-short password. Now the form validates client-side using the same `shared::RegistrationUser` validator the server uses, and parses the `{"error": ...}` body on non-2xx responses to populate the appropriate field-level error signal.

## Changes

- `web/src/cache.rs`: add `MutationError::RegistrationFailed { message }`
- `web/src/Cargo.toml`: add `validator = "0.20"` (derive feature; pure-Rust, wasm-compatible)
- `web/src/components/accounts.rs`:
  - `RegisterUserM::run` now branches on `response.status().is_success()`; reads JSON body `error` field on failure
  - `RegisterForm` submit handler calls `user.validate()` pre-submit and routes field errors to `username_error_signal` / `password_error_signal`
  - On server `RegistrationFailed`, route the message to password/username signal based on substring match ("password" / "username" / "already taken")
  - LoginForm untouched (server intentionally returns generic Unauthorized)

## Verification

- `cargo check -p web --target wasm32-unknown-unknown` — clean
- `cargo fmt --all -- --check` — clean

## Repro

Before: register with password "abc" → opaque "Unable to register user".
After: client-side rejects with "Password must be 8-72 characters" against the password field. Server-side errors (e.g. duplicate username, post-validate Conflict) also surface correctly.