### PR TITLE
fix(web): prevent native form submission on auth pages

### DIFF
--- a/web/src/components/accounts.rs
+++ b/web/src/components/accounts.rs
@@ -163,7 +163,8 @@ fn LoginForm() -> Element {
                 class: "flex flex-col gap-2",
                 id: "register-form",
                 method: "POST",
-                onsubmit: move |_| {
+                onsubmit: move |evt: FormEvent| {
+                    evt.prevent_default();
                     username_error_signal.set(String::default());
                     password_error_signal.set(String::default());
 
@@ -298,7 +299,8 @@ fn RegisterForm() -> Element {
                 class: "flex flex-col gap-2",
                 id: "register-form",
                 method: "POST",
-                onsubmit: move |_| {
+                onsubmit: move |evt: FormEvent| {
+                    evt.prevent_default();
                     username_error_signal.set(String::default());
                     password_error_signal.set(String::default());
 
@@ -453,7 +455,8 @@ fn LogoutButton() -> Element {
     rsx! {
         form {
             class: "flex flex-col gap-4 mt-4",
-            onsubmit: move |_| {
+            onsubmit: move |evt: FormEvent| {
+                evt.prevent_default();
                 let prior_refresh = storage.get().refresh_token.clone();
                 let mut state = storage.get();
                 state.username = None;


### PR DESCRIPTION
## Summary

- The login, register, and account-update `onsubmit` handlers were not calling `evt.prevent_default()`, so the browser performed a native POST to `/account/` in addition to the Dioxus mutation.
- `dx serve` only allows GET/HEAD on routes, producing a 405 and a confusing double-submit. Take a typed `FormEvent` and prevent the default action in all three handlers.

## Verification

- `RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"' cargo check -p web --target wasm32-unknown-unknown`
- Manual: submitted login, register, and account-update forms in dev; no more 405s or double network requests.