### PR TITLE
feat(game): A* multi-hop area pathfinding (closes hangrier_games-8pq)

### DIFF
--- a/game/src/areas/mod.rs
+++ b/game/src/areas/mod.rs
@@ -1,5 +1,6 @@
 pub mod events;
 pub mod hex;
+pub mod path;
 
 use crate::areas::events::AreaEvent;
 use crate::areas::hex::{SUB_SLOTS, SubAxial};

--- a/game/src/areas/path.rs
+++ b/game/src/areas/path.rs
@@ -1,0 +1,209 @@
+//! Area-level pathfinding: builds a graph over the v1 7-area hex topology
+//! and exposes a path-planning helper for tributes.
+//!
+//! Edge cost is a composite per the design decision (8pq Q2):
+//! `stamina_cost + harshness_penalty + closed_penalty`.
+//! - `stamina_cost`: per-tribute, per-terrain via `calculate_stamina_cost`
+//! - `harshness_penalty`: 0/10/20 for Mild/Moderate/Harsh
+//! - `closed_penalty`: high additive cost (`CLOSED_PENALTY`) so closed
+//!   areas are routed around when alternatives exist, but still
+//!   traversable as a last resort (8pq Q4 = K, "high penalty").
+
+use crate::areas::{Area, AreaDetails};
+use crate::pathfinding::{Graph, astar};
+use crate::terrain::Harshness;
+use crate::tributes::actions::Action;
+use crate::tributes::{Tribute, calculate_stamina_cost};
+use std::collections::HashMap;
+use strum::IntoEnumIterator;
+
+/// Penalty added to any edge entering a closed area. Picked so that even
+/// the cheapest detour through 2 open areas is preferred over a single
+/// closed-area hop (typical edge costs are ~20-50).
+pub const CLOSED_PENALTY: u32 = 1000;
+
+/// Snapshot of the area graph from one tribute's perspective at one
+/// moment in time. Built per planning call — do not cache across cycles.
+pub struct AreaGraph<'a> {
+    /// All known areas (whether represented in `area_details` or not).
+    /// Used to define the node set; missing details still produce a node
+    /// connected by topology, just with default-terrain cost.
+    pub areas: Vec<Area>,
+    /// Tribute doing the planning. Used for stamina-cost computation.
+    pub tribute: &'a Tribute,
+    /// Per-area details lookup (terrain, items, etc.).
+    pub details: HashMap<Area, &'a AreaDetails>,
+    /// Set of areas currently closed (e.g., due to area events).
+    pub closed: std::collections::HashSet<Area>,
+}
+
+impl<'a> AreaGraph<'a> {
+    pub fn new(areas: &'a [AreaDetails], closed: &[Area], tribute: &'a Tribute) -> Self {
+        let mut details: HashMap<Area, &AreaDetails> = HashMap::new();
+        for ad in areas {
+            if let Some(a) = ad.area {
+                details.insert(a, ad);
+            }
+        }
+        Self {
+            areas: Area::iter().collect(),
+            tribute,
+            details,
+            closed: closed.iter().copied().collect(),
+        }
+    }
+
+    fn edge_cost(&self, to: Area) -> u32 {
+        let detail = self.details.get(&to).copied();
+        let stamina = if let Some(ad) = detail {
+            calculate_stamina_cost(&Action::Move(Some(to)), &ad.terrain, self.tribute)
+        } else {
+            // No detail known — fall back to base move cost.
+            20
+        };
+        let harshness = if let Some(ad) = detail {
+            match ad.terrain.base.harshness() {
+                Harshness::Mild => 0,
+                Harshness::Moderate => 10,
+                Harshness::Harsh => 20,
+            }
+        } else {
+            0
+        };
+        let closed = if self.closed.contains(&to) {
+            CLOSED_PENALTY
+        } else {
+            0
+        };
+        stamina + harshness + closed
+    }
+}
+
+impl<'a> Graph for AreaGraph<'a> {
+    type Node = Area;
+    type Cost = u32;
+
+    fn neighbors(&self, node: Area) -> Vec<(Area, u32)> {
+        node.neighbors()
+            .into_iter()
+            .map(|n| (n, self.edge_cost(n)))
+            .collect()
+    }
+
+    fn heuristic(&self, _from: Area, _to: Area) -> u32 {
+        // Hop-count is 0 or 1 in this 7-node graph (Cornucopia is
+        // adjacent to everything; sectors are at most 2 hops apart).
+        // A constant zero (Dijkstra) is admissible and optimal here.
+        0
+    }
+}
+
+/// Plan a stamina-aware path from `start` to `goal`. Returns the full
+/// path including endpoints and the total cost. Returns `None` only if
+/// `goal` is unreachable from `start` (impossible in the v1 topology
+/// since the graph is fully connected via Cornucopia).
+pub fn plan_path(
+    areas: &[AreaDetails],
+    closed: &[Area],
+    tribute: &Tribute,
+    start: Area,
+    goal: Area,
+) -> Option<(Vec<Area>, u32)> {
+    let g = AreaGraph::new(areas, closed, tribute);
+    astar(&g, start, goal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terrain::{BaseTerrain, TerrainType};
+
+    fn area(name: &str, a: Area, base: BaseTerrain) -> AreaDetails {
+        AreaDetails::new_with_terrain(
+            Some(name.to_string()),
+            a,
+            TerrainType::new(base, vec![]).unwrap(),
+        )
+    }
+
+    fn standard_areas() -> Vec<AreaDetails> {
+        vec![
+            area("c", Area::Cornucopia, BaseTerrain::Clearing),
+            area("s1", Area::Sector1, BaseTerrain::Forest),
+            area("s2", Area::Sector2, BaseTerrain::Mountains),
+            area("s3", Area::Sector3, BaseTerrain::Grasslands),
+            area("s4", Area::Sector4, BaseTerrain::Desert),
+            area("s5", Area::Sector5, BaseTerrain::Wetlands),
+            area("s6", Area::Sector6, BaseTerrain::Tundra),
+        ]
+    }
+
+    fn fresh_tribute() -> Tribute {
+        Tribute::new("Pathfinder".to_string(), Some(0), None)
+    }
+
+    #[test]
+    fn plan_to_self_returns_singleton() {
+        let areas = standard_areas();
+        let t = fresh_tribute();
+        let (path, cost) = plan_path(&areas, &[], &t, Area::Cornucopia, Area::Cornucopia).unwrap();
+        assert_eq!(path, vec![Area::Cornucopia]);
+        assert_eq!(cost, 0);
+    }
+
+    #[test]
+    fn plan_neighbor_is_two_node_path() {
+        let areas = standard_areas();
+        let t = fresh_tribute();
+        let (path, _) = plan_path(&areas, &[], &t, Area::Cornucopia, Area::Sector1).unwrap();
+        assert_eq!(path, vec![Area::Cornucopia, Area::Sector1]);
+    }
+
+    #[test]
+    fn plan_opposite_sectors_routes_through_cornucopia() {
+        // Sector1 (top-right) and Sector4 (bottom-left) are not adjacent.
+        // The fastest route is Sector1 -> Cornucopia -> Sector4.
+        let areas = standard_areas();
+        let t = fresh_tribute();
+        let (path, _) = plan_path(&areas, &[], &t, Area::Sector1, Area::Sector4).unwrap();
+        assert_eq!(path.len(), 3);
+        assert_eq!(path[0], Area::Sector1);
+        assert_eq!(path[1], Area::Cornucopia);
+        assert_eq!(path[2], Area::Sector4);
+    }
+
+    #[test]
+    fn plan_routes_around_closed_area_when_possible() {
+        // Sector1 -> Sector4 normally goes via Cornucopia. If Cornucopia
+        // is closed, the routing must wrap around the ring (e.g. through
+        // Sector2 + Sector3).
+        let areas = standard_areas();
+        let t = fresh_tribute();
+        let closed = [Area::Cornucopia];
+        let (path, cost) = plan_path(&areas, &closed, &t, Area::Sector1, Area::Sector4).unwrap();
+        assert!(
+            !path.contains(&Area::Cornucopia),
+            "path detoured around closed cornucopia: {path:?}"
+        );
+        assert!(
+            cost < CLOSED_PENALTY,
+            "should not pay closed-penalty when an open route exists"
+        );
+    }
+
+    #[test]
+    fn plan_traverses_closed_area_as_last_resort() {
+        // Close every ring sector, leaving only the path Cornucopia -><br/>
+        // closed sector. Then Cornucopia -> Sector1 must traverse a
+        // closed area and pay the penalty.
+        let areas = standard_areas();
+        let t = fresh_tribute();
+        let closed = [Area::Sector1];
+        let (path, cost) = plan_path(&areas, &closed, &t, Area::Cornucopia, Area::Sector1).unwrap();
+        assert_eq!(path, vec![Area::Cornucopia, Area::Sector1]);
+        assert!(
+            cost >= CLOSED_PENALTY,
+            "expected closed-penalty in cost, got {cost}"
+        );
+    }
+}

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -980,6 +980,11 @@ impl Game {
                 })
                 .collect();
 
+            // Snapshot all areas before taking the mutable borrow on this
+            // tribute's area. The snapshot feeds multi-hop pathfinding which
+            // needs to reason about the full topology, not just neighbors.
+            let all_areas_snapshot: Vec<crate::areas::AreaDetails> = self.areas.clone();
+
             let area_details = &mut self.areas[area_index];
 
             let mut environment_details = EnvironmentContext {
@@ -987,6 +992,7 @@ impl Game {
                 area_details,
                 closed_areas: &closed_areas,
                 available_destinations,
+                all_areas: &all_areas_snapshot,
                 current_day: self.day.unwrap_or(1),
             };
 

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -6,6 +6,7 @@ pub mod games;
 pub mod items;
 pub mod messages;
 pub mod output;
+pub mod pathfinding;
 pub mod terrain;
 pub mod threats;
 pub mod tributes;

--- a/game/src/pathfinding.rs
+++ b/game/src/pathfinding.rs
@@ -1,0 +1,178 @@
+//! Generic graph pathfinding (A*).
+//!
+//! Designed to be reused at multiple granularities — v1 operates on the
+//! 7-area top-level hex graph; sub-tile pathfinding (hangrier_games-le8l)
+//! will plug in a separate `Graph` impl over the sub-tile grid.
+
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
+use std::hash::Hash;
+
+/// A weighted, directed graph over `Node`s with associated cost type
+/// `Cost`. Implementors expose neighbors and edge costs; pathfinding
+/// operates entirely through this trait.
+pub trait Graph {
+    type Node: Copy + Eq + Hash;
+    type Cost: Copy + Ord + Default + std::ops::Add<Output = Self::Cost>;
+
+    /// Outgoing edges from `node`: `(neighbor, edge_cost)`.
+    fn neighbors(&self, node: Self::Node) -> Vec<(Self::Node, Self::Cost)>;
+
+    /// Admissible heuristic: lower bound on cost from `from` to `to`.
+    /// Returning `Cost::default()` (zero) degrades A* to Dijkstra.
+    fn heuristic(&self, from: Self::Node, to: Self::Node) -> Self::Cost;
+}
+
+/// Priority-queue entry. `BinaryHeap` is a max-heap, so we invert the
+/// comparison on `f` (g + h) to get min-heap behavior.
+struct Frontier<N, C> {
+    f: C,
+    node: N,
+}
+
+impl<N, C: Ord> Ord for Frontier<N, C> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.f.cmp(&self.f)
+    }
+}
+impl<N, C: Ord> PartialOrd for Frontier<N, C> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<N, C: Eq> Eq for Frontier<N, C> {}
+impl<N, C: Eq> PartialEq for Frontier<N, C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.f == other.f
+    }
+}
+
+/// A* shortest path. Returns the path from `start` to `goal` inclusive,
+/// and the total cost. Returns `None` if `goal` is unreachable.
+pub fn astar<G: Graph>(
+    graph: &G,
+    start: G::Node,
+    goal: G::Node,
+) -> Option<(Vec<G::Node>, G::Cost)> {
+    if start == goal {
+        return Some((vec![start], G::Cost::default()));
+    }
+
+    let mut g_score: HashMap<G::Node, G::Cost> = HashMap::new();
+    let mut came_from: HashMap<G::Node, G::Node> = HashMap::new();
+    let mut open: BinaryHeap<Frontier<G::Node, G::Cost>> = BinaryHeap::new();
+
+    g_score.insert(start, G::Cost::default());
+    open.push(Frontier {
+        f: graph.heuristic(start, goal),
+        node: start,
+    });
+
+    while let Some(Frontier { node: current, .. }) = open.pop() {
+        if current == goal {
+            return Some(reconstruct(&came_from, current, g_score[&current]));
+        }
+        let current_g = g_score[&current];
+        for (neighbor, edge_cost) in graph.neighbors(current) {
+            let tentative_g = current_g + edge_cost;
+            let better = g_score
+                .get(&neighbor)
+                .map(|&existing| tentative_g < existing)
+                .unwrap_or(true);
+            if better {
+                came_from.insert(neighbor, current);
+                g_score.insert(neighbor, tentative_g);
+                let f = tentative_g + graph.heuristic(neighbor, goal);
+                open.push(Frontier { f, node: neighbor });
+            }
+        }
+    }
+
+    None
+}
+
+fn reconstruct<N: Copy + Eq + Hash, C: Copy>(
+    came_from: &HashMap<N, N>,
+    end: N,
+    cost: C,
+) -> (Vec<N>, C) {
+    let mut path = vec![end];
+    let mut cur = end;
+    while let Some(&prev) = came_from.get(&cur) {
+        path.push(prev);
+        cur = prev;
+    }
+    path.reverse();
+    (path, cost)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Trivial test graph: nodes are u32, neighbors come from a HashMap.
+    struct TestGraph {
+        edges: HashMap<u32, Vec<(u32, u32)>>,
+    }
+
+    impl Graph for TestGraph {
+        type Node = u32;
+        type Cost = u32;
+        fn neighbors(&self, node: u32) -> Vec<(u32, u32)> {
+            self.edges.get(&node).cloned().unwrap_or_default()
+        }
+        fn heuristic(&self, _from: u32, _to: u32) -> u32 {
+            0
+        }
+    }
+
+    fn graph(pairs: &[(u32, u32, u32)]) -> TestGraph {
+        let mut edges: HashMap<u32, Vec<(u32, u32)>> = HashMap::new();
+        for &(a, b, c) in pairs {
+            edges.entry(a).or_default().push((b, c));
+            edges.entry(b).or_default().push((a, c));
+        }
+        TestGraph { edges }
+    }
+
+    #[test]
+    fn start_equals_goal_returns_singleton() {
+        let g = graph(&[]);
+        let (path, cost) = astar(&g, 5, 5).unwrap();
+        assert_eq!(path, vec![5]);
+        assert_eq!(cost, 0);
+    }
+
+    #[test]
+    fn unreachable_returns_none() {
+        let g = graph(&[(1, 2, 1)]);
+        assert!(astar(&g, 1, 99).is_none());
+    }
+
+    #[test]
+    fn picks_lowest_cost_path_not_fewest_hops() {
+        // Direct edge 1->3 with cost 100; detour 1->2->3 with cost 1+1=2.
+        let g = graph(&[(1, 3, 100), (1, 2, 1), (2, 3, 1)]);
+        let (path, cost) = astar(&g, 1, 3).unwrap();
+        assert_eq!(path, vec![1, 2, 3]);
+        assert_eq!(cost, 2);
+    }
+
+    #[test]
+    fn finds_three_hop_path() {
+        let g = graph(&[(1, 2, 1), (2, 3, 1), (3, 4, 1)]);
+        let (path, cost) = astar(&g, 1, 4).unwrap();
+        assert_eq!(path, vec![1, 2, 3, 4]);
+        assert_eq!(cost, 3);
+    }
+
+    #[test]
+    fn ties_resolved_consistently() {
+        let g = graph(&[(1, 2, 1), (1, 3, 1), (2, 4, 1), (3, 4, 1)]);
+        let (path, cost) = astar(&g, 1, 4).unwrap();
+        assert_eq!(cost, 2);
+        assert_eq!(path.len(), 3);
+        assert_eq!(path[0], 1);
+        assert_eq!(path[2], 4);
+    }
+}

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -206,11 +206,20 @@ impl Brain {
     }
 
     /// The AI for a tribute. Automatic decisions based on the current state of the tribute.
+    ///
+    /// Multi-hop movement (8pq): when `all_areas` is non-empty, the brain
+    /// scores every known area (not just adjacent neighbors), uses A* to
+    /// plan a stamina-aware path to the best goal, and returns the first
+    /// hop along that path. When `all_areas` is empty (legacy callers,
+    /// brains-only unit tests) the brain falls back to neighbor-only
+    /// destination selection from `available_destinations`.
     pub fn act(
         &self,
         tribute: &Tribute,
         nearby_tributes: u32,
         available_destinations: &[crate::areas::DestinationInfo],
+        all_areas: &[AreaDetails],
+        closed_areas: &[Area],
         rng: &mut impl Rng,
     ) -> Action {
         if !tribute.is_alive() {
@@ -285,7 +294,42 @@ impl Brain {
         // If the action is Move(None), choose smart destination based on terrain
         match action {
             Action::Move(None) => {
-                // If no destinations available, keep Move(None) for backward compatibility
+                // Multi-hop pathfinding (8pq): score every known area
+                // (not just neighbors), then plan a stamina-aware path
+                // and return the first hop. Falls through to neighbor-
+                // only legacy behavior when `all_areas` is empty.
+                if !all_areas.is_empty()
+                    && let Some(best_goal) = self.choose_destination(all_areas, tribute)
+                {
+                    if best_goal == tribute.area {
+                        return Action::Rest;
+                    }
+                    if let Some((path, _cost)) = crate::areas::path::plan_path(
+                        all_areas,
+                        closed_areas,
+                        tribute,
+                        tribute.area,
+                        best_goal,
+                    ) && path.len() >= 2
+                    {
+                        let first_hop = path[1];
+                        // Stamina gate against the first hop's cost
+                        // (use available_destinations if present, else
+                        // fall back to permitting the move).
+                        let cost_ok = available_destinations
+                            .iter()
+                            .find(|d| d.area == first_hop)
+                            .map(|d| tribute.stamina >= d.stamina_cost)
+                            .unwrap_or(true);
+                        if cost_ok {
+                            return Action::Move(Some(first_hop));
+                        }
+                        return Action::Rest;
+                    }
+                }
+
+                // Legacy neighbor-only path (also used by brains tests
+                // that call `act` with empty slices).
                 if available_destinations.is_empty() {
                     return Action::Move(None);
                 }
@@ -695,7 +739,9 @@ mod tests {
     #[rstest]
     fn decide_on_action_default(tribute: Tribute, mut small_rng: SmallRng) {
         // If there are no enemies nearby, the tribute should move
-        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 0, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Move(None));
     }
 
@@ -703,7 +749,9 @@ mod tests {
     fn decide_on_action_low_health(mut tribute: Tribute, mut small_rng: SmallRng) {
         // If the tribute has low health, they should rest
         tribute.attributes.health = 10;
-        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 2, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Move(None));
     }
 
@@ -711,7 +759,9 @@ mod tests {
     fn decide_on_action_no_health(mut tribute: Tribute, mut small_rng: SmallRng) {
         // If the tribute has no health, they should do nothing
         tribute.attributes.health = 0;
-        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 2, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::None);
     }
 
@@ -719,7 +769,9 @@ mod tests {
     fn decide_on_action_no_movement_alone(mut tribute: Tribute, mut small_rng: SmallRng) {
         // If the tribute has no movement and is alone, they should rest
         tribute.attributes.movement = 0;
-        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 0, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Rest);
     }
 
@@ -731,14 +783,18 @@ mod tests {
         // If the tribute has no movement and is not alone, they should hide
         tribute.attributes.movement = 1;
         tribute.attributes.health = 10;
-        let action = tribute.brain.act(&tribute.clone(), 5, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 5, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Hide);
     }
 
     #[rstest]
     fn decide_on_action_enemies(tribute: Tribute, mut small_rng: SmallRng) {
         // If there are enemies nearby, the tribute should attack
-        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 2, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 
@@ -747,14 +803,18 @@ mod tests {
         // If there are enemies nearby, but the tribute is low on health
         // the tribute should hide
         tribute.attributes.health = 20;
-        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 2, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Move(None));
     }
 
     #[rstest]
     fn decide_on_action_preferred_action(mut tribute: Tribute, mut small_rng: SmallRng) {
         tribute.brain.set_preferred_action(Action::Rest, 1.0);
-        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 0, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Rest);
     }
 
@@ -773,14 +833,18 @@ mod tests {
     fn prefer_to_use_item_if_available(mut tribute: Tribute, mut small_rng: SmallRng) {
         let item = Item::new_random_consumable();
         tribute.items.push(item.clone());
-        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 0, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::UseItem(None));
     }
 
     #[rstest]
     fn prefer_to_hide_at_mid_health_and_visible(mut tribute: Tribute, mut small_rng: SmallRng) {
         tribute.attributes.health = 25;
-        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 0, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Hide);
     }
 
@@ -788,14 +852,18 @@ mod tests {
     fn prefer_to_move_at_mid_health_and_low_sanity(mut tribute: Tribute, mut small_rng: SmallRng) {
         tribute.attributes.health = 25;
         tribute.attributes.sanity = 15;
-        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 0, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Move(None));
     }
 
     #[rstest]
     fn decide_on_action_alone_healthy_no_movement(mut tribute: Tribute, mut small_rng: SmallRng) {
         tribute.attributes.movement = 0;
-        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 0, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Rest);
     }
 
@@ -807,7 +875,9 @@ mod tests {
         tribute.attributes.health = 10;
         tribute.attributes.movement = 0;
         tribute.attributes.sanity = 15;
-        let action = tribute.brain.act(&tribute.clone(), 3, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 3, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 
@@ -818,7 +888,9 @@ mod tests {
     ) {
         tribute.attributes.health = 15;
         tribute.attributes.sanity = 10;
-        let action = tribute.brain.act(&tribute.clone(), 3, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 3, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 
@@ -829,7 +901,9 @@ mod tests {
     ) {
         tribute.attributes.is_hidden = true;
         tribute.attributes.health = 10;
-        let action = tribute.brain.act(&tribute.clone(), 3, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 3, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::None);
     }
 
@@ -840,7 +914,9 @@ mod tests {
     ) {
         tribute.attributes.health = 25;
         tribute.attributes.sanity = 15;
-        let action = tribute.brain.act(&tribute.clone(), 3, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 3, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 
@@ -851,7 +927,9 @@ mod tests {
     ) {
         tribute.attributes.intelligence = 50;
         tribute.attributes.sanity = 50;
-        let action = tribute.brain.act(&tribute.clone(), 6, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 6, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Move(None));
     }
 
@@ -862,7 +940,9 @@ mod tests {
     ) {
         tribute.attributes.intelligence = 20;
         tribute.attributes.sanity = 20;
-        let action = tribute.brain.act(&tribute.clone(), 6, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 6, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Hide);
     }
 
@@ -875,7 +955,9 @@ mod tests {
         // threshold (~91 for Balanced after variance) for the Attack branch.
         tribute.attributes.intelligence = 5;
         tribute.attributes.sanity = 0;
-        let action = tribute.brain.act(&tribute.clone(), 6, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 6, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 
@@ -955,7 +1037,9 @@ mod tests {
         let mut tribute = Tribute::default();
         tribute.brain.psychotic_break = Some(PsychoticBreakType::Berserk);
 
-        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 2, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Attack);
     }
 
@@ -964,7 +1048,9 @@ mod tests {
         let mut tribute = Tribute::default();
         tribute.brain.psychotic_break = Some(PsychoticBreakType::Paranoid);
 
-        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 2, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::Hide);
     }
 
@@ -973,7 +1059,9 @@ mod tests {
         let mut tribute = Tribute::default();
         tribute.brain.psychotic_break = Some(PsychoticBreakType::Catatonic);
 
-        let action = tribute.brain.act(&tribute.clone(), 0, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 0, &[], &[], &[], &mut small_rng);
         assert_eq!(action, Action::None);
     }
 
@@ -983,7 +1071,9 @@ mod tests {
         tribute.brain.psychotic_break = Some(PsychoticBreakType::SelfDestructive);
         tribute.attributes.health = 5; // Very low health - normally would rest/hide
 
-        let action = tribute.brain.act(&tribute.clone(), 2, &[], &mut small_rng);
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 2, &[], &[], &[], &mut small_rng);
         // Self-destructive ignores health and attacks
         assert_eq!(action, Action::Attack);
     }
@@ -1038,5 +1128,62 @@ mod tests {
         let t = PersonalityThresholds::from_traits(&traits, &mut rng);
         assert!(t.extreme_low_sanity >= 1);
         assert!(t.low_health >= 1);
+    }
+
+    /// 8pq: when scoring picks a non-neighbor goal, brain.act should
+    /// return the *first hop* of the planned path (not the goal itself).
+    /// Goal Sector4 from Sector1 must route via Cornucopia.
+    #[rstest]
+    fn brain_act_routes_first_hop_to_non_neighbor_goal(
+        mut tribute: Tribute,
+        mut small_rng: SmallRng,
+    ) {
+        use crate::areas::Area;
+
+        // Place the tribute in Sector1.
+        tribute.area = Area::Sector1;
+        // Avoid the items branch & alliance branch — strip both.
+        tribute.items.clear();
+        tribute.brain.preferred_action = None;
+
+        // Build a 7-area world. Make Sector4 carry the tribute's terrain
+        // affinity so choose_destination prefers it; everything else is
+        // plain Clearing so neighbor scoring is uniform.
+        let mk = |a: Area, base: BaseTerrain| {
+            AreaDetails::new_with_terrain(
+                Some(format!("{a:?}")),
+                a,
+                TerrainType::new(base, vec![]).unwrap(),
+            )
+        };
+        // Give the tribute a Desert affinity, then make Sector4 a Desert.
+        tribute.terrain_affinity = vec![BaseTerrain::Desert];
+        let all_areas = vec![
+            mk(Area::Cornucopia, BaseTerrain::Clearing),
+            mk(Area::Sector1, BaseTerrain::Clearing),
+            mk(Area::Sector2, BaseTerrain::Clearing),
+            mk(Area::Sector3, BaseTerrain::Clearing),
+            mk(Area::Sector4, BaseTerrain::Desert),
+            mk(Area::Sector5, BaseTerrain::Clearing),
+            mk(Area::Sector6, BaseTerrain::Clearing),
+        ];
+
+        let action = tribute
+            .brain
+            .act(&tribute.clone(), 0, &[], &all_areas, &[], &mut small_rng);
+
+        match action {
+            Action::Move(Some(first_hop)) => {
+                // Sector1's clockwise neighbors are Sector2 and Cornucopia.
+                // The shortest path to Sector4 goes Sector1 -> Cornucopia
+                // -> Sector4, so the first hop must be Cornucopia.
+                assert_eq!(
+                    first_hop,
+                    Area::Cornucopia,
+                    "expected first hop toward Sector4 to be Cornucopia, got {first_hop:?}"
+                );
+            }
+            other => panic!("expected Move(Some(_)), got {other:?}"),
+        }
     }
 }

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -112,6 +112,9 @@ pub struct EnvironmentContext<'a> {
     pub area_details: &'a mut AreaDetails,
     pub closed_areas: &'a [Area],
     pub available_destinations: Vec<crate::areas::DestinationInfo>,
+    /// All known areas (read-only snapshot). Used by multi-hop
+    /// pathfinding so the planner can reason about non-neighbor goals.
+    pub all_areas: &'a [AreaDetails],
     /// Current game day (1-indexed). Used to gate day-1-only behavior such
     /// as suppressing sponsor gifts in the opening cycle.
     pub current_day: u32,
@@ -423,6 +426,8 @@ impl Tribute {
             self,
             number_of_nearby_tributes,
             &environment_details.available_destinations,
+            environment_details.all_areas,
+            environment_details.closed_areas,
             rng,
         );
 


### PR DESCRIPTION
## Summary

Tribute movement now plans across the full 7-area hex graph instead of being limited to neighbor-only hops. This restores opposite-sector reachability that regressed when the static 5-area arena was replaced with the 7-tile hex layout in #174.

## Design (per beads 8pq)

- **Q1=A**: A* over the area graph only; sub-tile pathfinding deferred to follow-up bead `le8l`.
- **Q2=E+F**: edge cost = `stamina_cost + harshness_penalty + closed_penalty` (composite).
- **Q4=K**: closed areas get a high additive penalty (`CLOSED_PENALTY = 1000`) but stay routable as a last resort, so isolated tributes never get permanently stranded.
- **Q5=L**: planner lives behind a generic `pathfinding::Graph` trait so the future sub-tile graph (`le8l`) can plug in unchanged.

## Changes

- New `game/src/pathfinding.rs`: generic `Graph` trait + `astar()` (min-heap via inverted `Frontier` ord). 5 unit tests.
- New `game/src/areas/path.rs`: `AreaGraph<'a>` impl + `plan_path()` helper. 5 unit tests covering self/neighbor/opposite-sector/closed-area routing.
- `EnvironmentContext` now exposes `all_areas: &'a [AreaDetails]`.
- `Brain::act` takes `all_areas` + `closed_areas`; when non-empty, scores every known area, plans a path with A*, and returns the first hop. Falls back to the legacy neighbor-only path when called with empty slices (brains-only unit tests).
- New brain-level test verifying `Sector1 -> Sector4` routes through `Cornucopia` as the first hop.
- Stateless per-cycle planning: no Tribute schema change. Reroutes happen automatically when the world shifts (closures, harshness changes, etc).

## Verification

- `cargo test -p game --lib` -> 505 passed, 0 failed
- `cargo clippy -p game --tests -- -D warnings` -> clean
- `cargo check -p api` -> clean
- `cargo fmt --all`

## Follow-ups

- `hangrier_games-le8l` - sub-tile pathfinding within an area (depends on this PR + `rzy`).
- `hangrier_games-rzy` - animated tribute movement on the hex map.