### PR TITLE
fix(web): register GamesListQ storage on GamePage to prevent panic when advancing day

### DIFF
--- a/web/src/components/game_detail.rs
+++ b/web/src/components/game_detail.rs
@@ -126,6 +126,17 @@ pub fn GamePage(identifier: String) -> Element {
             token: token.clone(),
         },
     ));
+    // Also ensure the GamesListQ storage exists in the root context so that
+    // NextStepM::on_settled's QueriesStorage::<GamesListQ>::invalidate_all()
+    // call doesn't panic when the user navigates straight to a game page
+    // without ever visiting the home list (games would otherwise vanish from
+    // the UI until a new game was created and the list rendered).
+    let _games_list_q = use_query(Query::new(
+        (),
+        crate::components::games_list::GamesListQ {
+            token: token.clone(),
+        },
+    ));
 
     let mut last_seen = use_signal(|| 0usize);
     use_effect(move || {


### PR DESCRIPTION
## Symptom

Games disappear from the home list after clicking 'next day'. They re-appear once a new game is created.

## Root cause

'NextStepM::on_settled' calls 'QueriesStorage::<GamesListQ>::invalidate_all()' after a successful day advance. 'invalidate_all()' calls 'consume_context::<QueriesStorage<Q>>()' and panics ('Could not find context QueriesStorage<...>') if no component has ever mounted a 'use_query' for that capability during the session.

When a user navigates straight to '/games/<id>', 'GamesList' never mounts, so 'GamesListQ' has no root storage. Advancing the day then panics the WASM runtime — exactly the panic in the user-supplied console output. Creating a new game routes through the home page, which mounts 'GamesList' and registers the storage, masking the bug on subsequent renders.

This is the same class of bug PR #164 fixed for 'DisplayGameQ' and 'TimelineSummaryQ'.

## Fix

In 'GamePage', mount a hidden 'use_query' for 'GamesListQ' so its storage is provided in the root context before any mutation tries to invalidate it.

## Verification

- 'cargo check -p web' clean
- Wasm build covered by CI