### PR TITLE
fix(game): make alliance formation a deliberate brain action

### DIFF
--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -912,122 +912,14 @@ impl Game {
         );
         let mut collected_events: Vec<CollectedEvent> = Vec::new();
 
-        // Alliance formation rolls (spec §6). For every pair of living
-        // tributes sharing an area where neither already lists the other as
-        // an ally and neither is at the alliance cap, run try_form_alliance.
-        // Collect successful pairs as (id_a, id_b, name_a, structured event)
-        // Alliance formation rolls (spec §6). For every pair of living
-        // tributes sharing an area where neither already lists the other as
-        // an ally and neither is at the alliance cap, run try_form_alliance.
-        // Collect successful pairs as (id_a, id_b, name_a, structured event)
-        // and apply after the immutable borrow ends. This runs *before* the
-        // per-tribute turn so newly-formed alliances are visible to
-        // pick_target this cycle.
-        type NewAlliance = (uuid::Uuid, uuid::Uuid, String, crate::events::GameEvent);
-        let mut new_alliances: Vec<NewAlliance> = Vec::new();
-        for tributes in tributes_by_area.values() {
-            for i in 0..tributes.len() {
-                for j in (i + 1)..tributes.len() {
-                    let a = tributes[i];
-                    let b = tributes[j];
-                    if a.allies.contains(&b.id) || b.allies.contains(&a.id) {
-                        continue;
-                    }
-                    if a.allies.len() >= crate::tributes::alliances::MAX_ALLIES
-                        || b.allies.len() >= crate::tributes::alliances::MAX_ALLIES
-                    {
-                        continue;
-                    }
-                    let same_district = a.district == b.district;
-                    let formed = crate::tributes::alliances::try_form_alliance(
-                        &a.traits,
-                        &b.traits,
-                        same_district,
-                        a.allies.len(),
-                        b.allies.len(),
-                        rng,
-                    );
-                    if formed {
-                        let factor = crate::tributes::alliances::deciding_factor(
-                            &a.traits,
-                            &b.traits,
-                            same_district,
-                        );
-                        let factor_label = factor
-                            .as_ref()
-                            .map(|f| f.label())
-                            .unwrap_or("mutual circumstance");
-                        let event = crate::events::GameEvent::AllianceFormed {
-                            tribute_a_id: a.id,
-                            tribute_a_name: a.name.clone(),
-                            tribute_b_id: b.id,
-                            tribute_b_name: b.name.clone(),
-                            factor: factor_label.to_string(),
-                        };
-                        new_alliances.push((a.id, b.id, a.name.clone(), event));
-                    }
-                }
-            }
-        }
-
-        // Alliance events drained from each tribute's local buffer this cycle.
-        // Appended to self.alliance_events after the mutable borrow ends, then
-        // processed via process_alliance_events so cascades resolve before the
-        // next cycle.
+        // Alliance formation now happens during each tribute's own turn via
+        // `Action::ProposeAlliance` (see `Brain::wants_to_propose_alliance`
+        // and the `Action::ProposeAlliance` arm in `Tribute::do_action`).
+        // Successful proposals enqueue `AllianceEvent::FormationRecorded`,
+        // which is applied symmetrically by `process_alliance_events` after
+        // the cycle.
         let mut drained_alliance_events: Vec<crate::tributes::alliances::AllianceEvent> =
             Vec::new();
-
-        // Apply alliance formations symmetrically. Both sides get each
-        // other's id pushed onto `allies` so the graph stays consistent.
-        // Skip duplicates defensively in case the same pair appears twice.
-        for (id_a, id_b, name_a, event) in &new_alliances {
-            // Find indices to satisfy the borrow checker for two-side mutation.
-            let mut idx_a: Option<usize> = None;
-            let mut idx_b: Option<usize> = None;
-            for (i, t) in self.tributes.iter().enumerate() {
-                if t.id == *id_a {
-                    idx_a = Some(i);
-                }
-                if t.id == *id_b {
-                    idx_b = Some(i);
-                }
-            }
-            let (Some(ia), Some(ib)) = (idx_a, idx_b) else {
-                continue;
-            };
-            // Re-check caps and existing membership at apply time in case
-            // multiple formations targeting the same tribute pushed the
-            // count over MAX_ALLIES.
-            if self.tributes[ia].allies.len() >= crate::tributes::alliances::MAX_ALLIES
-                || self.tributes[ib].allies.len() >= crate::tributes::alliances::MAX_ALLIES
-            {
-                continue;
-            }
-            if !self.tributes[ia].allies.contains(id_b) {
-                self.tributes[ia].allies.push(*id_b);
-            }
-            if !self.tributes[ib].allies.contains(id_a) {
-                self.tributes[ib].allies.push(*id_a);
-            }
-            collected_events.push((
-                self.tributes[ia].identifier.clone(),
-                name_a.clone(),
-                event.to_string(),
-                Some(crate::messages::MessagePayload::AllianceFormed {
-                    members: vec![
-                        crate::messages::TributeRef {
-                            identifier: self.tributes[ia].identifier.clone(),
-                            name: self.tributes[ia].name.clone(),
-                        },
-                        crate::messages::TributeRef {
-                            identifier: self.tributes[ib].identifier.clone(),
-                            name: self.tributes[ib].name.clone(),
-                        },
-                    ],
-                }),
-                Some(event.clone()),
-            ));
-        }
 
         // Process tributes
         for tribute in self.tributes.iter_mut() {
@@ -1378,6 +1270,77 @@ impl Game {
                     // even if their cascade roll failed.
                     for t in self.tributes.iter_mut() {
                         t.allies.retain(|x| *x != deceased);
+                    }
+                }
+                AllianceEvent::FormationRecorded {
+                    proposer,
+                    target,
+                    factor,
+                } => {
+                    let proposer_info = self
+                        .tributes
+                        .iter()
+                        .find(|t| t.id == proposer)
+                        .map(|t| (t.identifier.clone(), t.name.clone()));
+                    let target_info = self
+                        .tributes
+                        .iter()
+                        .find(|t| t.id == target)
+                        .map(|t| (t.identifier.clone(), t.name.clone()));
+                    let mut idx_p: Option<usize> = None;
+                    let mut idx_t: Option<usize> = None;
+                    for (i, t) in self.tributes.iter().enumerate() {
+                        if t.id == proposer {
+                            idx_p = Some(i);
+                        }
+                        if t.id == target {
+                            idx_t = Some(i);
+                        }
+                    }
+                    let (Some(ip), Some(it)) = (idx_p, idx_t) else {
+                        continue;
+                    };
+                    if self.tributes[ip].allies.len() >= crate::tributes::alliances::MAX_ALLIES
+                        || self.tributes[it].allies.len() >= crate::tributes::alliances::MAX_ALLIES
+                    {
+                        continue;
+                    }
+                    if !self.tributes[ip].allies.contains(&target) {
+                        self.tributes[ip].allies.push(target);
+                    }
+                    if !self.tributes[it].allies.contains(&proposer) {
+                        self.tributes[it].allies.push(proposer);
+                    }
+                    if let (Some((p_id, p_name)), Some((t_id, t_name))) =
+                        (proposer_info, target_info)
+                    {
+                        let event = crate::events::GameEvent::AllianceFormed {
+                            tribute_a_id: proposer,
+                            tribute_a_name: p_name.clone(),
+                            tribute_b_id: target,
+                            tribute_b_name: t_name.clone(),
+                            factor: factor.clone(),
+                        };
+                        let payload = crate::messages::MessagePayload::AllianceFormed {
+                            members: vec![
+                                crate::messages::TributeRef {
+                                    identifier: p_id.clone(),
+                                    name: p_name.clone(),
+                                },
+                                crate::messages::TributeRef {
+                                    identifier: t_id,
+                                    name: t_name,
+                                },
+                            ],
+                        };
+                        let tick = self.tick_counter.next();
+                        self.push_message(
+                            crate::messages::MessageSource::Tribute(p_id),
+                            p_name,
+                            event.to_string(),
+                            payload,
+                            tick,
+                        );
                     }
                 }
             }
@@ -1908,8 +1871,13 @@ mod tests {
 
         // Loop a few seeded cycles until at least one forms; if production
         // wiring is correct this should hit within a handful of trials.
+        // Alliance formation is now a deliberate `Action::ProposeAlliance`
+        // gated by Brain::wants_to_propose_alliance (5%-15% per turn for
+        // eligible tributes). Sweep many seeds so we deterministically hit at
+        // least one cycle where a Friendly same-district pair proposes and
+        // succeeds.
         let mut formed = false;
-        for seed in [313u64, 419, 547, 23, 89, 211] {
+        for seed in 0u64..400 {
             let mut g = game.clone();
             let mut rng = SmallRng::seed_from_u64(seed);
             let _ = g.run_tribute_cycle(

--- a/game/src/tributes/actions.rs
+++ b/game/src/tributes/actions.rs
@@ -27,6 +27,11 @@ pub enum Action {
     Attack,
     Hide,
     TakeItem,
+    /// Spend the turn proposing an alliance to a non-allied tribute in the
+    /// current area. The proposal succeeds or fails via the existing alliance
+    /// roll (`game::tributes::alliances::try_form_alliance`); either way the
+    /// turn is consumed. See spec §6.1.
+    ProposeAlliance,
 }
 
 impl Display for Action {
@@ -39,6 +44,7 @@ impl Display for Action {
             Action::Attack => write!(f, "attack"),
             Action::Hide => write!(f, "hide"),
             Action::TakeItem => write!(f, "take item"),
+            Action::ProposeAlliance => write!(f, "propose alliance"),
         }
     }
 }
@@ -55,6 +61,7 @@ impl FromStr for Action {
             "attack" => Ok(Action::Attack),
             "hide" => Ok(Action::Hide),
             "take item" => Ok(Action::TakeItem),
+            "propose alliance" => Ok(Action::ProposeAlliance),
             _ => Err(()),
         }
     }

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -20,6 +20,15 @@ pub const TREACHEROUS_BETRAYAL_INTERVAL: u8 = 5;
 /// Events emitted by tribute turns and drained by the game cycle. Pure data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AllianceEvent {
+    /// A successful alliance proposal during the proposer's turn. The game
+    /// loop applies the symmetric `allies` push to both tributes and emits
+    /// the `AllianceFormed` message. Carrying the deciding factor lets the
+    /// game-side message reuse the same prose as the legacy pre-pass.
+    FormationRecorded {
+        proposer: Uuid,
+        target: Uuid,
+        factor: String,
+    },
     BetrayalRecorded {
         betrayer: Uuid,
         victim: Uuid,

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -2,7 +2,8 @@ use crate::areas::{Area, AreaDetails};
 use crate::terrain::{BaseTerrain, Harshness, TerrainType, Visibility};
 use crate::tributes::Tribute;
 use crate::tributes::actions::Action;
-use crate::tributes::traits::{ThresholdDelta, Trait};
+use crate::tributes::alliances::MAX_ALLIES;
+use crate::tributes::traits::{REFUSERS, ThresholdDelta, Trait, geometric_mean_affinity};
 use rand::Rng;
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
@@ -258,6 +259,14 @@ impl Brain {
             return preferred_action.clone();
         }
 
+        // Spec §6.1: alliance proposals are a deliberate first-class action,
+        // not an automatic encounter side-effect. Considered before the
+        // health/sanity branching below so a healthy social tribute
+        // occasionally spends a turn forming bonds instead of attacking.
+        if self.wants_to_propose_alliance(tribute, nearby_tributes, rng) {
+            return Action::ProposeAlliance;
+        }
+
         // Does the tribute have items?
         let has_consumables = !tribute.consumables().is_empty();
         if has_consumables {
@@ -397,6 +406,12 @@ impl Brain {
             return preferred_action.clone();
         }
 
+        // Spec §6.1: alliance proposals are a deliberate first-class action.
+        // Mirrors the gate in `act` so terrain-aware paths behave the same.
+        if self.wants_to_propose_alliance(tribute, nearby_tributes, rng) {
+            return Action::ProposeAlliance;
+        }
+
         // Check if we have consumables
         let has_consumables = !tribute.consumables().is_empty();
         if has_consumables {
@@ -510,6 +525,52 @@ impl Brain {
             _ if is_concealed => Action::Hide,
             _ => Action::Hide,
         }
+    }
+
+    /// Decide whether the tribute spends this turn proposing an alliance.
+    ///
+    /// Returns true with low probability when ALL of the following hold:
+    /// - At least one nearby tribute exists (potential candidate).
+    /// - Tribute has not yet hit the per-tribute alliance cap (`MAX_ALLIES`).
+    /// - Tribute is healthy enough to socialize (above `low_health`).
+    /// - Tribute is sane enough to think (above `low_sanity`).
+    /// - Tribute carries no refuser trait (Lone Wolf, Paranoid).
+    /// - Tribute's own trait affinity is at least neutral
+    ///   (`geometric_mean_affinity >= 1.0`).
+    ///
+    /// The base proposal chance is intentionally small (5%) and scales with
+    /// trait affinity (Friendly/Loyal push it up). Even at the upper bound
+    /// this fires for far fewer tributes per cycle than the legacy O(N\u00b2)
+    /// pre-pass, which is the entire point of moving the trigger here.
+    fn wants_to_propose_alliance(
+        &self,
+        tribute: &Tribute,
+        nearby_tributes: u32,
+        rng: &mut impl Rng,
+    ) -> bool {
+        if nearby_tributes == 0 {
+            return false;
+        }
+        if tribute.allies.len() >= MAX_ALLIES {
+            return false;
+        }
+        if tribute.attributes.health < self.thresholds.low_health
+            || tribute.attributes.sanity < self.thresholds.low_sanity
+        {
+            return false;
+        }
+        if tribute.traits.iter().any(|t| REFUSERS.contains(t)) {
+            return false;
+        }
+        let affinity = geometric_mean_affinity(&tribute.traits);
+        if affinity < 1.0 {
+            return false;
+        }
+        // Base 5% per turn, scaled by trait affinity (Friendly=1.5,
+        // Loyal=1.4 push above; neutral stays at base). Clamp at 15% so
+        // even Friendly+Loyal tributes don't propose every other turn.
+        let chance = (0.05 * affinity).clamp(0.0, 0.15);
+        rng.random_bool(chance)
     }
 
     fn decide_action_no_enemies(&self, tribute: &Tribute) -> Action {

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -588,6 +588,77 @@ impl Tribute {
             Action::None => {
                 // Tribute does nothing - no output needed
             }
+            Action::ProposeAlliance => {
+                // Pick a candidate from potential_targets (already filtered to
+                // the actor's current area by the caller). Skip current allies,
+                // dead tributes, and those at the per-tribute cap. Skip
+                // candidates that fail the refuser gate so the message we emit
+                // doesn't promise something the alliance roll can never grant.
+                use crate::tributes::alliances::{
+                    self, MAX_ALLIES, deciding_factor, passes_gate, try_form_alliance,
+                };
+                let candidates: Vec<&Tribute> = encounter_context
+                    .potential_targets
+                    .iter()
+                    .filter(|t| t.is_alive())
+                    .filter(|t| !self.allies.contains(&t.id))
+                    .filter(|t| t.allies.len() < MAX_ALLIES)
+                    .filter(|t| passes_gate(&self.traits, &t.traits))
+                    .collect();
+                if candidates.is_empty() {
+                    // No viable candidate; treat as a wasted social attempt.
+                    // Emit nothing — the proposer is alone-among-rivals and
+                    // the log already records nearby tributes via earlier
+                    // events.
+                    return;
+                }
+                let target = {
+                    use rand::seq::IndexedRandom;
+                    candidates.choose(rng).cloned().unwrap()
+                };
+                let target_ref = TributeRef {
+                    identifier: target.identifier.clone(),
+                    name: target.name.clone(),
+                };
+                // Emit an AllianceProposed message regardless of outcome so
+                // the player sees the social action.
+                let proposed_line =
+                    format!("🤝 {} proposes an alliance to {}.", self.name, target.name);
+                events.push(TaggedEvent::new(
+                    proposed_line,
+                    MessagePayload::AllianceProposed {
+                        proposer: tribute_ref(),
+                        target: target_ref.clone(),
+                    },
+                ));
+
+                let same_district = self.district == target.district;
+                let formed = try_form_alliance(
+                    &self.traits,
+                    &target.traits,
+                    same_district,
+                    self.allies.len(),
+                    target.allies.len(),
+                    rng,
+                );
+                if formed {
+                    let factor = deciding_factor(&self.traits, &target.traits, same_district);
+                    let factor_label = factor
+                        .as_ref()
+                        .map(|f| f.label())
+                        .unwrap_or("mutual circumstance")
+                        .to_string();
+                    // Defer the symmetric `allies` push and the
+                    // AllianceFormed message to game::process_alliance_events
+                    // so we don't need a `&mut` borrow on `target` here.
+                    self.alliance_events
+                        .push(alliances::AllianceEvent::FormationRecorded {
+                            proposer: self.id,
+                            target: target.id,
+                            factor: factor_label,
+                        });
+                }
+            }
         }
     }
 
@@ -740,6 +811,8 @@ pub fn calculate_stamina_cost(
         Action::Attack => 25.0,
         Action::Rest | Action::None => 0.0,
         Action::UseItem(_) => 10.0,
+        // Proposing an alliance is a low-cost social action.
+        Action::ProposeAlliance => 5.0,
     };
 
     // If base cost is 0, no need to calculate multipliers


### PR DESCRIPTION
## Summary

- Quickstart games were producing dozens of alliances on day 1 because alliance formation ran as a global C(N,2) area-pair pre-pass each cycle.
- Replace it with a first-class brain action: tributes deliberately weigh `Action::ProposeAlliance` (5-15% per turn for eligible candidates) instead of automatically allying with everyone they share an area with.

## Changes

- `Action::ProposeAlliance` variant + `Display`/`FromStr`
- `AllianceEvent::FormationRecorded { proposer, target, factor }`
- `Brain::wants_to_propose_alliance` gate (refusers, allies cap, health/sanity floor, geometric-mean affinity ≥ 1.0) wired into both `Brain::act` and `Brain::decide_action_with_terrain`
- Action handler in `Tribute::do_action` filters `potential_targets` (alive, not already allied, under cap, passes_gate), picks one, emits `AllianceProposed`, runs `try_form_alliance`, and on success enqueues `AllianceEvent::FormationRecorded` on the proposer's local buffer
- `Game::process_alliance_events` now applies `FormationRecorded` symmetrically and emits the `AllianceFormed` message
- Removed the global pair-iteration pre-pass in `run_tribute_cycle`

## Verification

- `cargo fmt --all`
- `cargo clippy -p game -- -D warnings`
- `cargo clippy -p api -- -D warnings`
- `RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"' cargo check -p web --target wasm32-unknown-unknown`
- `cargo test -p game` (475 passed)