### PR TITLE
fix(api): verify record persistence after UPSERT writes

### DIFF
--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -104,6 +104,7 @@ async fn create_game_area(area: Area, db: &Surreal<Any>) -> Result<GameArea, App
         .bind(("body", body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create area: {}", e)))?;
+    crate::verify_record_persisted(db, &area_id, "create_game_area").await?;
 
     Ok(game_area)
 }
@@ -206,10 +207,11 @@ pub async fn create_game(
     state
         .db
         .query("UPSERT $rid CONTENT $body")
-        .bind(("rid", game_rid))
+        .bind(("rid", game_rid.clone()))
         .bind(("body", body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create game: {}", e)))?;
+    crate::verify_record_persisted(&state.db, &game_rid, "create_game").await?;
 
     let created_game = game;
 
@@ -314,6 +316,7 @@ pub async fn add_item_to_area(
             e
         )));
     }
+    crate::verify_record_persisted(db, &new_item_id, "add_item_to_area").await?;
 
     // Insert an area-item relationship via a raw RELATE query. RELATE always
     // returns an array, so the SDK's typed insert::<Vec<_>>().relation() path

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,8 +1,10 @@
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
+use surrealdb::RecordId;
 use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
 use thiserror::Error;
@@ -62,4 +64,47 @@ impl IntoResponse for AppError {
         };
         (status, Json(json!({ "error": error_message }))).into_response()
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct VerifyRow {
+    #[allow(dead_code)]
+    id: RecordId,
+}
+
+/// Verify that a record exists at the given `RecordId` after a write that
+/// the SDK reports as successful. SurrealDB returns an empty result set
+/// (no `Err`) when a permission or schema check rejects the write, so we
+/// must read back the row to be sure it landed.
+///
+/// Returns `Err(InternalServerError)` with a `site`-tagged message when
+/// the row is missing.
+pub async fn verify_record_persisted(
+    db: &Surreal<Any>,
+    rid: &RecordId,
+    site: &'static str,
+) -> Result<(), AppError> {
+    let mut resp = db
+        .query("SELECT id FROM $rid")
+        .bind(("rid", rid.clone()))
+        .await
+        .map_err(|e| {
+            AppError::InternalServerError(format!(
+                "{}: persistence verify query failed for {}: {}",
+                site, rid, e
+            ))
+        })?;
+    let rows: Vec<VerifyRow> = resp.take(0).map_err(|e| {
+        AppError::InternalServerError(format!(
+            "{}: persistence verify decode failed for {}: {}",
+            site, rid, e
+        ))
+    })?;
+    if rows.is_empty() {
+        return Err(AppError::InternalServerError(format!(
+            "{}: persistence verification failed for {}",
+            site, rid
+        )));
+    }
+    Ok(())
 }

--- a/api/src/tributes.rs
+++ b/api/src/tributes.rs
@@ -70,6 +70,7 @@ pub async fn create_tribute(
         .bind(("body", body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create tribute: {}", e)))?;
+    crate::verify_record_persisted(db, &id, "create_tribute").await?;
     let new_tribute = Some(tribute);
 
     db.query("RELATE $tribute->playing_in->$game")
@@ -89,6 +90,7 @@ pub async fn create_tribute(
         .bind(("body", item_body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create item: {}", e)))?;
+    crate::verify_record_persisted(db, &new_object_id, "create_tribute: item").await?;
     db.query("RELATE $tribute->owns->$item")
         .bind(("tribute", id.clone()))
         .bind(("item", new_object_id.clone()))


### PR DESCRIPTION
Closes hangrier_games-16w. Follow-up to PR #167.

Even with UPSERT, a permission rejection on a record write returns an empty result set (no `Err`) from the SurrealDB SDK. Adds a `verify_record_persisted` helper and calls it after each create site so this category of silent persistence bug stops being reachable.

## Changes

- New `verify_record_persisted(db, rid, site)` helper in `api/src/lib.rs` that runs `SELECT id FROM $rid` and returns `InternalServerError` with a site-tagged message when the row is missing.
- Wired into `create_game`, `create_game_area`, `add_item_to_area`, `create_tribute`, and the per-tribute item create.

## Follow-ups (not in this PR)

- The four UPSERT sites in `save_game` (lines 947, 978, 1103, 1213) have the same silent-failure risk and should get the same hardening.
- RELATE statements after each UPSERT have the same SDK-empty-on-deny problem; if perms reject the edge, we currently return `Ok` with a dangling record.

## Verification

- `cargo fmt --all`
- `cargo clippy -p api -- -D warnings`
- API integration tests skipped (require running SurrealDB).