### PR TITLE
fix(api): give Quickstart games a witty three-word name

### DIFF
--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -175,9 +175,12 @@ pub async fn create_game(
         .validate()
         .map_err(|e| AppError::ValidationError(format!("{}", e)))?;
 
-    // Generate server-controlled fields
+    // Generate server-controlled fields. Game::default() runs WPGen to
+    // produce a three-word "clever" name; use it as the fallback when
+    // the client didn't supply one (e.g. Quickstart).
+    let default_game = Game::default();
     let game_identifier = Uuid::new_v4().to_string();
-    let game_name = payload.name.unwrap_or_else(|| "Unnamed Game".to_string());
+    let game_name = payload.name.unwrap_or(default_game.name);
 
     // Construct Game with server-controlled fields
     let game = Game {


### PR DESCRIPTION
## Summary

POST `/api/games` without a `name` in the payload (Quickstart) was naming the new game the literal string **"Unnamed Game"**, even though `game::games::Game::default()` already generates a witty three-word name via `WPGen` (e.g. `squiggly-alert-routine`, `unshadily-sincere-pie`). The handler just wasn't using it.

## Changes

`api/src/games.rs::create_game`: replace the `"Unnamed Game"` literal with the name from `Game::default()`. Explicit names supplied by the client still win.

```rust
let default_game = Game::default();
let game_identifier = Uuid::new_v4().to_string();
let game_name = payload.name.unwrap_or(default_game.name);
```

## Verification

End-to-end in the devcontainer:

```
POST {}                          -> name= unshadily-sincere-pie
POST {"name":"My Custom Game"}   -> name= My Custom Game
POST {}                          -> name= squiggly-alert-routine
```

- `cargo fmt --all` clean
- `cargo clippy -p api -- -D warnings` clean