### PR TITLE
fix(web): prevent runtime panics from missing JWT and uninitialized query storages

### DIFF
--- a/web/src/components/codemap.md
+++ b/web/src/components/codemap.md
@@ -438,7 +438,7 @@ div { class: "peer-focus:visible peer-focus:opacity-100" }
 ### 5. Token Extraction Pattern
 ```rust
 let storage = use_persistent("hangry-games", AppState::default);
-let token = storage.get().jwt.expect("No JWT found");
+let token = storage.get().jwt.unwrap_or_default();
 ```
 
 ---

--- a/web/src/components/create_game.rs
+++ b/web/src/components/create_game.rs
@@ -71,7 +71,7 @@ pub fn CreateGameButton() -> Element {
 
     let onclick = move |_| {
         loading_signal.set(LoadingState::Loading);
-        let token = storage.get().jwt.expect("No JWT found");
+        let token = storage.get().jwt.unwrap_or_default();
         spawn(async move {
             let _ = mutate.mutate_async((None, token)).await;
             loading_signal.set(LoadingState::Loaded);
@@ -95,7 +95,7 @@ pub fn CreateGameForm() -> Element {
     let mut loading_signal = use_context::<Signal<LoadingState>>();
 
     let onsubmit = move |_| {
-        let token = storage.get().jwt.expect("No JWT found");
+        let token = storage.get().jwt.unwrap_or_default();
         let name = game_name_signal.peek().clone();
         if name.is_empty() {
             return;

--- a/web/src/components/game_areas.rs
+++ b/web/src/components/game_areas.rs
@@ -41,7 +41,7 @@ impl QueryCapability for GameAreasQ {
 #[component]
 pub fn GameAreaList(game: DisplayGame) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
-    let token = storage.get().jwt.expect("No JWT found");
+    let token = storage.get().jwt.unwrap_or_default();
 
     let identifier = game.identifier.clone();
 

--- a/web/src/components/game_delete.rs
+++ b/web/src/components/game_delete.rs
@@ -85,7 +85,7 @@ pub fn DeleteGameModal() -> Element {
 
     let delete = move |_| {
         if let Some(dg) = delete_game_info.clone() {
-            let token = storage.get().jwt.expect("No JWT found");
+            let token = storage.get().jwt.unwrap_or_default();
             spawn(async move {
                 let reader = mutate.mutate_async((dg.clone(), token)).await;
                 let state = reader.state();

--- a/web/src/components/game_detail.rs
+++ b/web/src/components/game_detail.rs
@@ -10,7 +10,7 @@ use crate::components::period_grid::PeriodGrid;
 use crate::components::recap_card::RecapCard;
 use crate::components::timeline::PeriodFilters;
 use crate::env::APP_API_HOST;
-use crate::hooks::use_timeline_summary::TimelineSummaryQ;
+use crate::hooks::use_timeline_summary::use_timeline_summary;
 use crate::hooks::{ConnectionState, use_game_websocket};
 use crate::routes::Routes;
 use crate::storage::{AppState, use_persistent};
@@ -108,8 +108,6 @@ impl MutationCapability for NextStepM {
         if result.is_ok() {
             QueriesStorage::<DisplayGameQ>::invalidate_all().await;
             QueriesStorage::<GamesListQ>::invalidate_all().await;
-            QueriesStorage::<TimelineSummaryQ>::invalidate_all().await;
-            QueriesStorage::<crate::components::game_period_page::DayLogQ>::invalidate_all().await;
         }
     }
 }
@@ -117,6 +115,17 @@ impl MutationCapability for NextStepM {
 #[component]
 pub fn GamePage(identifier: String) -> Element {
     let (ws_events, ws_connection) = use_game_websocket(identifier.clone());
+
+    // Ensure storages exist for queries we want to invalidate from this page.
+    let storage = use_persistent("hangry-games", AppState::default);
+    let token = storage.get().jwt.unwrap_or_default();
+    let summary_q = use_timeline_summary(identifier.clone(), token.clone());
+    let game_q = use_query(Query::new(
+        identifier.clone(),
+        DisplayGameQ {
+            token: token.clone(),
+        },
+    ));
 
     let mut last_seen = use_signal(|| 0usize);
     use_effect(move || {
@@ -135,10 +144,8 @@ pub fn GamePage(identifier: String) -> Element {
         drop(evs);
         last_seen.set(len);
         if bump_phase {
-            spawn(async {
-                QueriesStorage::<TimelineSummaryQ>::invalidate_all().await;
-                QueriesStorage::<DisplayGameQ>::invalidate_all().await;
-            });
+            summary_q.invalidate();
+            game_q.invalidate();
         }
     });
 

--- a/web/src/components/game_edit.rs
+++ b/web/src/components/game_edit.rs
@@ -112,7 +112,7 @@ pub fn EditGameForm() -> Element {
 
     let save = move |e: Event<FormData>| {
         let identifier = identifier.clone();
-        let token = storage.get().jwt.expect("No JWT found");
+        let token = storage.get().jwt.unwrap_or_default();
 
         let name = match e.data().get_first("name") {
             Some(FormValue::Text(s)) => s,

--- a/web/src/components/game_tributes.rs
+++ b/web/src/components/game_tributes.rs
@@ -54,7 +54,7 @@ impl QueryCapability for GameTributesQ {
 #[component]
 pub fn GameTributes(game: DisplayGame) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
-    let token = storage.get().jwt.expect("No JWT found");
+    let token = storage.get().jwt.unwrap_or_default();
 
     let identifier = game.identifier.clone();
 
@@ -139,7 +139,7 @@ pub fn GameTributeListMember(
     game_status: GameStatus,
 ) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
-    let _token = storage.get().jwt.expect("No JWT found");
+    let _token = storage.get().jwt.unwrap_or_default();
 
     let fist_item = Item::new_weapon("basic fist");
 

--- a/web/src/components/games_list.rs
+++ b/web/src/components/games_list.rs
@@ -59,7 +59,7 @@ fn NoGames() -> Element {
 #[component]
 pub fn GamesList() -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
-    let token = storage.get().jwt.expect("No JWT found");
+    let token = storage.get().jwt.unwrap_or_default();
     let games_query = use_query(Query::new((), GamesListQ { token }));
 
     let reader = games_query.read();

--- a/web/src/components/tribute_detail.rs
+++ b/web/src/components/tribute_detail.rs
@@ -116,7 +116,7 @@ fn trait_chip_classes(t: &Trait) -> &'static str {
 #[component]
 pub fn TributeDetail(game_identifier: String, tribute_identifier: String) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
-    let token = storage.get().jwt.expect("No JWT found");
+    let token = storage.get().jwt.unwrap_or_default();
 
     let tribute_query = use_query(Query::new(
         (game_identifier.clone(), tribute_identifier.clone()),
@@ -306,7 +306,7 @@ pub fn TributeDetail(game_identifier: String, tribute_identifier: String) -> Ele
 #[component]
 fn TributeLog(game_identifier: String, identifier: String) -> Element {
     let storage = use_persistent("hangry-games", AppState::default);
-    let token = storage.get().jwt.expect("No JWT found");
+    let token = storage.get().jwt.unwrap_or_default();
 
     let log_query = use_query(Query::new(
         (game_identifier.clone(), identifier.clone()),
@@ -408,7 +408,7 @@ fn TributeAllies(game_identifier: String, ally_ids: Vec<uuid::Uuid>) -> Element 
     }
 
     let storage = use_persistent("hangry-games", AppState::default);
-    let token = storage.get().jwt.expect("No JWT found");
+    let token = storage.get().jwt.unwrap_or_default();
 
     let roster_query = use_query(Query::new(game_identifier.clone(), GameTributesQ { token }));
     let reader = roster_query.read();

--- a/web/src/components/tribute_edit.rs
+++ b/web/src/components/tribute_edit.rs
@@ -134,7 +134,7 @@ pub fn EditTributeForm() -> Element {
     let game_identifier_for_upload = game_identifier.clone();
 
     let save = move |e: Event<FormData>| {
-        let token = storage.get().jwt.expect("No JWT found");
+        let token = storage.get().jwt.unwrap_or_default();
         let game_identifier = game_identifier.clone();
         let tribute_details = edit_tribute_signal
             .read()
@@ -168,7 +168,7 @@ pub fn EditTributeForm() -> Element {
     };
 
     let upload_avatar = move |e: Event<FormData>| {
-        let token = storage.get().jwt.expect("No JWT found");
+        let token = storage.get().jwt.unwrap_or_default();
         let game_id = game_identifier_for_upload.clone();
         let tribute_id = identifier.clone();
 


### PR DESCRIPTION
## Summary

- Replace `.jwt.expect(\"No JWT found\")` with `.jwt.unwrap_or_default()` across 9 components so an expired/missing token degrades to a 401 (which the existing error UI handles) instead of panicking the WASM runtime.
- Initialize `TimelineSummaryQ` and `DisplayGameQ` storages locally in `GamePage` and invalidate via the local query handles, fixing a `Could not find context QueriesStorage<DayLogQ>` panic that fired when WebSocket phase events arrived before any consumer of those storages had rendered.

## Verification

- `RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"' cargo check -p web --target wasm32-unknown-unknown`
- Manual: refreshed an expired session and confirmed the page now shows the 401 error UI instead of the WASM panic overlay.