### PR TITLE
fix(game,web): emit env deaths as TributeKilled and sort timeline by emit_index

### DIFF
--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -1251,7 +1251,7 @@ async fn game_day_logs(
         .query(
             r#"SELECT * FROM message
         WHERE string::starts_with(subject, $identifier) AND
-        game_day = $day ORDER BY timestamp;"#,
+        game_day = $day ORDER BY phase, emit_index;"#,
         )
         .bind(("identifier", game_identifier))
         .bind(("day", day))

--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -203,6 +203,7 @@ impl Game {
     }
 
     /// Returns the tributes that are recently dead, i.e., died in the current round.
+    #[cfg_attr(not(test), allow(dead_code))]
     fn recently_dead_tributes(&self) -> Vec<Tribute> {
         self.tributes
             .iter()
@@ -461,19 +462,11 @@ impl Game {
         let game_id = self.identifier.clone();
         let current_day = self.day.unwrap_or(1);
 
-        // Announce tribute deaths from this cycle.
-        let dead: Vec<(String, String)> = self
-            .recently_dead_tributes()
-            .into_iter()
-            .map(|t| (t.identifier.clone(), t.name.clone()))
-            .collect();
-        for (id, name) in dead {
-            self.log(
-                crate::messages::MessageSource::Tribute(id),
-                format!("game:{}", game_id),
-                format!("{} has fallen.", name),
-            );
-        }
+        // Death announcements are now emitted at the kill site as typed
+        // `MessagePayload::TributeKilled` (combat: `Combat(Killed)`; env /
+        // status: `TributeKilled`). Re-announcing "X has fallen" here
+        // duplicated those events with a `SanityBreak` fallback payload
+        // which mis-classified them in the timeline.
 
         let phase = if day { "day" } else { "night" };
         self.log(
@@ -544,8 +537,17 @@ impl Game {
         // Process each tribute's survival check
         for tribute_idx in tribute_indices {
             // Outcome messages we'll log after the tribute borrow is released.
-            let mut pending_messages: Vec<(crate::messages::MessageSource, String, String)> =
-                Vec::new();
+            // Each entry carries an optional typed payload so death lines
+            // become `MessagePayload::TributeKilled` (and render as
+            // DeathCard / count toward timeline death tallies) instead of
+            // falling through to the legacy `SanityBreak` fallback.
+            type PendingMsg = (
+                crate::messages::MessageSource,
+                String,
+                String,
+                Option<crate::messages::MessagePayload>,
+            );
+            let mut pending_messages: Vec<PendingMsg> = Vec::new();
 
             {
                 let tribute = &mut self.tributes[tribute_idx];
@@ -594,6 +596,14 @@ impl Game {
                 // Apply results
                 if !result.survived {
                     tribute.attributes.health = 0;
+                    let cause = most_severe_event.to_string();
+                    tribute.statistics.killed_by = Some(cause.clone());
+                    // Mark as RecentlyDead so the end-of-cycle announcement
+                    // and the alliance-cascade pipeline both pick this death
+                    // up. Without this, env-killed tributes were silently
+                    // promoted to Dead at the next cycle and never triggered
+                    // "has fallen" or DeathRecorded.
+                    tribute.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
 
                     let content = if result.instant_death {
                         format!(
@@ -606,7 +616,15 @@ impl Game {
                             tribute.name, most_severe_event, roll_detail
                         )
                     };
-                    pending_messages.push((source, subject, content));
+                    let payload = crate::messages::MessagePayload::TributeKilled {
+                        victim: crate::messages::TributeRef {
+                            identifier: tribute.identifier.clone(),
+                            name: tribute.name.clone(),
+                        },
+                        killer: None,
+                        cause,
+                    };
+                    pending_messages.push((source, subject, content, Some(payload)));
                 } else {
                     // Always announce the survival itself so the narrative captures
                     // who weathered the event, even when no rewards land.
@@ -617,6 +635,7 @@ impl Game {
                             "{} survives the {} {}",
                             tribute.name, most_severe_event, roll_detail
                         ),
+                        None,
                     ));
 
                     // Survivor - apply rewards if any
@@ -629,6 +648,7 @@ impl Game {
                                 "{} recovers {} stamina from the {}",
                                 tribute.name, result.stamina_restored, most_severe_event
                             ),
+                            None,
                         ));
                     }
 
@@ -644,6 +664,7 @@ impl Game {
                                 "{} recovers {} sanity from the {}",
                                 tribute.name, result.sanity_restored, most_severe_event
                             ),
+                            None,
                         ));
                     }
 
@@ -658,13 +679,19 @@ impl Game {
                                 "{} finds a {} after surviving the {}",
                                 tribute.name, item_name, most_severe_event
                             ),
+                            None,
                         ));
                     }
                 }
             }
 
-            for (source, subject, content) in pending_messages {
-                self.log(source, subject, content);
+            // Each env-event message is its own action group, so advance
+            // the per-phase tick before pushing so they sort after the
+            // area announcement and any prior tribute actions.
+            for (source, subject, content, payload) in pending_messages {
+                let tick = self.tick_counter.next();
+                let payload = payload.unwrap_or_else(|| Self::fallback_payload(&source));
+                self.push_message(source, subject, content, payload, tick);
             }
         }
         Ok(())
@@ -1582,8 +1609,10 @@ mod tests {
         let mut game = create_test_game_with_tributes(vec![tribute1.clone(), tribute2.clone()]);
         game.day = Some(1);
         let _ = game.announce_cycle_end(true);
-        // One death message + one cycle-end summary.
-        assert_eq!(game.messages.len(), 2);
+        // Death announcements moved to the kill site as typed
+        // `MessagePayload::TributeKilled`. Only the cycle-end summary
+        // remains here.
+        assert_eq!(game.messages.len(), 1);
     }
 
     #[test]

--- a/web/src/components/timeline/timeline.rs
+++ b/web/src/components/timeline/timeline.rs
@@ -17,7 +17,12 @@ pub fn Timeline(props: TimelineProps) -> Element {
         .into_iter()
         .filter(|m| props.filter.matches(m.payload.kind()))
         .collect();
-    sorted.sort_by_key(|m| (m.tick, m.emit_index));
+    // `emit_index` is the monotonic per-phase emission counter, so it is
+    // the only correct chronological order. `tick` is a per-action group
+    // id (boundary messages all share tick=0); sorting by it would float
+    // every cycle-start, area-event, env-death, and "has fallen" message
+    // ahead of per-tribute action messages emitted between them.
+    sorted.sort_by_key(|m| m.emit_index);
     rsx! {
         if sorted.is_empty() {
             div { class: "rounded border border-dashed p-6 text-center text-sm",


### PR DESCRIPTION
## Summary

Three bugs in the day-detail / timeline pipeline, all rooted in the legacy `Game::log` -> `fallback_payload` path:

- **Environmental deaths were classified as State, not Death.** `process_event_for_area` emitted death lines via `Game::log`, which synthesises a `MessagePayload::SanityBreak` fallback for `MessageSource::Tribute`. They never rendered as `DeathCard`, never counted in the day summary, and never marked the tribute `RecentlyDead` for the alliance cascade. Now emits a typed `MessagePayload::TributeKilled { cause: <event>, killer: None }` and sets `RecentlyDead`.
- **End-of-cycle was duplicating death events under the wrong payload.** `announce_cycle_end` re-announced "X has fallen" via `Game::log` for every `RecentlyDead` tribute, also under `SanityBreak`. With combat (`Combat(Killed)`) and now env (`TributeKilled`) emitting at the kill site, this trailing line was redundant noise misclassified as State. Removed; the kill-site event is the single source of truth.
- **Day detail page sorted phase-boundary messages ahead of action messages.** UI sorted by `(tick, emit_index)`. `tick=0` is reserved for boundary events (cycle-start, area announcements, env messages, cycle-end), so they all floated to the top of the period. Now sorts by `emit_index` alone (monotonic per phase across every `push_message`). Also switched the API day-log query from `ORDER BY timestamp` to `ORDER BY phase, emit_index` for the same reason.

## Verification

- `cargo build -p game -p api -p shared -p web` clean
- `cargo test -p game` 507 passed
- `cargo test -p shared` 19 passed (incl. timeline summary regression test)
- Updated `test_announce_cycle_end` to assert the new single-message shape

## Follow-ups

- The dev SurrealDB schema-loss issue from earlier in the session is not addressed here; it lives under a separate beads issue.