### PR TITLE
fix(game): break Cornucopia clustering deadlock so combat engages

### DIFF
--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -301,7 +301,34 @@ impl Brain {
                 if !all_areas.is_empty()
                     && let Some(best_goal) = self.choose_destination(all_areas, tribute)
                 {
-                    if best_goal == tribute.area {
+                    // Anti-clustering: if every area scores the same
+                    // (e.g. all Clearing, no affinity), `choose_destination`
+                    // returns the first area, which on the smart-path is
+                    // typically the tribute's current area — leading every
+                    // crowded tribute to Rest forever and combat to never
+                    // engage. When the chosen "best" is just where we are
+                    // and the area is crowded, force a hop to the cheapest
+                    // reachable open neighbor instead.
+                    let crowded = nearby_tributes >= LOW_ENEMY_LIMIT;
+                    if best_goal == tribute.area && !crowded {
+                        return Action::Rest;
+                    }
+                    let goal = if best_goal == tribute.area && crowded {
+                        // Pick a cheap open neighbor we can actually afford
+                        // to walk to. Falls through to plan_path below using
+                        // that neighbor as the goal.
+                        available_destinations
+                            .iter()
+                            .filter(|d| d.area != tribute.area)
+                            .filter(|d| !closed_areas.contains(&d.area))
+                            .filter(|d| tribute.stamina >= d.stamina_cost)
+                            .min_by_key(|d| d.stamina_cost)
+                            .map(|d| d.area)
+                            .unwrap_or(best_goal)
+                    } else {
+                        best_goal
+                    };
+                    if goal == tribute.area {
                         return Action::Rest;
                     }
                     if let Some((path, _cost)) = crate::areas::path::plan_path(
@@ -309,7 +336,7 @@ impl Brain {
                         closed_areas,
                         tribute,
                         tribute.area,
-                        best_goal,
+                        goal,
                     ) && path.len() >= 2
                     {
                         let first_hop = path[1];


### PR DESCRIPTION
## Summary

User report: 10+ days, 0 deaths. DB inspection: 22 of 24 tributes alive in Cornucopia, all Healthy, avg HP 66 — combat never engages.

Root cause: When all areas share the same terrain (e.g. every hex is a Clearing, which is the current default), ``choose_destination`` returns the first tied area, which on the smart-path is typically the tribute's own current area. The caller then short-circuits to ``Action::Rest``, so even when ``decide_action_many_enemies`` correctly says ``Move(None)`` to spread crowded tributes out, every tribute just rests in place. No movement, no encounters, no combat.

## Changes

In ``Brain::act`` (game/src/tributes/brains.rs), when:
- the chosen ``best_goal`` is the tribute's current area, AND
- ``nearby_tributes >= LOW_ENEMY_LIMIT``

…escape to the cheapest reachable open neighbor we can afford (stamina-aware) instead of resting. Falls through to the existing ``plan_path`` + first-hop logic for the new goal. Behavior is unchanged when the area isn't crowded.

## Verification

- ``cargo test -p game --lib brains`` — 32 passed
- API rebuilt + restarted in devcontainer
- Manual: advance the existing day-11 stuck game and confirm the Cornucopia crowd starts dispersing and engaging

## Follow-ups

- Long-term improvement: add an enemies-per-area signal directly to ``choose_destination`` so the scoring penalises crowding instead of relying on the call-site override