### PR TITLE
feat(web): shelter + hunger/thirst frontend (PR2)

### DIFF
--- a/web/src/components/game_tributes.rs
+++ b/web/src/components/game_tributes.rs
@@ -3,6 +3,7 @@ use crate::components::icons::loading::LoadingIcon;
 use crate::components::icons::map_pin::MapPinIcon;
 use crate::components::item_icon::ItemIcon;
 use crate::components::tribute_edit::TributeEdit;
+use crate::components::tribute_state_strip::TributeStateStrip;
 use crate::components::tribute_status_icon::TributeStatusIcon;
 use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
@@ -98,11 +99,13 @@ pub fn GameTributes(game: DisplayGame) -> Element {
                                     tribute: chunk.first().unwrap().clone(),
                                     game_identifier: identifier.clone(),
                                     game_status: game.status.clone(),
+                                    current_phase: game.day.map(|d| d * 2),
                                 }
                                 GameTributeListMember {
                                     tribute: chunk.last().unwrap().clone(),
                                     game_identifier: identifier.clone(),
                                     game_status: game.status.clone(),
+                                    current_phase: game.day.map(|d| d * 2),
                                 }
                             }
                         }
@@ -132,6 +135,7 @@ pub fn GameTributeListMember(
     tribute: Tribute,
     game_identifier: String,
     game_status: GameStatus,
+    current_phase: Option<u32>,
 ) -> Element {
     let fist_item = Item::new_weapon("basic fist");
 
@@ -250,6 +254,10 @@ pub fn GameTributeListMember(
                             class: "",
                             "{tribute.status.to_string()}"
                         }
+                    }
+                    TributeStateStrip {
+                        tribute: tribute.clone(),
+                        current_phase: current_phase,
                     }
                     div {
                         class: r#"

--- a/web/src/components/map.rs
+++ b/web/src/components/map.rs
@@ -1,4 +1,6 @@
+use crate::components::map_affordance_overlay::MapAffordanceOverlay;
 use dioxus::prelude::*;
+use game::areas::Area;
 use game::areas::AreaDetails;
 use game::areas::hex::{SUB_SIZE_RATIO, SUB_SLOTS, default_layout};
 
@@ -24,6 +26,8 @@ fn hex_corners(cx: f64, cy: f64, size: f64) -> String {
 #[component]
 pub fn Map(areas: Vec<AreaDetails>) -> Element {
     let layout = default_layout();
+    let mut selected: Signal<Option<Area>> = use_signal(|| None);
+    let any_selected = selected.read().is_some();
 
     // Compute viewBox bounds.
     let mut min_x = f64::INFINITY;
@@ -58,9 +62,26 @@ pub fn Map(areas: Vec<AreaDetails>) -> Element {
                     let points = hex_corners(cx, cy, HEX_SIZE);
                     let area_id = area_name.to_lowercase().replace(' ', "-");
                     let label = format!("{}", i);
+                    let area_for_click = *area;
                     let on_click = move |_| {
-                        tracing::info!("hex tile clicked: {}", area_name);
+                        selected.with_mut(|s| {
+                            if *s == Some(area_for_click) {
+                                *s = None;
+                            } else {
+                                *s = Some(area_for_click);
+                            }
+                        });
                     };
+                    let is_selected = selected.read().as_ref() == Some(area);
+                    let stroke_class = if is_selected {
+                        "stroke-emerald-400"
+                    } else {
+                        "stroke-stone-700"
+                    };
+                    let area_details_for_overlay = areas
+                        .iter()
+                        .find(|ad| ad.area == Some(*area))
+                        .cloned();
                     rsx! {
                         g {
                             key: "{area_id}",
@@ -68,9 +89,9 @@ pub fn Map(areas: Vec<AreaDetails>) -> Element {
                             polygon {
                                 id: "{area_id}",
                                 "data-open": "{is_open}",
-                                class: "fill-stone-200 data-[open=false]:fill-red-500 theme3:fill-stone-400 stroke-stone-700",
+                                class: "fill-stone-200 data-[open=false]:fill-red-500 theme3:fill-stone-400 {stroke_class}",
                                 points: "{points}",
-                                stroke_width: "2",
+                                stroke_width: if is_selected { "4" } else { "2" },
                             }
                             // Sub-tile grid: 7 smaller hexes per area for
                             // tribute positioning (presentation-only).
@@ -103,6 +124,16 @@ pub fn Map(areas: Vec<AreaDetails>) -> Element {
                                 font_size: "32",
                                 font_weight: "bold",
                                 "{label}"
+                            }
+                            if any_selected {
+                                if let Some(ad) = area_details_for_overlay {
+                                    MapAffordanceOverlay {
+                                        cx: cx,
+                                        cy: cy,
+                                        size: HEX_SIZE,
+                                        area: ad,
+                                    }
+                                }
                             }
                         }
                     }

--- a/web/src/components/map_affordance_overlay.rs
+++ b/web/src/components/map_affordance_overlay.rs
@@ -1,0 +1,55 @@
+use dioxus::prelude::*;
+use game::areas::AreaDetails;
+use game::areas::forage::forage_richness;
+use game::areas::shelter::shelter_quality;
+use game::areas::water::water_source;
+use game::areas::weather::current_weather;
+
+#[component]
+pub fn MapAffordanceOverlay(cx: f64, cy: f64, size: f64, area: AreaDetails) -> Element {
+    let weather = current_weather();
+    let terrain = area.terrain.base;
+    let water = water_source(terrain, &weather);
+    let forage = forage_richness(terrain);
+    let shelter = shelter_quality(terrain, &weather);
+
+    let glyph_size = size * 0.20;
+    let row_y = cy + size * 0.55;
+    let mut glyphs: Vec<&'static str> = Vec::new();
+    if water > 0 {
+        glyphs.push("💧");
+    }
+    if forage > 0 {
+        glyphs.push("🌿");
+    }
+    if shelter >= 2 {
+        glyphs.push("🏠");
+    }
+    if glyphs.is_empty() {
+        return rsx! {};
+    }
+    let total = glyphs.len() as f64;
+    let spacing = glyph_size * 1.2;
+    let start_x = cx - ((total - 1.0) * spacing) / 2.0;
+
+    rsx! {
+        g {
+            class: "pointer-events-none",
+            for (i, g) in glyphs.into_iter().enumerate() {
+                {
+                    let x = start_x + (i as f64) * spacing;
+                    rsx! {
+                        text {
+                            key: "{i}",
+                            x: "{x}",
+                            y: "{row_y}",
+                            text_anchor: "middle",
+                            font_size: "{glyph_size}",
+                            "{g}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/web/src/components/mod.rs
+++ b/web/src/components/mod.rs
@@ -60,5 +60,7 @@ mod server_version;
 mod tribute_edit;
 mod tribute_filter_chips;
 pub use tribute_filter_chips::TributeFilterChips;
+mod tribute_state_strip;
+pub use tribute_state_strip::TributeStateStrip;
 mod tribute_status_icon;
 pub use tribute_status_icon::TributeStatusIcon;

--- a/web/src/components/mod.rs
+++ b/web/src/components/mod.rs
@@ -64,3 +64,5 @@ mod tribute_state_strip;
 pub use tribute_state_strip::TributeStateStrip;
 mod tribute_status_icon;
 pub use tribute_status_icon::TributeStatusIcon;
+mod tribute_survival_section;
+pub use tribute_survival_section::TributeSurvivalSection;

--- a/web/src/components/mod.rs
+++ b/web/src/components/mod.rs
@@ -43,6 +43,8 @@ mod loading_modal;
 pub use loading_modal::LoadingModal;
 mod map;
 pub use map::Map;
+mod map_affordance_overlay;
+pub use map_affordance_overlay::MapAffordanceOverlay;
 pub mod modal;
 pub use modal::Modal;
 mod navbar;

--- a/web/src/components/timeline/cards/death_card.rs
+++ b/web/src/components/timeline/cards/death_card.rs
@@ -36,7 +36,14 @@ pub fn DeathCard(props: DeathCardProps) -> Element {
                     }
                 }
             }
-            p { class: "text-xs text-gray-600", "{props.cause}" }
+            p { class: "text-xs {cause_class(&props.cause)}", "{props.cause}" }
         }
+    }
+}
+
+fn cause_class(cause: &str) -> &'static str {
+    match cause {
+        "starvation" | "dehydration" => "text-amber-600 theme2:text-amber-300 italic",
+        _ => "text-gray-600",
     }
 }

--- a/web/src/components/timeline/cards/mod.rs
+++ b/web/src/components/timeline/cards/mod.rs
@@ -5,3 +5,4 @@ pub mod death_card;
 pub mod item_card;
 pub mod movement_card;
 pub mod state_card;
+pub mod survival_card;

--- a/web/src/components/timeline/cards/survival_card.rs
+++ b/web/src/components/timeline/cards/survival_card.rs
@@ -1,0 +1,114 @@
+use dioxus::prelude::*;
+use shared::messages::{GameMessage, MessagePayload};
+
+#[derive(Props, PartialEq, Clone)]
+pub struct SurvivalCardProps {
+    pub message: GameMessage,
+}
+
+#[component]
+pub fn SurvivalCard(props: SurvivalCardProps) -> Element {
+    match &props.message.payload {
+        MessagePayload::HungerBandChanged { tribute, from, to } => {
+            let cls = hunger_class(to);
+            rsx! {
+                article { class: "rounded border-l-4 border-amber-400 bg-amber-50 theme2:bg-amber-950/40 p-2 text-sm",
+                    p {
+                        class: "{cls}",
+                        "{tribute.name} is now "
+                        strong { "{to}" }
+                        span { class: "text-xs text-stone-500 ml-1", "(was {from})" }
+                    }
+                }
+            }
+        }
+        MessagePayload::ThirstBandChanged { tribute, from, to } => {
+            let cls = thirst_class(to);
+            rsx! {
+                article { class: "rounded border-l-4 border-sky-400 bg-sky-50 theme2:bg-sky-950/40 p-2 text-sm",
+                    p {
+                        class: "{cls}",
+                        "{tribute.name} is now "
+                        strong { "{to}" }
+                        span { class: "text-xs text-stone-500 ml-1", "(was {from})" }
+                    }
+                }
+            }
+        }
+        MessagePayload::ShelterSought {
+            tribute,
+            area,
+            success,
+            roll: _,
+        } => rsx! {
+            article { class: "rounded border-l-4 border-emerald-400 bg-emerald-50 theme2:bg-emerald-950/40 p-2 text-sm",
+                p {
+                    class: "text-xs text-stone-600 theme2:text-stone-300",
+                    if *success {
+                        "🏠 {tribute.name} found shelter in {area.name}."
+                    } else {
+                        "🏠 {tribute.name} failed to find shelter in {area.name}."
+                    }
+                }
+            }
+        },
+        MessagePayload::Foraged {
+            tribute,
+            area,
+            success,
+            debt_recovered,
+        } => rsx! {
+            article { class: "rounded border-l-4 border-lime-500 bg-lime-50 theme2:bg-lime-950/40 p-2 text-sm",
+                p {
+                    class: "text-xs text-stone-600 theme2:text-stone-300",
+                    if *success {
+                        "🌿 {tribute.name} foraged in {area.name} (+{debt_recovered} hunger relief)."
+                    } else {
+                        "🌿 {tribute.name} foraged in {area.name} but found nothing."
+                    }
+                }
+            }
+        },
+        MessagePayload::Drank {
+            tribute,
+            source: _,
+            debt_recovered,
+        } => rsx! {
+            article { class: "rounded border-l-4 border-sky-400 bg-sky-50 theme2:bg-sky-950/40 p-2 text-sm",
+                p {
+                    class: "text-xs text-stone-600 theme2:text-stone-300",
+                    "💧 {tribute.name} drank (+{debt_recovered} thirst relief)."
+                }
+            }
+        },
+        MessagePayload::Ate {
+            tribute,
+            item: _,
+            debt_recovered,
+        } => rsx! {
+            article { class: "rounded border-l-4 border-amber-400 bg-amber-50 theme2:bg-amber-950/40 p-2 text-sm",
+                p {
+                    class: "text-xs text-stone-600 theme2:text-stone-300",
+                    "🍗 {tribute.name} ate (+{debt_recovered} hunger relief)."
+                }
+            }
+        },
+        _ => rsx! {},
+    }
+}
+
+fn hunger_class(band: &str) -> &'static str {
+    match band {
+        "Hungry" => "text-amber-600 theme2:text-amber-300",
+        "Starving" => "text-red-600 theme2:text-red-400 font-semibold",
+        _ => "text-stone-600 theme2:text-stone-300",
+    }
+}
+
+fn thirst_class(band: &str) -> &'static str {
+    match band {
+        "Parched" => "text-sky-600 theme2:text-sky-300",
+        "Dehydrated" => "text-red-600 theme2:text-red-400 font-semibold",
+        _ => "text-stone-600 theme2:text-stone-300",
+    }
+}

--- a/web/src/components/timeline/event_card.rs
+++ b/web/src/components/timeline/event_card.rs
@@ -1,6 +1,7 @@
 use crate::components::timeline::cards::{
     alliance_card::AllianceCard, combat_card::CombatCard, combat_swing_card::CombatSwingCard,
     death_card::DeathCard, item_card::ItemCard, movement_card::MovementCard, state_card::StateCard,
+    survival_card::SurvivalCard,
 };
 use dioxus::prelude::*;
 use shared::messages::{GameMessage, MessageKind, MessagePayload};
@@ -47,7 +48,15 @@ pub fn EventCard(props: EventCardProps) -> Element {
                 game_identifier: props.game_identifier.clone(),
                 message: props.message.clone(),
             } },
-            MessageKind::State => rsx! { StateCard { message: props.message.clone() } },
+            MessageKind::State => match payload {
+                MessagePayload::HungerBandChanged { .. }
+                | MessagePayload::ThirstBandChanged { .. }
+                | MessagePayload::ShelterSought { .. }
+                | MessagePayload::Foraged { .. }
+                | MessagePayload::Drank { .. }
+                | MessagePayload::Ate { .. } => rsx! { SurvivalCard { message: props.message.clone() } },
+                _ => rsx! { StateCard { message: props.message.clone() } },
+            },
             MessageKind::CombatSwing => {
                 if let MessagePayload::CombatSwing(beat) = payload {
                     rsx! { CombatSwingCard {

--- a/web/src/components/tribute_detail.rs
+++ b/web/src/components/tribute_detail.rs
@@ -4,6 +4,7 @@ use crate::components::icons::uturn::UTurnIcon;
 use crate::components::info_detail::InfoDetail;
 use crate::components::item_icon::ItemIcon;
 use crate::components::tribute_status_icon::TributeStatusIcon;
+use crate::components::tribute_survival_section::TributeSurvivalSection;
 use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use crate::routes::Routes;
@@ -218,6 +219,11 @@ pub fn TributeDetail(game_identifier: String, tribute_identifier: String) -> Ele
                             dt { "Outlook" }
                             dd { "TODO" }
                         }
+                    }
+
+                    TributeSurvivalSection {
+                        tribute: (**tribute).clone(),
+                        current_phase: None,
                     }
 
                     InfoDetail {

--- a/web/src/components/tribute_state_strip.rs
+++ b/web/src/components/tribute_state_strip.rs
@@ -1,0 +1,87 @@
+use dioxus::prelude::*;
+use game::tributes::Tribute;
+use game::tributes::survival::{HungerBand, ThirstBand, hunger_band, thirst_band};
+
+#[component]
+pub fn TributeStateStrip(tribute: Tribute, current_phase: Option<u32>) -> Element {
+    let h_band = hunger_band(tribute.hunger);
+    let t_band = thirst_band(tribute.thirst);
+    let sheltered_phases_left = match (tribute.sheltered_until, current_phase) {
+        (Some(until), Some(now)) if until > now => Some(until - now),
+        _ => None,
+    };
+
+    let any_visible = h_band != HungerBand::Sated
+        || t_band != ThirstBand::Sated
+        || sheltered_phases_left.is_some();
+
+    if !any_visible {
+        return rsx! {};
+    }
+
+    rsx! {
+        div {
+            class: "flex flex-row gap-2 items-center text-sm select-none",
+            if h_band != HungerBand::Sated {
+                HungerPip { band: h_band, raw: tribute.hunger }
+            }
+            if t_band != ThirstBand::Sated {
+                ThirstPip { band: t_band, raw: tribute.thirst }
+            }
+            if let Some(left) = sheltered_phases_left {
+                ShelterPip { phases_left: left }
+            }
+        }
+    }
+}
+
+#[component]
+fn HungerPip(band: HungerBand, raw: u8) -> Element {
+    let (cls, label) = match band {
+        HungerBand::Peckish => ("text-amber-300/60", "Peckish"),
+        HungerBand::Hungry => ("text-amber-400", "Hungry"),
+        HungerBand::Starving => ("text-red-500 animate-pulse", "Starving"),
+        HungerBand::Sated => return rsx! {},
+    };
+    rsx! {
+        span {
+            class: "inline-flex items-center gap-1 {cls}",
+            "aria-label": "Hunger: {label}",
+            title: "Hunger {raw} — {label}",
+            span { class: "text-base", "🍗" }
+            span { class: "text-xs uppercase tracking-wide", "{label}" }
+        }
+    }
+}
+
+#[component]
+fn ThirstPip(band: ThirstBand, raw: u8) -> Element {
+    let (cls, label) = match band {
+        ThirstBand::Thirsty => ("text-sky-300/60", "Thirsty"),
+        ThirstBand::Parched => ("text-sky-400", "Parched"),
+        ThirstBand::Dehydrated => ("text-red-500 animate-pulse", "Dehydrated"),
+        ThirstBand::Sated => return rsx! {},
+    };
+    rsx! {
+        span {
+            class: "inline-flex items-center gap-1 {cls}",
+            "aria-label": "Thirst: {label}",
+            title: "Thirst {raw} — {label}",
+            span { class: "text-base", "💧" }
+            span { class: "text-xs uppercase tracking-wide", "{label}" }
+        }
+    }
+}
+
+#[component]
+fn ShelterPip(phases_left: u32) -> Element {
+    rsx! {
+        span {
+            class: "inline-flex items-center gap-1 text-emerald-300",
+            "aria-label": "Sheltered for {phases_left} more phases",
+            title: "Sheltered for {phases_left} more phases",
+            span { class: "text-base", "🏠" }
+            span { class: "text-xs", "{phases_left}" }
+        }
+    }
+}

--- a/web/src/components/tribute_survival_section.rs
+++ b/web/src/components/tribute_survival_section.rs
@@ -1,0 +1,68 @@
+use dioxus::prelude::*;
+use game::tributes::Tribute;
+use game::tributes::survival::{HungerBand, ThirstBand, hunger_band, thirst_band};
+
+#[component]
+pub fn TributeSurvivalSection(tribute: Tribute, current_phase: Option<u32>) -> Element {
+    let h_band = hunger_band(tribute.hunger);
+    let t_band = thirst_band(tribute.thirst);
+    let sheltered_phases_left = match (tribute.sheltered_until, current_phase) {
+        (Some(until), Some(now)) if until > now => Some(until - now),
+        _ => None,
+    };
+
+    let starvation_drain_line: Option<String> = if h_band == HungerBand::Starving {
+        Some(format!(
+            "Starving — losing {} HP/phase (next phase: {})",
+            tribute.starvation_drain_step,
+            tribute.starvation_drain_step.saturating_add(1),
+        ))
+    } else {
+        None
+    };
+
+    let dehydration_drain_line: Option<String> = if t_band == ThirstBand::Dehydrated {
+        Some(format!(
+            "Dehydrated — losing {} HP/phase (next phase: {})",
+            tribute.dehydration_drain_step,
+            tribute.dehydration_drain_step.saturating_add(1),
+        ))
+    } else {
+        None
+    };
+
+    let h_label = format!("{:?}", h_band);
+    let t_label = format!("{:?}", t_band);
+
+    rsx! {
+        section {
+            class: "rounded-lg border border-stone-700/40 bg-stone-900/30 p-4 mt-4",
+            h3 {
+                class: "text-lg font-semibold mb-2 text-stone-100",
+                "Survival"
+            }
+            dl {
+                class: "grid grid-cols-2 gap-y-1 text-sm",
+                dt { class: "text-stone-400", "Hunger" }
+                dd { class: "text-stone-100", "{tribute.hunger} ({h_label})" }
+                dt { class: "text-stone-400", "Thirst" }
+                dd { class: "text-stone-100", "{tribute.thirst} ({t_label})" }
+                dt { class: "text-stone-400", "Shelter" }
+                dd {
+                    class: "text-stone-100",
+                    if let Some(left) = sheltered_phases_left {
+                        "Sheltered for {left} more phases"
+                    } else {
+                        "Exposed"
+                    }
+                }
+            }
+            if let Some(line) = starvation_drain_line {
+                p { class: "mt-2 text-sm text-red-400", "{line}" }
+            }
+            if let Some(line) = dehydration_drain_line {
+                p { class: "mt-1 text-sm text-red-400", "{line}" }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Frontend slice of the shelter + hunger/thirst spec. Pairs with PR1 (#199, merged).

- Generic `TributeStateStrip` component renders survival pips (🍗 hunger, 💧 thirst, 🏠 shelter) on tribute cards and self-hides for healthy tributes; future emotion frontend slots its pips into the same strip.
- `TributeSurvivalSection` on the tribute detail page exposes hunger/thirst counters, bands, shelter status, and the escalating-drain line when Starving/Dehydrated.
- New `SurvivalCard` handles `HungerBandChanged`, `ThirstBandChanged`, `ShelterSought`, `Foraged`, `Drank`, and `Ate` timeline events with band-tinted styling; death cards italicize `starvation` / `dehydration` causes in amber.
- Map terrain affordance overlay: clicking a hex toggles selection; while any hex is selected, every hex shows 💧 / 🌿 / 🏠 glyphs along its lower edge so terrain choices are legible at a glance. Selected hex gets an emerald 4px outline.

## Spec
- `docs/superpowers/specs/2026-05-03-shelter-hunger-thirst-design.md`
- Backend (predecessor): #199

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --tests -- -D warnings` — clean
- `cargo test -p game --lib` — 651 pass

## Follow-ups
- Optional Task 5 (survival filter chip in timeline) deferred — the existing filter system warrants its own design pass; file as follow-up if desired.
- Wire `current_phase` source into `TributeSurvivalSection` (currently `None`) once the tribute-detail page fetches game state.
- Successful `SeekShelter` glyph/animation on the hex (spec open question).

Refs: hangrier_games-0yz