### PR TITLE
docs(spec,plans): shelter+hunger and gamemaker event system designs (hangrier_games-0yz, -5q9)

### DIFF
--- a/docs/superpowers/plans/2026-05-03-gamemaker-event-system-pr1-backend.md
+++ b/docs/superpowers/plans/2026-05-03-gamemaker-event-system-pr1-backend.md
@@ -1,0 +1,2668 @@
+# Gamemaker Event System PR1 — Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the gamemaker actor (gauges + profile + 6 intervention variants + 11 typed events + active-effect lifecycle + brain integration) as a backend-only PR. No frontend changes.
+
+**Architecture:** New `game/src/gamemaker/` module hangs off `Game.gamemaker: Gamemaker`. Per-phase decision flow runs from `run_day_night_cycle`. Each `InterventionKind` is a small file implementing a `score`/`target_pref`/`resolve` trio. `ActiveIntervention` carries persistent state for mutts/closures/convergence. All emissions are typed `MessagePayload` variants; no stringly-typed fallbacks. Independent of the pending weather refactor — uses a local `Weather` stub if shelter PR1 hasn't shipped.
+
+**Tech Stack:** Rust 2024, rstest for parametric tests, serde for persistence, `chrono`/`uuid` already in scope, `rand::SmallRng` for determinism. No new crate dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-gamemaker-event-system-design.md`
+
+---
+
+## File Structure
+
+**Created:**
+
+- `game/src/gamemaker/mod.rs` — module root; `Gamemaker` struct + `RecentIntervention`
+- `game/src/gamemaker/gauges.rs` — `Gauges` struct + tick/reaction tables
+- `game/src/gamemaker/profile.rs` — `GamemakerProfile` struct + `CASSANDRA` const
+- `game/src/gamemaker/decision.rs` — `should_intervene`, variant selection, targeting fallback loop
+- `game/src/gamemaker/active.rs` — `ActiveIntervention` enum + per-phase tick/resolve
+- `game/src/gamemaker/weather_stub.rs` — local `Weather` enum (only if shelter PR1 not merged)
+- `game/src/gamemaker/interventions/mod.rs` — `InterventionKind` enum + `InterventionLogic` trait
+- `game/src/gamemaker/interventions/fireball.rs`
+- `game/src/gamemaker/interventions/mutt_pack.rs`
+- `game/src/gamemaker/interventions/force_field.rs`
+- `game/src/gamemaker/interventions/area_closure.rs`
+- `game/src/gamemaker/interventions/convergence.rs`
+- `game/src/gamemaker/interventions/weather_override.rs`
+- `game/tests/gamemaker_integration.rs`
+
+**Modified:**
+
+- `game/src/lib.rs` — `pub mod gamemaker;`
+- `game/src/games.rs` — `Game.gamemaker: Gamemaker` field + Default + integration into `run_day_night_cycle`
+- `game/src/tributes/brain.rs` (or wherever `choose_destination` / action selection lives) — convergence pull, mutt avoidance, sealed-area filter
+- `shared/src/messages.rs` — 11 new `MessagePayload` variants + `Lure` enum + `DespawnReason` enum + 3 cause constants
+
+---
+
+## Conventions
+
+- **TDD throughout.** Failing test → run → minimal impl → run → commit.
+- **Commit message:** `feat(gamemaker): <task summary>` for new code; `feat(shared): <summary>` for shared crate; `feat(game): <summary>` for game-crate integration touch points.
+- **Test command (game crate):** `cargo test --package game gamemaker`
+- **Test command (specific test):** `cargo test --package game gamemaker -- <test_name> --exact --nocapture`
+- **Run after every task:** `just fmt && cargo check --workspace`
+- **Use `SmallRng::seed_from_u64(N)` in tests** for determinism. Snapshot ranges (e.g., `assert!(count >= 28 && count <= 60)`) over exact equality where rng-driven.
+
+---
+
+## Task 1: Module skeleton + Weather stub coordination
+
+**Files:**
+- Create: `game/src/gamemaker/mod.rs`
+- Create: `game/src/gamemaker/weather_stub.rs`
+- Modify: `game/src/lib.rs`
+
+**Goal:** Empty module compiles; `Weather` enum is reachable from inside `gamemaker::` regardless of whether shelter PR1 has shipped.
+
+- [ ] **Step 1: Check whether shelter PR1's `Weather` exists.** Run:
+
+```bash
+grep -rn "pub enum Weather" game/src/ | head -3
+```
+
+If a `pub enum Weather { Clear, HeavyRain, Heatwave, Blizzard, ... }` is found in `game/src/`, **skip the stub file** and `pub use` from that location instead in Step 3 below.
+
+If nothing is found, proceed with the stub.
+
+- [ ] **Step 2: Create `game/src/gamemaker/weather_stub.rs`** (only if Step 1 found nothing):
+
+```rust
+//! Local `Weather` wedge. Removed when shelter PR1 (or weather spec) lands its
+//! own `Weather` enum in `game/src/weather.rs` or similar.
+//!
+//! See `docs/superpowers/specs/2026-05-03-gamemaker-event-system-design.md`,
+//! "Coexistence with current `AreaEvent`" section.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Weather {
+    Clear,
+    HeavyRain,
+    Heatwave,
+    Blizzard,
+}
+
+impl Default for Weather {
+    fn default() -> Self {
+        Weather::Clear
+    }
+}
+
+/// Stub: always returns `Weather::Clear`. Replaced by real producer when
+/// weather spec lands.
+pub fn current_weather() -> Weather {
+    Weather::Clear
+}
+```
+
+- [ ] **Step 3: Create `game/src/gamemaker/mod.rs`:**
+
+```rust
+//! Gamemaker / Capitol intervention system.
+//!
+//! See `docs/superpowers/specs/2026-05-03-gamemaker-event-system-design.md`.
+
+pub mod active;
+pub mod decision;
+pub mod gauges;
+pub mod interventions;
+pub mod profile;
+
+#[cfg(not(feature = "shelter_weather"))]
+pub mod weather_stub;
+
+#[cfg(not(feature = "shelter_weather"))]
+pub use weather_stub::Weather;
+
+#[cfg(feature = "shelter_weather")]
+pub use crate::weather::Weather;
+
+use std::collections::VecDeque;
+
+use serde::{Deserialize, Serialize};
+
+pub use active::ActiveIntervention;
+pub use decision::should_intervene;
+pub use gauges::Gauges;
+pub use interventions::{InterventionKind, Lure};
+pub use profile::{CASSANDRA, GamemakerProfile};
+
+/// Maximum recent-interventions window the dispatcher inspects when
+/// applying `recent_penalty`.
+pub const RECENT_WINDOW: usize = 6;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct RecentIntervention {
+    pub kind: InterventionKind,
+    pub phase_index: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Gamemaker {
+    pub profile: GamemakerProfile,
+    pub gauges: Gauges,
+    #[serde(default)]
+    pub recent_interventions: VecDeque<RecentIntervention>,
+    #[serde(default)]
+    pub interventions_today: u8,
+    #[serde(default)]
+    pub active_effects: Vec<ActiveIntervention>,
+}
+
+impl Default for Gamemaker {
+    fn default() -> Self {
+        Self {
+            profile: CASSANDRA,
+            gauges: Gauges::STARTING,
+            recent_interventions: VecDeque::with_capacity(RECENT_WINDOW),
+            interventions_today: 0,
+            active_effects: Vec::new(),
+        }
+    }
+}
+
+impl Gamemaker {
+    pub fn new(profile: GamemakerProfile) -> Self {
+        Self {
+            profile,
+            gauges: Gauges::STARTING,
+            recent_interventions: VecDeque::with_capacity(RECENT_WINDOW),
+            interventions_today: 0,
+            active_effects: Vec::new(),
+        }
+    }
+
+    /// Records a freshly-fired intervention and trims the window.
+    pub fn record_intervention(&mut self, kind: InterventionKind, phase_index: u32) {
+        self.recent_interventions.push_back(RecentIntervention { kind, phase_index });
+        while self.recent_interventions.len() > RECENT_WINDOW {
+            self.recent_interventions.pop_front();
+        }
+        self.interventions_today = self.interventions_today.saturating_add(1);
+        self.gauges.patience = 0;
+    }
+
+    /// Counts how many times `kind` appears in the recent-interventions window.
+    pub fn recent_count(&self, kind: InterventionKind) -> u32 {
+        self.recent_interventions
+            .iter()
+            .filter(|r| r.kind == kind)
+            .count() as u32
+    }
+}
+```
+
+- [ ] **Step 4: Add `pub mod gamemaker;` to `game/src/lib.rs`** (placed alphabetically with other modules).
+
+- [ ] **Step 5: Stub the sub-modules so the workspace compiles.** Create empty `gauges.rs`, `profile.rs`, `decision.rs`, `active.rs`, and `interventions/mod.rs` with just `// task N` placeholders for now — they'll be filled in subsequent tasks. Minimal stubs:
+
+```rust
+// game/src/gamemaker/gauges.rs
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Gauges {
+    pub drama_pressure: u8,
+    pub audience_attention: u8,
+    pub bloodthirst: u8,
+    pub chaos: u8,
+    pub patience: u8,
+    pub body_count_debt: u8,
+}
+
+impl Gauges {
+    pub const STARTING: Self = Self {
+        drama_pressure: 0,
+        audience_attention: 80,
+        bloodthirst: 20,
+        chaos: 10,
+        patience: 0,
+        body_count_debt: 0,
+    };
+}
+```
+
+```rust
+// game/src/gamemaker/profile.rs
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct GamemakerProfile {
+    pub name: &'static str,
+    pub pressure_decay_rate: u8,
+    pub attention_decay_rate: u8,
+    pub bloodthirst_weight: u8,
+    pub chaos_weight: u8,
+    pub patience_threshold: u8,
+    pub max_per_day: u8,
+    pub max_concurrent_events: u8,
+    pub late_game_multiplier: f32,
+    pub recent_penalty: u32,
+}
+
+pub const CASSANDRA: GamemakerProfile = GamemakerProfile {
+    name: "Cassandra",
+    pressure_decay_rate: 8,
+    attention_decay_rate: 3,
+    bloodthirst_weight: 100,
+    chaos_weight: 100,
+    patience_threshold: 30,
+    max_per_day: 2,
+    max_concurrent_events: 2,
+    late_game_multiplier: 1.5,
+    recent_penalty: 25,
+};
+```
+
+```rust
+// game/src/gamemaker/active.rs
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum ActiveIntervention {
+    // Filled in Task 9
+    Placeholder,
+}
+```
+
+```rust
+// game/src/gamemaker/decision.rs
+use crate::gamemaker::Gamemaker;
+
+pub fn should_intervene(_g: &Gamemaker) -> bool {
+    false // Filled in Task 6
+}
+```
+
+```rust
+// game/src/gamemaker/interventions/mod.rs
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum InterventionKind {
+    Fireball,
+    MuttPack,
+    ForceFieldShift,
+    AreaClosure,
+    ConvergencePoint,
+    WeatherOverride,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum Lure {
+    Feast,
+}
+```
+
+- [ ] **Step 6: Run `cargo check --workspace` and `just fmt`.** Expected: clean build, no warnings about unused enums (the variants are public so they're fine).
+
+- [ ] **Step 7: Commit:**
+
+```bash
+jj describe -m "feat(gamemaker): module skeleton with Gamemaker + Weather stub (hangrier_games-5q9)"
+jj new
+```
+
+---
+
+## Task 2: Wire `Gamemaker` into `Game`
+
+**Files:**
+- Modify: `game/src/games.rs:90-125` (Game struct and Default)
+- Test: inline in `game/src/gamemaker/mod.rs`
+
+- [ ] **Step 1: Write failing test in `game/src/gamemaker/mod.rs`:**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gamemaker_default_uses_cassandra_starting_gauges() {
+        let gm = Gamemaker::default();
+        assert_eq!(gm.profile.name, "Cassandra");
+        assert_eq!(gm.gauges, Gauges::STARTING);
+        assert_eq!(gm.interventions_today, 0);
+        assert!(gm.recent_interventions.is_empty());
+        assert!(gm.active_effects.is_empty());
+    }
+
+    #[test]
+    fn record_intervention_caps_window_and_resets_patience() {
+        let mut gm = Gamemaker::default();
+        gm.gauges.patience = 50;
+        for i in 0..(RECENT_WINDOW as u32 + 3) {
+            gm.record_intervention(InterventionKind::Fireball, i);
+        }
+        assert_eq!(gm.recent_interventions.len(), RECENT_WINDOW);
+        assert_eq!(gm.interventions_today, RECENT_WINDOW as u8 + 3);
+        assert_eq!(gm.gauges.patience, 0);
+        assert_eq!(gm.recent_count(InterventionKind::Fireball), RECENT_WINDOW as u32);
+    }
+
+    #[test]
+    fn game_has_default_gamemaker() {
+        let game = crate::games::Game::default();
+        assert_eq!(game.gamemaker.profile.name, "Cassandra");
+    }
+}
+```
+
+- [ ] **Step 2: Run test:**
+
+```bash
+cargo test --package game gamemaker:: -- --nocapture
+```
+
+Expected: third test fails — `Game` has no `gamemaker` field.
+
+- [ ] **Step 3: Add field to `Game` struct in `game/src/games.rs`** (after `pub emit_index: u32,` near line ~125):
+
+```rust
+    /// Capitol intervention actor. See spec
+    /// `2026-05-03-gamemaker-event-system-design.md`.
+    #[serde(default)]
+    pub gamemaker: crate::gamemaker::Gamemaker,
+```
+
+- [ ] **Step 4: Add to `Default` impl** (around line ~155, with other field initializers):
+
+```rust
+            gamemaker: crate::gamemaker::Gamemaker::default(),
+```
+
+- [ ] **Step 5: Run tests:**
+
+```bash
+cargo test --package game gamemaker:: -- --nocapture
+```
+
+Expected: all three pass.
+
+- [ ] **Step 6: Run full game test suite to confirm nothing broke:**
+
+```bash
+just test
+```
+
+Expected: pass (allowing pre-existing unrelated failures).
+
+- [ ] **Step 7: Commit:**
+
+```bash
+jj describe -m "feat(gamemaker): attach Gamemaker to Game with serde default"
+jj new
+```
+
+---
+
+## Task 3: Gauge tick — background per-phase rises/decays
+
+**Files:**
+- Modify: `game/src/gamemaker/gauges.rs`
+
+Implements the per-phase background tick (rises before any per-event reaction). Late-game multiplier applied here when caller passes `alive_tributes <= 8`.
+
+- [ ] **Step 1: Write failing test in `game/src/gamemaker/gauges.rs`:**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gamemaker::profile::CASSANDRA;
+
+    #[test]
+    fn tick_phase_raises_pressure_and_drops_attention() {
+        let mut g = Gauges::STARTING;
+        g.tick_phase(&CASSANDRA, /*alive_tributes=*/ 16);
+        assert_eq!(g.drama_pressure, 8);
+        assert_eq!(g.audience_attention, 77); // 80 - 3
+        assert_eq!(g.patience, 1);
+    }
+
+    #[test]
+    fn tick_phase_clamps_pressure_at_100() {
+        let mut g = Gauges::STARTING;
+        g.drama_pressure = 95;
+        g.tick_phase(&CASSANDRA, 16);
+        assert_eq!(g.drama_pressure, 100);
+    }
+
+    #[test]
+    fn tick_phase_late_game_multiplier_amplifies_pressure_rise() {
+        let mut g = Gauges::STARTING;
+        g.tick_phase(&CASSANDRA, /*alive_tributes=*/ 5);
+        // 8 * 1.5 = 12
+        assert_eq!(g.drama_pressure, 12);
+    }
+
+    #[test]
+    fn tick_phase_attention_clamps_at_zero() {
+        let mut g = Gauges::STARTING;
+        g.audience_attention = 1;
+        g.tick_phase(&CASSANDRA, 16);
+        assert_eq!(g.audience_attention, 0);
+        // tick again
+        g.tick_phase(&CASSANDRA, 16);
+        assert_eq!(g.audience_attention, 0);
+    }
+
+    #[test]
+    fn tick_phase_patience_saturates() {
+        let mut g = Gauges::STARTING;
+        g.patience = 254;
+        g.tick_phase(&CASSANDRA, 16);
+        assert_eq!(g.patience, 255);
+        g.tick_phase(&CASSANDRA, 16);
+        assert_eq!(g.patience, 255);
+    }
+}
+```
+
+- [ ] **Step 2: Run:**
+
+```bash
+cargo test --package game gamemaker::gauges -- --nocapture
+```
+
+Expected: all five fail — `tick_phase` does not exist.
+
+- [ ] **Step 3: Implement in `gauges.rs`** (append after the struct):
+
+```rust
+use crate::gamemaker::profile::GamemakerProfile;
+
+const LATE_GAME_THRESHOLD: u32 = 8;
+
+impl Gauges {
+    /// Per-phase background tick: rises pressure, decays attention, increments patience.
+    /// Applies `profile.late_game_multiplier` to pressure rise when `alive_tributes <= 8`.
+    pub fn tick_phase(&mut self, profile: &GamemakerProfile, alive_tributes: u32) {
+        let mult = if alive_tributes <= LATE_GAME_THRESHOLD {
+            profile.late_game_multiplier
+        } else {
+            1.0
+        };
+        let rise = (profile.pressure_decay_rate as f32 * mult).round() as u16;
+        self.drama_pressure = self.drama_pressure.saturating_add(rise.min(255) as u8).min(100);
+
+        self.audience_attention = self.audience_attention.saturating_sub(profile.attention_decay_rate);
+        self.patience = self.patience.saturating_add(1);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests:**
+
+```bash
+cargo test --package game gamemaker::gauges -- --nocapture
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit:**
+
+```bash
+jj describe -m "feat(gamemaker): per-phase gauge tick with late-game multiplier"
+jj new
+```
+
+---
+
+## Task 4: Gauge per-event reactions
+
+**Files:**
+- Modify: `game/src/gamemaker/gauges.rs`
+
+Implements `react_to(...)` matching the per-event table in the spec.
+
+- [ ] **Step 1: Write failing tests:**
+
+```rust
+#[cfg(test)]
+mod react_tests {
+    use super::*;
+    use crate::gamemaker::profile::CASSANDRA;
+
+    fn baseline() -> Gauges {
+        Gauges {
+            drama_pressure: 50,
+            audience_attention: 50,
+            bloodthirst: 50,
+            chaos: 50,
+            patience: 10,
+            body_count_debt: 20,
+        }
+    }
+
+    #[test]
+    fn tribute_killed_decays_pressure_and_bloodthirst_boosts_attention() {
+        let mut g = baseline();
+        g.react_to(&GaugeReaction::TributeKilled);
+        assert_eq!(g.drama_pressure, 35); // -15
+        assert_eq!(g.audience_attention, 62); // +12
+        assert_eq!(g.bloodthirst, 30); // -20
+        assert_eq!(g.chaos, 45); // -5
+        assert_eq!(g.body_count_debt, 10); // -10
+    }
+
+    #[test]
+    fn hazard_no_kill_softer_drop() {
+        let mut g = baseline();
+        g.react_to(&GaugeReaction::HazardNoKill);
+        assert_eq!(g.drama_pressure, 42); // -8
+        assert_eq!(g.audience_attention, 55); // +5
+        assert_eq!(g.chaos, 40); // -10
+    }
+
+    #[test]
+    fn day_boundary_no_deaths_amplifies_pressure_and_bloodthirst() {
+        let mut g = baseline();
+        g.react_to(&GaugeReaction::DayBoundaryNoDeaths);
+        assert_eq!(g.drama_pressure, 70); // +20
+        assert_eq!(g.bloodthirst, 75); // +25
+        assert_eq!(g.body_count_debt, 25); // +5
+    }
+
+    #[test]
+    fn intervention_kill_resets_patience_and_drops_drama() {
+        let mut g = baseline();
+        g.react_to(&GaugeReaction::InterventionResolvedWithKill);
+        assert_eq!(g.drama_pressure, 20); // -30
+        assert_eq!(g.audience_attention, 70); // +20
+        assert_eq!(g.bloodthirst, 20); // -30
+        assert_eq!(g.chaos, 40); // -10
+    }
+
+    #[test]
+    fn weather_override_reaction_is_cheap() {
+        let mut g = baseline();
+        g.react_to(&GaugeReaction::WeatherOverride);
+        assert_eq!(g.drama_pressure, 45); // -5
+        assert_eq!(g.chaos, 45); // -5
+    }
+}
+```
+
+- [ ] **Step 2: Run tests; expected: all fail (`GaugeReaction` undefined).**
+
+- [ ] **Step 3: Implement in `gauges.rs`:**
+
+```rust
+/// Discrete event signals the gamemaker reacts to. Each maps to a row of
+/// the per-event reaction table in the spec.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GaugeReaction {
+    TributeKilled,
+    HazardNoKill,
+    HazardWithKill,
+    CombatRoundNoKill,
+    DayBoundaryDebtAccrued { expected: u32, actual: u32 },
+    DayBoundaryNoDeaths,
+    InterventionResolvedWithKill,
+    InterventionResolvedNoKill,
+    InterventionDisruptive,        // ForceFieldShift, AreaClosure
+    InterventionConvergenceAnnounce,
+    WeatherOverride,
+}
+
+impl Gauges {
+    pub fn react_to(&mut self, r: &GaugeReaction) {
+        match r {
+            GaugeReaction::TributeKilled => {
+                self.drama_pressure = self.drama_pressure.saturating_sub(15);
+                self.audience_attention = (self.audience_attention.saturating_add(12)).min(100);
+                self.bloodthirst = self.bloodthirst.saturating_sub(20);
+                self.chaos = self.chaos.saturating_sub(5);
+                self.body_count_debt = self.body_count_debt.saturating_sub(10);
+            }
+            GaugeReaction::HazardNoKill => {
+                self.drama_pressure = self.drama_pressure.saturating_sub(8);
+                self.audience_attention = (self.audience_attention.saturating_add(5)).min(100);
+                self.bloodthirst = self.bloodthirst.saturating_sub(2);
+                self.chaos = self.chaos.saturating_sub(10);
+            }
+            GaugeReaction::HazardWithKill => {
+                self.drama_pressure = self.drama_pressure.saturating_sub(15);
+                self.audience_attention = (self.audience_attention.saturating_add(12)).min(100);
+                self.bloodthirst = self.bloodthirst.saturating_sub(20);
+                self.chaos = self.chaos.saturating_sub(15);
+                self.body_count_debt = self.body_count_debt.saturating_sub(10);
+            }
+            GaugeReaction::CombatRoundNoKill => {
+                self.drama_pressure = self.drama_pressure.saturating_sub(3);
+                self.audience_attention = (self.audience_attention.saturating_add(2)).min(100);
+                self.bloodthirst = (self.bloodthirst.saturating_add(2)).min(100);
+                self.chaos = self.chaos.saturating_sub(2);
+            }
+            GaugeReaction::DayBoundaryDebtAccrued { expected, actual } => {
+                let delta = expected.saturating_sub(*actual);
+                self.bloodthirst = (self.bloodthirst.saturating_add(10)).min(100);
+                let bump = (delta * 5).min(100) as u8;
+                self.body_count_debt = (self.body_count_debt.saturating_add(bump)).min(100);
+            }
+            GaugeReaction::DayBoundaryNoDeaths => {
+                self.drama_pressure = (self.drama_pressure.saturating_add(20)).min(100);
+                self.bloodthirst = (self.bloodthirst.saturating_add(25)).min(100);
+                self.body_count_debt = (self.body_count_debt.saturating_add(5)).min(100);
+            }
+            GaugeReaction::InterventionResolvedWithKill => {
+                self.drama_pressure = self.drama_pressure.saturating_sub(30);
+                self.audience_attention = (self.audience_attention.saturating_add(20)).min(100);
+                self.bloodthirst = self.bloodthirst.saturating_sub(30);
+                self.chaos = self.chaos.saturating_sub(10);
+            }
+            GaugeReaction::InterventionResolvedNoKill => {
+                self.drama_pressure = self.drama_pressure.saturating_sub(15);
+                self.audience_attention = (self.audience_attention.saturating_add(5)).min(100);
+                self.bloodthirst = self.bloodthirst.saturating_sub(10);
+                self.chaos = self.chaos.saturating_sub(5);
+            }
+            GaugeReaction::InterventionDisruptive => {
+                self.drama_pressure = self.drama_pressure.saturating_sub(10);
+                self.audience_attention = (self.audience_attention.saturating_add(5)).min(100);
+                self.chaos = self.chaos.saturating_sub(20);
+            }
+            GaugeReaction::InterventionConvergenceAnnounce => {
+                self.drama_pressure = self.drama_pressure.saturating_sub(5);
+                self.audience_attention = (self.audience_attention.saturating_add(3)).min(100);
+            }
+            GaugeReaction::WeatherOverride => {
+                self.drama_pressure = self.drama_pressure.saturating_sub(5);
+                self.chaos = self.chaos.saturating_sub(5);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run; expected pass.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+jj describe -m "feat(gamemaker): per-event gauge reactions"
+jj new
+```
+
+---
+
+## Task 5: Shared payloads — Lure, DespawnReason, cause constants, 11 MessagePayload variants
+
+**Files:**
+- Modify: `shared/src/messages.rs`
+
+This is a single fat task because all 11 variants need to land together; tests in subsequent tasks reference them.
+
+- [ ] **Step 1: Write failing tests in `shared/src/messages.rs`** (append to existing `#[cfg(test)] mod tests` block, or create one):
+
+```rust
+#[cfg(test)]
+mod gamemaker_payload_tests {
+    use super::*;
+
+    #[test]
+    fn lure_feast_serializes_round_trip() {
+        let l = Lure::Feast;
+        let json = serde_json::to_string(&l).unwrap();
+        let back: Lure = serde_json::from_str(&json).unwrap();
+        assert_eq!(l, back);
+    }
+
+    #[test]
+    fn despawn_reasons_round_trip() {
+        for r in [DespawnReason::Morning, DespawnReason::NoTargetsNearby, DespawnReason::NoMembersLeft] {
+            let json = serde_json::to_string(&r).unwrap();
+            let back: DespawnReason = serde_json::from_str(&json).unwrap();
+            assert_eq!(r, back);
+        }
+    }
+
+    #[test]
+    fn fireball_strike_round_trip() {
+        let p = MessagePayload::FireballStrike {
+            area: AreaRef { id: "a1".into(), name: "Forest".into() },
+            severity_label: "Major".into(),
+            victims: vec![],
+            survivors: vec![],
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: MessagePayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, back);
+    }
+
+    #[test]
+    fn cause_constants_present() {
+        assert_eq!(CAUSE_FIREBALL, "fireball");
+        assert_eq!(CAUSE_MUTT_PACK, "mutt_pack");
+        assert_eq!(CAUSE_AREA_SEAL, "area_seal");
+    }
+}
+```
+
+- [ ] **Step 2: Run; expected fail.**
+
+```bash
+cargo test --package shared gamemaker_payload -- --nocapture
+```
+
+- [ ] **Step 3: Add to `shared/src/messages.rs`** — insert the new types and variants. Place `Lure`, `DespawnReason`, and the cause constants near the top of the file (after the existing `use` block); insert the 11 new variants into the `MessagePayload` enum (alphabetically grouped is fine; spec section "Events / Messages" lists them):
+
+```rust
+// === Cause constants for TributeKilled.cause ===
+pub const CAUSE_FIREBALL: &str = "fireball";
+pub const CAUSE_MUTT_PACK: &str = "mutt_pack";
+pub const CAUSE_AREA_SEAL: &str = "area_seal";
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Lure {
+    Feast,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum DespawnReason {
+    Morning,
+    NoTargetsNearby,
+    NoMembersLeft,
+}
+```
+
+Then add the 11 variants to `pub enum MessagePayload`. Use `severity_label: String` (free-form, since `EventSeverity` lives in `game/` not `shared/`) and `kind_label: String` for animal kind (game crate stringifies it). Keeps shared crate independent of game crate types.
+
+```rust
+    // --- Gamemaker: lethal ---
+    FireballStrike {
+        area: AreaRef,
+        severity_label: String,
+        victims: Vec<TributeRef>,
+        survivors: Vec<TributeRef>,
+    },
+    MuttSwarmSpawned {
+        area: AreaRef,
+        kind_label: String,
+        members: u8,
+    },
+    MuttSwarmAttack {
+        area: AreaRef,
+        kind_label: String,
+        victim: TributeRef,
+        damage: u32,
+        killed: bool,
+    },
+    MuttSwarmDespawned {
+        area: AreaRef,
+        kind_label: String,
+        reason: DespawnReason,
+    },
+
+    // --- Gamemaker: disruptive ---
+    ForceFieldShifted {
+        closed: Vec<AreaRef>,
+        opened: Vec<AreaRef>,
+        warning_phases: u8,
+    },
+    AreaSealed {
+        area: AreaRef,
+        expires_at_phase: u32,
+    },
+    AreaUnsealed {
+        area: AreaRef,
+    },
+    AreaSealEntryDamage {
+        area: AreaRef,
+        tribute: TributeRef,
+        damage: u32,
+    },
+
+    // --- Gamemaker: convergence ---
+    ConvergencePointAnnounced {
+        area: AreaRef,
+        lure: Lure,
+        starts_at_phase: u32,
+    },
+    ConvergencePointExpired {
+        area: AreaRef,
+        lure: Lure,
+        claimed_by: Vec<TributeRef>,
+    },
+
+    // --- Gamemaker: atmospheric ---
+    WeatherOverridden {
+        area: AreaRef,
+        weather_label: String,
+        duration_phases: u8,
+    },
+```
+
+- [ ] **Step 4: Run shared tests:**
+
+```bash
+cargo test --package shared -- --nocapture
+```
+
+Expected: all four new tests pass.
+
+- [ ] **Step 5: Run workspace check (the new `MessagePayload` arms may break exhaustive matches in `web/` or `api/`):**
+
+```bash
+cargo check --workspace
+```
+
+If matches break, add `MessagePayload::FireballStrike { .. } | MessagePayload::MuttSwarmSpawned { .. } | ... => { /* TODO PR2 */ }` arms to any non-exhaustive matches in `web/` or `api/`. **Do NOT delete or alter existing arms.** Locate via:
+
+```bash
+grep -rn "match.*MessagePayload" web/src api/src
+```
+
+Common touch-points: `web/src/components/timeline/cards/`, `api/src/routes/events.rs`. Add a generic fallback arm that returns nothing visible (PR2 wires real rendering).
+
+- [ ] **Step 6: Re-run `cargo check --workspace`; expected: clean.**
+
+- [ ] **Step 7: Commit:**
+
+```bash
+jj describe -m "feat(shared): add 11 gamemaker MessagePayload variants + Lure + DespawnReason"
+jj new
+```
+
+---
+
+## Task 6: `should_intervene` — eligibility gate
+
+**Files:**
+- Modify: `game/src/gamemaker/decision.rs`
+
+- [ ] **Step 1: Failing tests in `decision.rs`:**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gamemaker::{Gamemaker, Gauges};
+    use crate::gamemaker::profile::CASSANDRA;
+
+    fn fresh() -> Gamemaker {
+        Gamemaker::default()
+    }
+
+    #[test]
+    fn no_intervene_when_patience_below_threshold() {
+        let mut gm = fresh();
+        gm.gauges = Gauges {
+            patience: 10, // below 30
+            drama_pressure: 99,
+            bloodthirst: 99,
+            chaos: 99,
+            body_count_debt: 99,
+            ..Gauges::STARTING
+        };
+        assert!(!should_intervene(&gm, /*active_count=*/ 0));
+    }
+
+    #[test]
+    fn no_intervene_when_per_day_cap_hit() {
+        let mut gm = fresh();
+        gm.gauges.patience = 30;
+        gm.gauges.drama_pressure = 99;
+        gm.interventions_today = CASSANDRA.max_per_day;
+        assert!(!should_intervene(&gm, 0));
+    }
+
+    #[test]
+    fn no_intervene_when_concurrent_cap_hit() {
+        let mut gm = fresh();
+        gm.gauges.patience = 30;
+        gm.gauges.drama_pressure = 99;
+        assert!(!should_intervene(&gm, CASSANDRA.max_concurrent_events as usize));
+    }
+
+    #[test]
+    fn no_intervene_when_no_threshold_crossed() {
+        let mut gm = fresh();
+        gm.gauges.patience = 30;
+        // all gauges below their thresholds
+        assert!(!should_intervene(&gm, 0));
+    }
+
+    #[test]
+    fn intervene_when_pressure_above_60() {
+        let mut gm = fresh();
+        gm.gauges.patience = 30;
+        gm.gauges.drama_pressure = 60;
+        assert!(should_intervene(&gm, 0));
+    }
+
+    #[test]
+    fn intervene_when_bloodthirst_above_70() {
+        let mut gm = fresh();
+        gm.gauges.patience = 30;
+        gm.gauges.bloodthirst = 70;
+        assert!(should_intervene(&gm, 0));
+    }
+}
+```
+
+- [ ] **Step 2: Run; expected fail.**
+
+- [ ] **Step 3: Implement in `decision.rs`** (replacing the placeholder):
+
+```rust
+use crate::gamemaker::Gamemaker;
+
+pub const PRESSURE_TRIGGER: u8 = 60;
+pub const BLOODTHIRST_TRIGGER: u8 = 70;
+pub const CHAOS_TRIGGER: u8 = 70;
+pub const BODY_COUNT_DEBT_TRIGGER: u8 = 10;
+
+pub fn should_intervene(gm: &Gamemaker, active_count: usize) -> bool {
+    if gm.interventions_today >= gm.profile.max_per_day {
+        return false;
+    }
+    if active_count >= gm.profile.max_concurrent_events as usize {
+        return false;
+    }
+    if gm.gauges.patience < gm.profile.patience_threshold {
+        return false;
+    }
+    let g = &gm.gauges;
+    g.drama_pressure >= PRESSURE_TRIGGER
+        || g.bloodthirst >= BLOODTHIRST_TRIGGER
+        || g.chaos >= CHAOS_TRIGGER
+        || g.body_count_debt >= BODY_COUNT_DEBT_TRIGGER
+}
+```
+
+- [ ] **Step 4: Run; expected pass.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+jj describe -m "feat(gamemaker): should_intervene eligibility gate"
+jj new
+```
+
+---
+
+## Task 7: `InterventionLogic` trait + `GameSnapshot` view
+
+**Files:**
+- Modify: `game/src/gamemaker/interventions/mod.rs`
+
+`GameSnapshot` is a read-only view passed into scoring/targeting so per-variant logic stays a pure function. Building it from `&Game` happens in Task 14 (integration).
+
+- [ ] **Step 1: Failing test:**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_default_has_zero_alive() {
+        let snap = GameSnapshot::default();
+        assert_eq!(snap.alive_tributes, 0);
+    }
+
+    #[test]
+    fn target_spec_single_area_eq() {
+        let a = TargetSpec::SingleArea(AreaId("forest".into()));
+        let b = TargetSpec::SingleArea(AreaId("forest".into()));
+        assert_eq!(a, b);
+    }
+}
+```
+
+- [ ] **Step 2: Run; expected fail.**
+
+- [ ] **Step 3: Implement in `interventions/mod.rs`:**
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum InterventionKind {
+    Fireball,
+    MuttPack,
+    ForceFieldShift,
+    AreaClosure,
+    ConvergencePoint,
+    WeatherOverride,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum Lure {
+    Feast,
+}
+
+/// Stable identifier for an area in the per-phase decision pipeline.
+/// Wrapped so tests can construct one without the `Area` enum.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct AreaId(pub String);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TargetSpec {
+    SingleArea(AreaId),
+    AreaSet { close: Vec<AreaId>, open: Vec<AreaId> },
+}
+
+/// Derived snapshot of game state passed to intervention scoring/targeting.
+/// Built once per phase by the dispatcher.
+#[derive(Clone, Debug, Default)]
+pub struct GameSnapshot {
+    pub alive_tributes: u32,
+    pub current_phase_index: u32,
+    /// (area_id, alive_tribute_count, adjacent_area_ids)
+    pub areas: Vec<AreaSnapshot>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AreaSnapshot {
+    pub id: AreaId,
+    pub tribute_count: u32,
+    pub adjacent_ids: Vec<AreaId>,
+    pub is_open: bool,
+    pub has_active_intervention: bool,
+}
+
+pub trait InterventionLogic {
+    fn kind(&self) -> InterventionKind;
+    fn score(
+        &self,
+        profile: &crate::gamemaker::profile::GamemakerProfile,
+        gauges: &crate::gamemaker::gauges::Gauges,
+        snap: &GameSnapshot,
+    ) -> u32;
+    fn target_pref(&self, snap: &GameSnapshot) -> Option<TargetSpec>;
+}
+
+pub mod area_closure;
+pub mod convergence;
+pub mod fireball;
+pub mod force_field;
+pub mod mutt_pack;
+pub mod weather_override;
+```
+
+- [ ] **Step 4: Create empty stub files** (one-line `// Task N` placeholders) for each listed sub-module, so `cargo check` passes:
+
+```bash
+for f in fireball mutt_pack force_field area_closure convergence weather_override; do
+  printf '// Implemented in Task 8\n' > game/src/gamemaker/interventions/$f.rs
+done
+```
+
+(Run from the `hangrier_games` crate root, not the specs worktree.)
+
+- [ ] **Step 5: Run tests:**
+
+```bash
+cargo test --package game gamemaker::interventions -- --nocapture
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit:**
+
+```bash
+jj describe -m "feat(gamemaker): InterventionLogic trait + GameSnapshot + AreaId"
+jj new
+```
+
+---
+
+## Task 8: Six intervention scorers + targeting
+
+**Files:**
+- Modify: `game/src/gamemaker/interventions/{fireball,mutt_pack,force_field,area_closure,convergence,weather_override}.rs`
+
+Each variant gets a unit struct, `impl InterventionLogic`, and one or two unit tests. Numbers from the spec's "Variant Scoring & Targeting" sketch.
+
+### 8a. Fireball
+
+- [ ] **Step 1: Write `game/src/gamemaker/interventions/fireball.rs`:**
+
+```rust
+use crate::gamemaker::gauges::Gauges;
+use crate::gamemaker::profile::GamemakerProfile;
+use super::{AreaId, GameSnapshot, InterventionKind, InterventionLogic, TargetSpec};
+
+pub struct Fireball;
+
+impl InterventionLogic for Fireball {
+    fn kind(&self) -> InterventionKind { InterventionKind::Fireball }
+
+    fn score(&self, profile: &GamemakerProfile, gauges: &Gauges, _snap: &GameSnapshot) -> u32 {
+        let blood = (gauges.bloodthirst as u32 * profile.bloodthirst_weight as u32) / 50;
+        blood + gauges.drama_pressure as u32
+    }
+
+    fn target_pref(&self, snap: &GameSnapshot) -> Option<TargetSpec> {
+        let best = snap
+            .areas
+            .iter()
+            .filter(|a| a.is_open && a.tribute_count > 0)
+            .max_by_key(|a| a.tribute_count)?;
+        Some(TargetSpec::SingleArea(best.id.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gamemaker::profile::CASSANDRA;
+
+    #[test]
+    fn score_zero_when_all_gauges_zero() {
+        let g = Gauges {
+            drama_pressure: 0, bloodthirst: 0, audience_attention: 0,
+            chaos: 0, patience: 0, body_count_debt: 0,
+        };
+        assert_eq!(Fireball.score(&CASSANDRA, &g, &GameSnapshot::default()), 0);
+    }
+
+    #[test]
+    fn score_scales_with_bloodthirst() {
+        let mut g = Gauges {
+            drama_pressure: 50, bloodthirst: 50, audience_attention: 50,
+            chaos: 50, patience: 50, body_count_debt: 50,
+        };
+        let s1 = Fireball.score(&CASSANDRA, &g, &GameSnapshot::default());
+        g.bloodthirst = 100;
+        let s2 = Fireball.score(&CASSANDRA, &g, &GameSnapshot::default());
+        assert!(s2 > s1);
+    }
+
+    #[test]
+    fn target_pref_picks_area_with_most_tributes() {
+        let snap = GameSnapshot {
+            alive_tributes: 5,
+            current_phase_index: 0,
+            areas: vec![
+                super::super::AreaSnapshot { id: AreaId("a".into()), tribute_count: 1, adjacent_ids: vec![], is_open: true, has_active_intervention: false },
+                super::super::AreaSnapshot { id: AreaId("b".into()), tribute_count: 4, adjacent_ids: vec![], is_open: true, has_active_intervention: false },
+            ],
+        };
+        match Fireball.target_pref(&snap) {
+            Some(TargetSpec::SingleArea(id)) => assert_eq!(id, AreaId("b".into())),
+            _ => panic!("expected SingleArea(b)"),
+        }
+    }
+
+    #[test]
+    fn target_pref_none_when_no_open_area_has_tributes() {
+        assert!(Fireball.target_pref(&GameSnapshot::default()).is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run; expected pass.**
+
+```bash
+cargo test --package game gamemaker::interventions::fireball -- --nocapture
+```
+
+### 8b. MuttPack
+
+- [ ] **Step 3: Write `mutt_pack.rs`:**
+
+```rust
+use crate::gamemaker::gauges::Gauges;
+use crate::gamemaker::profile::GamemakerProfile;
+use super::{AreaId, GameSnapshot, InterventionKind, InterventionLogic, TargetSpec};
+
+pub struct MuttPack;
+
+impl InterventionLogic for MuttPack {
+    fn kind(&self) -> InterventionKind { InterventionKind::MuttPack }
+
+    fn score(&self, _profile: &GamemakerProfile, gauges: &Gauges, _snap: &GameSnapshot) -> u32 {
+        gauges.bloodthirst as u32
+            + (gauges.body_count_debt as u32) * 2
+            + gauges.chaos as u32
+    }
+
+    fn target_pref(&self, snap: &GameSnapshot) -> Option<TargetSpec> {
+        let best = snap.areas.iter()
+            .filter(|a| a.is_open && a.tribute_count > 0)
+            .filter(|a| {
+                snap.areas.iter().any(|other| {
+                    other.id != a.id && other.tribute_count > 0 && a.adjacent_ids.contains(&other.id)
+                })
+            })
+            .max_by_key(|a| a.tribute_count)
+            .or_else(|| snap.areas.iter().filter(|a| a.is_open && a.tribute_count > 0).max_by_key(|a| a.tribute_count))?;
+        Some(TargetSpec::SingleArea(best.id.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gamemaker::profile::CASSANDRA;
+
+    #[test]
+    fn score_uses_body_count_debt_double() {
+        let g = Gauges {
+            bloodthirst: 10, body_count_debt: 20, chaos: 5,
+            drama_pressure: 0, audience_attention: 0, patience: 0,
+        };
+        // 10 + 20*2 + 5 = 55
+        assert_eq!(MuttPack.score(&CASSANDRA, &g, &GameSnapshot::default()), 55);
+    }
+}
+```
+
+- [ ] **Step 4: Run; expected pass.**
+
+### 8c. ForceFieldShift
+
+- [ ] **Step 5: Write `force_field.rs`:**
+
+```rust
+use crate::gamemaker::gauges::Gauges;
+use crate::gamemaker::profile::GamemakerProfile;
+use super::{AreaId, GameSnapshot, InterventionKind, InterventionLogic, TargetSpec};
+
+pub struct ForceFieldShift;
+
+const MIN_OPEN_AFTER_SHIFT: usize = 3;
+
+impl InterventionLogic for ForceFieldShift {
+    fn kind(&self) -> InterventionKind { InterventionKind::ForceFieldShift }
+
+    fn score(&self, profile: &GamemakerProfile, gauges: &Gauges, snap: &GameSnapshot) -> u32 {
+        let chaos = (gauges.chaos as u32 * profile.chaos_weight as u32) / 33; // x3
+        let alive_penalty = if snap.alive_tributes <= 4 { 50 } else { 0 };
+        chaos.saturating_add(gauges.drama_pressure as u32).saturating_sub(alive_penalty)
+    }
+
+    fn target_pref(&self, snap: &GameSnapshot) -> Option<TargetSpec> {
+        let open_low: Vec<AreaId> = snap.areas.iter()
+            .filter(|a| a.is_open && a.tribute_count == 0)
+            .map(|a| a.id.clone())
+            .take(2)
+            .collect();
+        let closed_candidates: Vec<AreaId> = snap.areas.iter()
+            .filter(|a| !a.is_open)
+            .map(|a| a.id.clone())
+            .take(open_low.len())
+            .collect();
+        let total_open_after = snap.areas.iter().filter(|a| a.is_open).count()
+            + closed_candidates.len()
+            - open_low.len();
+        if open_low.is_empty() || total_open_after < MIN_OPEN_AFTER_SHIFT {
+            return None;
+        }
+        Some(TargetSpec::AreaSet { close: open_low, open: closed_candidates })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_pref_none_with_no_empty_open_areas() {
+        let snap = GameSnapshot {
+            alive_tributes: 4,
+            current_phase_index: 0,
+            areas: vec![
+                super::super::AreaSnapshot { id: AreaId("a".into()), tribute_count: 4, adjacent_ids: vec![], is_open: true, has_active_intervention: false },
+            ],
+        };
+        assert!(ForceFieldShift.target_pref(&snap).is_none());
+    }
+}
+```
+
+- [ ] **Step 6: Run; expected pass.**
+
+### 8d. AreaClosure
+
+- [ ] **Step 7: Write `area_closure.rs`:**
+
+```rust
+use crate::gamemaker::gauges::Gauges;
+use crate::gamemaker::profile::GamemakerProfile;
+use super::{GameSnapshot, InterventionKind, InterventionLogic, TargetSpec};
+
+pub struct AreaClosure;
+
+impl InterventionLogic for AreaClosure {
+    fn kind(&self) -> InterventionKind { InterventionKind::AreaClosure }
+
+    fn score(&self, profile: &GamemakerProfile, gauges: &Gauges, _snap: &GameSnapshot) -> u32 {
+        let chaos = (gauges.chaos as u32 * profile.chaos_weight as u32) / 50;
+        chaos + gauges.drama_pressure as u32
+    }
+
+    fn target_pref(&self, snap: &GameSnapshot) -> Option<TargetSpec> {
+        let area = snap.areas.iter()
+            .filter(|a| a.is_open && !a.has_active_intervention)
+            .min_by_key(|a| a.tribute_count)?;
+        Some(TargetSpec::SingleArea(area.id.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_pref_picks_lowest_population_open_area() {
+        let snap = GameSnapshot {
+            alive_tributes: 6,
+            current_phase_index: 0,
+            areas: vec![
+                super::super::AreaSnapshot { id: super::super::AreaId("a".into()), tribute_count: 5, adjacent_ids: vec![], is_open: true, has_active_intervention: false },
+                super::super::AreaSnapshot { id: super::super::AreaId("b".into()), tribute_count: 1, adjacent_ids: vec![], is_open: true, has_active_intervention: false },
+            ],
+        };
+        match AreaClosure.target_pref(&snap) {
+            Some(TargetSpec::SingleArea(id)) => assert_eq!(id, super::super::AreaId("b".into())),
+            _ => panic!(),
+        }
+    }
+}
+```
+
+- [ ] **Step 8: Run; expected pass.**
+
+### 8e. ConvergencePoint
+
+- [ ] **Step 9: Write `convergence.rs`:**
+
+```rust
+use crate::gamemaker::gauges::Gauges;
+use crate::gamemaker::profile::GamemakerProfile;
+use super::{GameSnapshot, InterventionKind, InterventionLogic, TargetSpec};
+
+pub struct ConvergencePoint;
+
+impl InterventionLogic for ConvergencePoint {
+    fn kind(&self) -> InterventionKind { InterventionKind::ConvergencePoint }
+
+    fn score(&self, _profile: &GamemakerProfile, gauges: &Gauges, snap: &GameSnapshot) -> u32 {
+        let mut s = (gauges.drama_pressure as u32) * 2;
+        if gauges.audience_attention < 40 { s += 30; }
+        if snap.alive_tributes >= 6 { s += 15; }
+        s
+    }
+
+    fn target_pref(&self, snap: &GameSnapshot) -> Option<TargetSpec> {
+        let area = snap.areas.iter()
+            .filter(|a| a.is_open && !a.has_active_intervention)
+            .max_by_key(|a| a.adjacent_ids.len() as i64 - a.tribute_count as i64)?;
+        Some(TargetSpec::SingleArea(area.id.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gamemaker::profile::CASSANDRA;
+
+    #[test]
+    fn audience_attention_low_adds_bonus() {
+        let g_high = Gauges { audience_attention: 80, drama_pressure: 50, ..Gauges::STARTING };
+        let g_low = Gauges { audience_attention: 20, drama_pressure: 50, ..Gauges::STARTING };
+        let snap = GameSnapshot::default();
+        assert!(ConvergencePoint.score(&CASSANDRA, &g_low, &snap) > ConvergencePoint.score(&CASSANDRA, &g_high, &snap));
+    }
+}
+```
+
+- [ ] **Step 10: Run; expected pass.**
+
+### 8f. WeatherOverride
+
+- [ ] **Step 11: Write `weather_override.rs`:**
+
+```rust
+use crate::gamemaker::gauges::Gauges;
+use crate::gamemaker::profile::GamemakerProfile;
+use super::{GameSnapshot, InterventionKind, InterventionLogic, TargetSpec};
+
+pub struct WeatherOverride;
+
+impl InterventionLogic for WeatherOverride {
+    fn kind(&self) -> InterventionKind { InterventionKind::WeatherOverride }
+
+    fn score(&self, _profile: &GamemakerProfile, gauges: &Gauges, _snap: &GameSnapshot) -> u32 {
+        (gauges.drama_pressure as u32 + gauges.chaos as u32)
+            .saturating_sub(gauges.bloodthirst as u32)
+    }
+
+    fn target_pref(&self, snap: &GameSnapshot) -> Option<TargetSpec> {
+        let area = snap.areas.iter()
+            .filter(|a| a.is_open)
+            .max_by_key(|a| a.tribute_count)
+            .or_else(|| snap.areas.iter().find(|a| a.is_open))?;
+        Some(super::TargetSpec::SingleArea(area.id.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gamemaker::profile::CASSANDRA;
+
+    #[test]
+    fn score_drops_when_bloodthirsty() {
+        let g_calm = Gauges { drama_pressure: 60, chaos: 60, bloodthirst: 0, ..Gauges::STARTING };
+        let g_blood = Gauges { drama_pressure: 60, chaos: 60, bloodthirst: 80, ..Gauges::STARTING };
+        let snap = GameSnapshot::default();
+        assert!(WeatherOverride.score(&CASSANDRA, &g_calm, &snap) > WeatherOverride.score(&CASSANDRA, &g_blood, &snap));
+    }
+}
+```
+
+- [ ] **Step 12: Run; expected pass.**
+
+- [ ] **Step 13: Run all interventions tests at once + commit:**
+
+```bash
+cargo test --package game gamemaker::interventions -- --nocapture
+just fmt
+jj describe -m "feat(gamemaker): six intervention scorers and target_prefs"
+jj new
+```
+
+---
+
+## Task 9: `ActiveIntervention` enum + per-phase tick
+
+**Files:**
+- Modify: `game/src/gamemaker/active.rs`
+
+- [ ] **Step 1: Failing tests:**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::threats::animals::Animal;
+
+    #[test]
+    fn mutt_swarm_construct() {
+        let s = ActiveIntervention::MuttSwarm {
+            area_id: "forest".into(),
+            kind: Animal::Wolf,
+            members: 4,
+            hp: 80,
+            max_hp_per_member: 20,
+            phases_since_combat: 0,
+            despawn_at_morning: false,
+        };
+        assert_eq!(s.area_id_str(), "forest");
+    }
+
+    #[test]
+    fn closure_expires_when_phase_passes_expiry() {
+        let c = ActiveIntervention::AreaClosure {
+            area_id: "desert".into(),
+            expires_at_phase: 10,
+            damage_per_phase: 5,
+        };
+        assert!(c.expired_at(11));
+        assert!(!c.expired_at(10));
+        assert!(!c.expired_at(9));
+    }
+
+    #[test]
+    fn convergence_expires_when_phase_passes_expiry() {
+        let c = ActiveIntervention::ConvergencePoint {
+            area_id: "clearing".into(),
+            lure: shared::messages::Lure::Feast,
+            expires_at_phase: 4,
+            payload: vec![],
+        };
+        assert!(c.expired_at(5));
+        assert!(!c.expired_at(4));
+    }
+
+    #[test]
+    fn mutt_swarm_decrement_member_drops_hp_pro_rata() {
+        let mut s = ActiveIntervention::MuttSwarm {
+            area_id: "a".into(), kind: Animal::Wolf, members: 4, hp: 80,
+            max_hp_per_member: 20, phases_since_combat: 0, despawn_at_morning: false,
+        };
+        s.apply_damage(20);
+        match s {
+            ActiveIntervention::MuttSwarm { members, hp, .. } => {
+                assert_eq!(members, 3);
+                assert_eq!(hp, 60);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expected fail.**
+
+- [ ] **Step 3: Replace `active.rs` placeholder:**
+
+```rust
+use serde::{Deserialize, Serialize};
+
+use crate::threats::animals::Animal;
+use shared::items::Item;
+use shared::messages::Lure;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum ActiveIntervention {
+    MuttSwarm {
+        area_id: String,
+        kind: Animal,
+        members: u8,
+        hp: u32,
+        max_hp_per_member: u32,
+        phases_since_combat: u8,
+        despawn_at_morning: bool,
+    },
+    AreaClosure {
+        area_id: String,
+        expires_at_phase: u32,
+        damage_per_phase: u32,
+    },
+    ConvergencePoint {
+        area_id: String,
+        lure: Lure,
+        expires_at_phase: u32,
+        payload: Vec<Item>,
+    },
+}
+
+impl ActiveIntervention {
+    pub fn area_id_str(&self) -> &str {
+        match self {
+            ActiveIntervention::MuttSwarm { area_id, .. }
+            | ActiveIntervention::AreaClosure { area_id, .. }
+            | ActiveIntervention::ConvergencePoint { area_id, .. } => area_id,
+        }
+    }
+
+    /// Returns true if this effect has expired by `current_phase`.
+    /// Mutt swarms never expire by phase index alone (use `mutt_should_despawn`).
+    pub fn expired_at(&self, current_phase: u32) -> bool {
+        match self {
+            ActiveIntervention::MuttSwarm { .. } => false,
+            ActiveIntervention::AreaClosure { expires_at_phase, .. }
+            | ActiveIntervention::ConvergencePoint { expires_at_phase, .. } => {
+                current_phase > *expires_at_phase
+            }
+        }
+    }
+
+    /// Apply combat damage to a mutt swarm. No-op for other variants.
+    /// Reduces HP first; when HP drops below `(members - 1) * max_hp_per_member`,
+    /// reduce members by 1. Members floor at 0.
+    pub fn apply_damage(&mut self, dmg: u32) {
+        if let ActiveIntervention::MuttSwarm { members, hp, max_hp_per_member, .. } = self {
+            *hp = hp.saturating_sub(dmg);
+            let target_members = (*hp as f32 / *max_hp_per_member as f32).ceil() as u32;
+            *members = target_members.min(*members as u32) as u8;
+        }
+    }
+
+    /// Should this swarm despawn this phase? Returns true on next-morning rollover
+    /// or when `phases_since_combat` exceeds the threshold (4 phases).
+    pub fn mutt_should_despawn(&self, is_morning_rollover: bool) -> Option<shared::messages::DespawnReason> {
+        if let ActiveIntervention::MuttSwarm { members, despawn_at_morning, phases_since_combat, .. } = self {
+            if *members == 0 {
+                return Some(shared::messages::DespawnReason::NoMembersLeft);
+            }
+            if is_morning_rollover && *despawn_at_morning {
+                return Some(shared::messages::DespawnReason::Morning);
+            }
+            if *phases_since_combat >= 4 {
+                return Some(shared::messages::DespawnReason::NoTargetsNearby);
+            }
+        }
+        None
+    }
+}
+```
+
+- [ ] **Step 4: Run tests; pass.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+just fmt
+jj describe -m "feat(gamemaker): ActiveIntervention enum with damage and despawn helpers"
+jj new
+```
+
+---
+
+## Task 10: Variant selection — score-aggregator with recent-penalty
+
+**Files:**
+- Modify: `game/src/gamemaker/decision.rs`
+
+Picks the highest-scoring variant whose `target_pref` returns `Some`. Subtracts `profile.recent_penalty * recent_count(kind)` from each candidate's raw score before comparison. Falls through up to 3 attempts; returns the first variant whose targeting succeeds.
+
+- [ ] **Step 1: Failing tests in `decision.rs`:**
+
+```rust
+#[cfg(test)]
+mod selection_tests {
+    use super::*;
+    use crate::gamemaker::interventions::{
+        AreaId, AreaSnapshot, GameSnapshot, InterventionKind, TargetSpec,
+    };
+
+    fn snap_with_two_areas() -> GameSnapshot {
+        GameSnapshot {
+            alive_tributes: 8,
+            current_phase_index: 0,
+            areas: vec![
+                AreaSnapshot { id: AreaId("a".into()), tribute_count: 4, adjacent_ids: vec![AreaId("b".into())], is_open: true, has_active_intervention: false },
+                AreaSnapshot { id: AreaId("b".into()), tribute_count: 4, adjacent_ids: vec![AreaId("a".into())], is_open: true, has_active_intervention: false },
+            ],
+        }
+    }
+
+    #[test]
+    fn returns_none_when_no_variant_targets() {
+        let mut gm = Gamemaker::default();
+        gm.gauges = Gauges { drama_pressure: 90, ..Gauges::STARTING };
+        let snap = GameSnapshot::default(); // no areas
+        assert!(select_intervention(&gm, &snap).is_none());
+    }
+
+    #[test]
+    fn highest_scoring_variant_wins() {
+        let mut gm = Gamemaker::default();
+        gm.gauges = Gauges { bloodthirst: 100, drama_pressure: 60, ..Gauges::STARTING };
+        let snap = snap_with_two_areas();
+        let pick = select_intervention(&gm, &snap).expect("should pick something");
+        // bloodthirst-dominant -> Fireball or MuttPack
+        assert!(matches!(pick.kind, InterventionKind::Fireball | InterventionKind::MuttPack));
+    }
+
+    #[test]
+    fn recent_penalty_drops_score() {
+        let mut gm = Gamemaker::default();
+        gm.gauges = Gauges { bloodthirst: 100, drama_pressure: 60, ..Gauges::STARTING };
+        // saturate Fireball window
+        for i in 0..6 { gm.record_intervention(InterventionKind::Fireball, i); }
+        gm.gauges.patience = 30;
+        gm.interventions_today = 0;
+        let snap = snap_with_two_areas();
+        let pick = select_intervention(&gm, &snap).expect("should still pick something");
+        // Fireball is heavily penalised; MuttPack should win
+        assert_eq!(pick.kind, InterventionKind::MuttPack);
+    }
+}
+```
+
+- [ ] **Step 2: Run; expected fail.**
+
+- [ ] **Step 3: Append to `decision.rs`:**
+
+```rust
+use crate::gamemaker::interventions::{
+    GameSnapshot, InterventionKind, InterventionLogic, TargetSpec,
+    area_closure::AreaClosure, convergence::ConvergencePoint, fireball::Fireball,
+    force_field::ForceFieldShift, mutt_pack::MuttPack, weather_override::WeatherOverride,
+};
+
+pub struct PickedIntervention {
+    pub kind: InterventionKind,
+    pub target: TargetSpec,
+}
+
+fn all_logics() -> Vec<Box<dyn InterventionLogic>> {
+    vec![
+        Box::new(Fireball),
+        Box::new(MuttPack),
+        Box::new(ForceFieldShift),
+        Box::new(AreaClosure),
+        Box::new(ConvergencePoint),
+        Box::new(WeatherOverride),
+    ]
+}
+
+pub fn select_intervention(gm: &Gamemaker, snap: &GameSnapshot) -> Option<PickedIntervention> {
+    let logics = all_logics();
+    let mut scored: Vec<(InterventionKind, u32, &dyn InterventionLogic)> = logics.iter()
+        .map(|l| {
+            let raw = l.score(&gm.profile, &gm.gauges, snap);
+            let penalty = gm.profile.recent_penalty.saturating_mul(gm.recent_count(l.kind()));
+            (l.kind(), raw.saturating_sub(penalty), l.as_ref())
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.cmp(&a.1));
+
+    for (kind, _score, logic) in scored.into_iter().take(3) {
+        if let Some(target) = logic.target_pref(snap) {
+            return Some(PickedIntervention { kind, target });
+        }
+    }
+    None
+}
+```
+
+- [ ] **Step 4: Run tests; pass.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+just fmt
+jj describe -m "feat(gamemaker): select_intervention with recent-penalty scoring"
+jj new
+```
+
+---
+
+## Task 11: Mutt vs. tribute combat resolution (shelter +5 / hide +2)
+
+**Files:**
+- Modify: `game/src/gamemaker/active.rs`
+
+A small pure helper used by the per-phase tick when resolving a mutt swarm's attack.
+
+- [ ] **Step 1: Failing tests:**
+
+```rust
+#[cfg(test)]
+mod combat_tests {
+    use super::*;
+
+    #[test]
+    fn evade_bonus_zero_when_neither_sheltered_nor_hidden() {
+        assert_eq!(evade_bonus(false, false), 0);
+    }
+
+    #[test]
+    fn evade_bonus_five_when_sheltered_only() {
+        assert_eq!(evade_bonus(true, false), 5);
+    }
+
+    #[test]
+    fn evade_bonus_two_when_hidden_only() {
+        assert_eq!(evade_bonus(false, true), 2);
+    }
+
+    #[test]
+    fn evade_bonus_seven_when_both() {
+        assert_eq!(evade_bonus(true, true), 7);
+    }
+}
+```
+
+- [ ] **Step 2: Run; expected fail.**
+
+- [ ] **Step 3: Append to `active.rs`:**
+
+```rust
+/// Defender's evade bonus against a mutt swarm attack.
+/// Sheltered = +5, Hidden = +2, additive (max +7).
+pub fn evade_bonus(sheltered: bool, hidden: bool) -> i32 {
+    let mut b = 0;
+    if sheltered { b += 5; }
+    if hidden { b += 2; }
+    b
+}
+```
+
+- [ ] **Step 4: Run; pass.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+just fmt
+jj describe -m "feat(gamemaker): mutt evade bonus helper"
+jj new
+```
+
+---
+
+## Task 12: Brain integration — convergence pull, mutt avoidance, sealed-area filter
+
+**Files:**
+- Modify: `game/src/tributes/brain.rs` (or wherever `choose_destination` lives — locate via `grep -rn "fn choose_destination" game/src/`)
+
+The override pass runs *before* hunger/thirst overrides (which run before the standard brain), but *after* combat preempts. Order:
+
+1. Combat preempt (existing rule, unchanged)
+2. **Gamemaker overrides (new):**
+   a. Mutt in current area + can flee → `Travel(adjacent_clear_area)`
+   b. Active convergence point exists + tribute eligible → adds pull term to `choose_destination`
+   c. Sealed areas filtered out of `choose_destination` candidates
+3. Hunger/thirst overrides (from shelter PR1, if landed; otherwise no-op)
+4. Standard brain logic
+
+- [ ] **Step 1: Locate the relevant fn:**
+
+```bash
+grep -rn "fn choose_destination\|fn act\|pub fn brain" game/src/tributes/ | head -10
+```
+
+- [ ] **Step 2: Write a failing integration test in `game/tests/gamemaker_brain.rs`** (create if absent). Sketch:
+
+```rust
+//! Brain integration with gamemaker overrides.
+use game::gamemaker::active::ActiveIntervention;
+use game::threats::animals::Animal;
+
+#[test]
+fn tribute_flees_area_with_mutt_swarm_when_adjacent_clear_area_exists() {
+    // Build a minimal Game with two adjacent areas, one with a mutt swarm,
+    // one tribute in the swarm area, no enemies present.
+    // Assert tribute's chosen action is Travel(adjacent area).
+    // (Implementation depends on existing test helpers - see
+    // game/tests/ for `Game::new_test_with_tributes` or similar.)
+    //
+    // SKETCH: copy pattern from existing brain tests.
+}
+```
+
+- [ ] **Step 3: Inspect existing brain tests to find the test-helper pattern:**
+
+```bash
+grep -rn "Game::new\|fn new_test\|build_test_game" game/tests/ game/src/games.rs | head -10
+```
+
+- [ ] **Step 4: Use the located helper to write the actual test.** Pseudocode (adapt to real helper signatures):
+
+```rust
+let mut game = build_test_game_with_areas_and_tributes(
+    /*areas*/ vec![("forest", vec!["clearing"]), ("clearing", vec!["forest"])],
+    /*tributes*/ vec![("Alice", "forest")],
+);
+game.gamemaker.active_effects.push(ActiveIntervention::MuttSwarm {
+    area_id: "forest".into(), kind: Animal::Wolf, members: 3, hp: 60,
+    max_hp_per_member: 20, phases_since_combat: 0, despawn_at_morning: false,
+});
+let action = game.tributes[0].decide_action(&game);
+assert!(matches!(action, Action::Travel(area) if area == Area::from_str("clearing").unwrap()));
+```
+
+- [ ] **Step 5: Run; expected fail (no override applied).**
+
+- [ ] **Step 6: Add override pass to brain logic.** In the action-decision function (likely `Brain::act` or `Tribute::decide_action`), insert immediately after the combat-preempt check, before any other branch:
+
+```rust
+// Gamemaker overrides — Capitol force majeure trumps non-combat planning.
+if let Some(action) = gamemaker_override(self, game) {
+    return action;
+}
+```
+
+Implement the helper in a new location next to the brain, e.g. `game/src/gamemaker/brain_override.rs`:
+
+```rust
+use crate::areas::Area;
+use crate::games::Game;
+use crate::tributes::Tribute;
+use crate::tributes::actions::Action;
+use crate::gamemaker::ActiveIntervention;
+
+/// Returns an override action when gamemaker state should preempt the standard brain.
+/// Order: mutt-flee > sealed-area-filter (passive — applied to choose_destination input) >
+/// convergence-pull (adds to choose_destination scoring, never returns standalone).
+pub fn gamemaker_override(tribute: &Tribute, game: &Game) -> Option<Action> {
+    // 1. Mutt in current area: try to flee.
+    let in_combat = tribute.in_combat(game); // existing helper
+    if !in_combat {
+        for eff in &game.gamemaker.active_effects {
+            if let ActiveIntervention::MuttSwarm { area_id, .. } = eff {
+                if Some(area_id.as_str()) == tribute.area.map(|a| a.to_string()).as_deref() {
+                    if let Some(escape) = pick_flee_target(tribute, game) {
+                        return Some(Action::Travel(escape));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn pick_flee_target(tribute: &Tribute, game: &Game) -> Option<Area> {
+    let here = tribute.area?;
+    let neighbours = here.neighbours(); // existing helper, or use AreaDetails graph
+    neighbours.into_iter().find(|n| {
+        // No mutt in neighbour
+        !game.gamemaker.active_effects.iter().any(|eff| {
+            if let ActiveIntervention::MuttSwarm { area_id, .. } = eff {
+                area_id == &n.to_string()
+            } else { false }
+        })
+        // Not sealed
+        && !game.gamemaker.active_effects.iter().any(|eff| {
+            if let ActiveIntervention::AreaClosure { area_id, .. } = eff {
+                area_id == &n.to_string()
+            } else { false }
+        })
+    })
+}
+```
+
+(NOTE: the call sites `tribute.in_combat`, `tribute.area`, `here.neighbours` and `Action::Travel` need to be adjusted to match what actually exists in `game/src/tributes/`. Run `grep -rn "fn in_combat\|fn neighbours\|enum Action" game/src/tributes/ game/src/areas/` to locate.)
+
+- [ ] **Step 7: Wire `gamemaker_override` into the brain's action-decision flow.**
+
+- [ ] **Step 8: Add convergence-pull and sealed-area-filter integration to `choose_destination`** (likely a separate function in the brain module). Add a helper:
+
+```rust
+fn area_filter_and_convergence_bias(game: &Game) -> (HashSet<Area>, HashMap<Area, i32>) {
+    let mut sealed = HashSet::new();
+    let mut convergence_bias = HashMap::new();
+    for eff in &game.gamemaker.active_effects {
+        match eff {
+            ActiveIntervention::AreaClosure { area_id, .. } => {
+                if let Ok(a) = Area::from_str(area_id) { sealed.insert(a); }
+            }
+            ActiveIntervention::ConvergencePoint { area_id, .. } => {
+                if let Ok(a) = Area::from_str(area_id) { convergence_bias.insert(a, 50); }
+            }
+            _ => {}
+        }
+    }
+    (sealed, convergence_bias)
+}
+```
+
+Inside `choose_destination` (existing fn): filter candidates by `!sealed.contains(area)` and add `convergence_bias.get(area).copied().unwrap_or(0)` to each candidate's score.
+
+- [ ] **Step 9: Run integration test from Step 4; expected pass.**
+
+- [ ] **Step 10: Run the full game-crate test suite to confirm no regression:**
+
+```bash
+just test
+```
+
+- [ ] **Step 11: Commit:**
+
+```bash
+just fmt
+jj describe -m "feat(gamemaker): brain overrides for mutt-flee, sealed-area filter, convergence pull"
+jj new
+```
+
+---
+
+## Task 13: Per-phase active-effect tick (decay, expiry, damage emission)
+
+**Files:**
+- Modify: `game/src/gamemaker/active.rs`
+- Modify: `game/src/gamemaker/mod.rs` (or new `tick.rs`)
+
+This is the per-phase routine that:
+
+1. Decrements `phases_since_combat` counters on mutt swarms
+2. Emits `MuttSwarmAttack` events for tributes still in mutt-swarm areas
+3. Emits `AreaSealEntryDamage` for tributes in sealed areas
+4. Emits expiry events (`MuttSwarmDespawned`, `AreaUnsealed`, `ConvergencePointExpired`) and removes expired effects
+5. Returns counts of (kills, hazards_with_kill, hazards_no_kill) so the caller can apply gauge reactions in Task 14
+
+- [ ] **Step 1: Failing test in `active.rs`:**
+
+```rust
+#[cfg(test)]
+mod tick_tests {
+    use super::*;
+
+    #[test]
+    fn closure_at_expiry_phase_removed_and_emits_unsealed() {
+        let mut effects = vec![
+            ActiveIntervention::AreaClosure {
+                area_id: "a".into(), expires_at_phase: 5, damage_per_phase: 10,
+            },
+        ];
+        let result = drain_expired(&mut effects, /*current_phase=*/ 6);
+        assert!(effects.is_empty());
+        assert_eq!(result.unsealed_areas, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn convergence_at_expiry_collects_lure() {
+        let mut effects = vec![
+            ActiveIntervention::ConvergencePoint {
+                area_id: "b".into(), lure: shared::messages::Lure::Feast,
+                expires_at_phase: 3, payload: vec![],
+            },
+        ];
+        let result = drain_expired(&mut effects, 4);
+        assert!(effects.is_empty());
+        assert_eq!(result.convergence_expired, vec![("b".to_string(), shared::messages::Lure::Feast)]);
+    }
+
+    #[test]
+    fn mutt_swarm_with_zero_members_despawns() {
+        let mut effects = vec![
+            ActiveIntervention::MuttSwarm {
+                area_id: "c".into(), kind: crate::threats::animals::Animal::Wolf,
+                members: 0, hp: 0, max_hp_per_member: 20,
+                phases_since_combat: 0, despawn_at_morning: false,
+            },
+        ];
+        let result = drain_expired(&mut effects, 1);
+        assert!(effects.is_empty());
+        assert_eq!(result.mutt_despawns.len(), 1);
+        assert_eq!(result.mutt_despawns[0].2, shared::messages::DespawnReason::NoMembersLeft);
+    }
+}
+```
+
+- [ ] **Step 2: Run; expected fail.**
+
+- [ ] **Step 3: Append to `active.rs`:**
+
+```rust
+use shared::messages::{DespawnReason, Lure};
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DrainResult {
+    pub unsealed_areas: Vec<String>,
+    pub convergence_expired: Vec<(String, Lure)>,
+    pub mutt_despawns: Vec<(String, crate::threats::animals::Animal, DespawnReason)>,
+}
+
+/// Removes expired effects from `effects` and reports what was removed.
+/// `current_phase` is the phase index we have just begun ticking.
+pub fn drain_expired(effects: &mut Vec<ActiveIntervention>, current_phase: u32) -> DrainResult {
+    let mut out = DrainResult::default();
+
+    effects.retain(|eff| match eff {
+        ActiveIntervention::AreaClosure { area_id, expires_at_phase, .. } => {
+            if current_phase > *expires_at_phase {
+                out.unsealed_areas.push(area_id.clone());
+                false
+            } else { true }
+        }
+        ActiveIntervention::ConvergencePoint { area_id, lure, expires_at_phase, .. } => {
+            if current_phase > *expires_at_phase {
+                out.convergence_expired.push((area_id.clone(), lure.clone()));
+                false
+            } else { true }
+        }
+        ActiveIntervention::MuttSwarm { area_id, kind, members, phases_since_combat, despawn_at_morning, .. } => {
+            if *members == 0 {
+                out.mutt_despawns.push((area_id.clone(), *kind, DespawnReason::NoMembersLeft));
+                false
+            } else if *despawn_at_morning && is_morning_phase(current_phase) {
+                out.mutt_despawns.push((area_id.clone(), *kind, DespawnReason::Morning));
+                false
+            } else if *phases_since_combat >= 4 {
+                out.mutt_despawns.push((area_id.clone(), *kind, DespawnReason::NoTargetsNearby));
+                false
+            } else {
+                true
+            }
+        }
+    });
+
+    out
+}
+
+/// True when this phase index is the start of a new game-day (i.e., morning).
+/// Convention: even phases = Day, odd phases = Night.
+fn is_morning_phase(phase: u32) -> bool {
+    phase % 2 == 0
+}
+```
+
+- [ ] **Step 4: Run; pass.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+just fmt
+jj describe -m "feat(gamemaker): drain_expired removes finished effects and reports them"
+jj new
+```
+
+---
+
+## Task 14: Per-phase decision pipeline + `Game` integration
+
+**Files:**
+- Modify: `game/src/gamemaker/decision.rs`
+- Modify: `game/src/games.rs` — call from `run_day_night_cycle`
+
+The orchestrator `Game::tick_gamemaker(&mut self, current_phase: u32, rng: &mut impl Rng)` does the per-phase work in spec order:
+
+1. Tick gauges (background)
+2. Drain expired active effects → emit unsealed/expired/despawn payloads
+3. Resolve persistent damage (mutt attacks, seal entry damage) → emit attack/damage payloads, increment `phases_since_combat`
+4. Check `should_intervene`; if no, done
+5. Build `GameSnapshot`
+6. `select_intervention` → `PickedIntervention`
+7. Resolve immediately (Fireball/ForceFieldShift/WeatherOverride) or push to `active_effects` (MuttPack/AreaClosure/ConvergencePoint)
+8. Emit announcement/strike payloads
+9. Apply per-event gauge reaction
+10. `record_intervention` (which resets patience)
+11. Call site: at start of `run_day_night_cycle`, derive `current_phase` from existing `tick_counter`/day/phase state, then call `self.tick_gamemaker(...)`. Day rollover: when `current_phase % 2 == 0` AND `current_phase > 0`, also reset `interventions_today` to 0.
+
+This task is *long*. Break into sub-steps; commit after each runs cleanly.
+
+### 14a. Snapshot builder
+
+- [ ] **Step 1: Failing test:**
+
+```rust
+#[cfg(test)]
+mod snapshot_tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_counts_alive_tributes_and_areas() {
+        let mut game = crate::games::Game::default();
+        // (Use existing helpers to populate areas + tributes; see test patterns elsewhere)
+        let snap = build_snapshot(&game);
+        assert_eq!(snap.alive_tributes, 0);
+        assert!(snap.areas.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run; expected fail.**
+
+- [ ] **Step 3: Implement `build_snapshot` in `decision.rs`:**
+
+```rust
+use crate::games::Game;
+use crate::gamemaker::interventions::{AreaId, AreaSnapshot, GameSnapshot};
+
+pub fn build_snapshot(game: &Game) -> GameSnapshot {
+    let alive_tributes = game.tributes.iter().filter(|t| !t.is_dead()).count() as u32;
+    let areas: Vec<AreaSnapshot> = game.areas.iter().filter_map(|ad| {
+        let area = ad.area?;
+        let id = AreaId(area.to_string());
+        let tribute_count = game.tributes.iter()
+            .filter(|t| !t.is_dead() && t.area == Some(area))
+            .count() as u32;
+        let adjacent_ids = ad.neighbours().iter().map(|n| AreaId(n.to_string())).collect();
+        let has_active_intervention = game.gamemaker.active_effects.iter()
+            .any(|eff| eff.area_id_str() == area.to_string());
+        Some(AreaSnapshot {
+            id,
+            tribute_count,
+            adjacent_ids,
+            is_open: ad.is_open(),
+            has_active_intervention,
+        })
+    }).collect();
+
+    GameSnapshot {
+        alive_tributes,
+        current_phase_index: 0, // caller stamps
+        areas,
+    }
+}
+```
+
+(Adjust `is_dead`, `area`, `neighbours`, `is_open` to match real method names — discover with `grep -rn "fn is_dead\|fn neighbours\|fn is_open" game/src/`.)
+
+- [ ] **Step 4: Run; pass.**
+
+### 14b. `tick_gamemaker` orchestrator
+
+- [ ] **Step 5: Add to `games.rs` (impl block for `Game`):**
+
+```rust
+/// Runs the gamemaker decision pipeline for one phase.
+/// Called from `run_day_night_cycle` immediately after `prepare_cycle`.
+pub fn tick_gamemaker(&mut self, current_phase: u32, _rng: &mut SmallRng) {
+    // 1. Day rollover bookkeeping.
+    if current_phase % 2 == 0 && current_phase > 0 {
+        self.gamemaker.interventions_today = 0;
+    }
+
+    // 2. Tick gauges.
+    let alive = self.tributes.iter().filter(|t| !t.is_dead()).count() as u32;
+    self.gamemaker.gauges.tick_phase(&self.gamemaker.profile, alive);
+
+    // 3. Drain expired active effects.
+    let drain = crate::gamemaker::active::drain_expired(
+        &mut self.gamemaker.active_effects,
+        current_phase,
+    );
+    for area_id in &drain.unsealed_areas {
+        self.emit_area_unsealed(area_id);
+    }
+    for (area_id, lure) in &drain.convergence_expired {
+        self.emit_convergence_expired(area_id, lure.clone(), /*claimed_by=*/ vec![]);
+    }
+    for (area_id, kind, reason) in &drain.mutt_despawns {
+        self.emit_mutt_swarm_despawned(area_id, *kind, *reason);
+    }
+
+    // 4. Resolve persistent damage (mutt attacks, seal entry damage).
+    self.resolve_active_effect_damage(current_phase);
+
+    // 5. Eligibility gate.
+    if !crate::gamemaker::decision::should_intervene(&self.gamemaker, self.gamemaker.active_effects.len()) {
+        return;
+    }
+
+    // 6. Build snapshot + pick variant.
+    let mut snap = crate::gamemaker::decision::build_snapshot(self);
+    snap.current_phase_index = current_phase;
+    let picked = match crate::gamemaker::decision::select_intervention(&self.gamemaker, &snap) {
+        Some(p) => p,
+        None => return,
+    };
+
+    // 7. Resolve.
+    self.resolve_intervention(picked, current_phase);
+}
+
+// Emission helpers (private to games.rs):
+fn emit_area_unsealed(&mut self, area_id: &str) {
+    use shared::messages::{AreaRef, MessagePayload, MessageSource};
+    self.log_payload(
+        MessageSource::Game(self.identifier.clone()),
+        MessagePayload::AreaUnsealed { area: AreaRef { id: area_id.into(), name: area_id.into() } },
+    );
+}
+
+fn emit_convergence_expired(&mut self, area_id: &str, lure: shared::messages::Lure, claimed_by: Vec<shared::messages::TributeRef>) {
+    use shared::messages::{AreaRef, MessagePayload, MessageSource};
+    self.log_payload(
+        MessageSource::Game(self.identifier.clone()),
+        MessagePayload::ConvergencePointExpired {
+            area: AreaRef { id: area_id.into(), name: area_id.into() },
+            lure, claimed_by,
+        },
+    );
+}
+
+fn emit_mutt_swarm_despawned(&mut self, area_id: &str, kind: crate::threats::animals::Animal, reason: shared::messages::DespawnReason) {
+    use shared::messages::{AreaRef, MessagePayload, MessageSource};
+    self.log_payload(
+        MessageSource::Game(self.identifier.clone()),
+        MessagePayload::MuttSwarmDespawned {
+            area: AreaRef { id: area_id.into(), name: area_id.into() },
+            kind_label: kind.to_string(),
+            reason,
+        },
+    );
+}
+
+fn resolve_active_effect_damage(&mut self, current_phase: u32) {
+    // Iterate active effects, apply damage, emit attack payloads.
+    // Implementation: snapshot the effect list, compute damage per affected
+    // tribute, mutate tributes, then mutate the effect list (separate borrows).
+    let snapshot: Vec<(usize, ActiveInterventionResolutionInput)> = self.gamemaker.active_effects.iter().enumerate().filter_map(|(i, eff)| {
+        match eff {
+            crate::gamemaker::ActiveIntervention::MuttSwarm { area_id, kind, members, .. } => Some((i, ActiveInterventionResolutionInput::Mutt { area_id: area_id.clone(), kind: *kind, members: *members })),
+            crate::gamemaker::ActiveIntervention::AreaClosure { area_id, damage_per_phase, .. } => Some((i, ActiveInterventionResolutionInput::Seal { area_id: area_id.clone(), damage: *damage_per_phase })),
+            _ => None,
+        }
+    }).collect();
+
+    for (idx, input) in snapshot {
+        match input {
+            ActiveInterventionResolutionInput::Mutt { area_id, kind, members } => {
+                // Pick first alive tribute in the mutt's area; mutts attack one per phase.
+                let victim_idx = self.tributes.iter().position(|t| !t.is_dead() && t.area.map(|a| a.to_string()) == Some(area_id.clone()));
+                if let Some(vi) = victim_idx {
+                    let damage = (members as u32) * 5; // tunable
+                    let killed = self.tributes[vi].take_damage(damage); // existing helper or apply manually
+                    let victim = self.tributes[vi].as_ref();
+                    self.emit_mutt_swarm_attack(&area_id, kind, &victim, damage, killed);
+                    if let crate::gamemaker::ActiveIntervention::MuttSwarm { phases_since_combat, .. } = &mut self.gamemaker.active_effects[idx] {
+                        *phases_since_combat = 0;
+                    }
+                } else if let crate::gamemaker::ActiveIntervention::MuttSwarm { phases_since_combat, .. } = &mut self.gamemaker.active_effects[idx] {
+                    *phases_since_combat = phases_since_combat.saturating_add(1);
+                }
+            }
+            ActiveInterventionResolutionInput::Seal { area_id, damage } => {
+                let in_area: Vec<usize> = self.tributes.iter().enumerate().filter(|(_, t)| !t.is_dead() && t.area.map(|a| a.to_string()) == Some(area_id.clone())).map(|(i, _)| i).collect();
+                for vi in in_area {
+                    self.tributes[vi].take_damage(damage);
+                    let victim = self.tributes[vi].as_ref();
+                    self.emit_seal_entry_damage(&area_id, &victim, damage);
+                }
+            }
+        }
+    }
+}
+
+enum ActiveInterventionResolutionInput {
+    Mutt { area_id: String, kind: crate::threats::animals::Animal, members: u8 },
+    Seal { area_id: String, damage: u32 },
+}
+
+fn emit_mutt_swarm_attack(&mut self, area_id: &str, kind: crate::threats::animals::Animal, victim: &shared::messages::TributeRef, damage: u32, killed: bool) {
+    use shared::messages::{AreaRef, MessagePayload, MessageSource};
+    self.log_payload(
+        MessageSource::Game(self.identifier.clone()),
+        MessagePayload::MuttSwarmAttack {
+            area: AreaRef { id: area_id.into(), name: area_id.into() },
+            kind_label: kind.to_string(),
+            victim: victim.clone(),
+            damage,
+            killed,
+        },
+    );
+}
+
+fn emit_seal_entry_damage(&mut self, area_id: &str, victim: &shared::messages::TributeRef, damage: u32) {
+    use shared::messages::{AreaRef, MessagePayload, MessageSource};
+    self.log_payload(
+        MessageSource::Game(self.identifier.clone()),
+        MessagePayload::AreaSealEntryDamage {
+            area: AreaRef { id: area_id.into(), name: area_id.into() },
+            tribute: victim.clone(),
+            damage,
+        },
+    );
+}
+
+fn resolve_intervention(&mut self, picked: crate::gamemaker::decision::PickedIntervention, current_phase: u32) {
+    use crate::gamemaker::interventions::{InterventionKind, TargetSpec};
+    use shared::messages::{AreaRef, MessagePayload, MessageSource};
+
+    let kind = picked.kind;
+    match (picked.kind, picked.target) {
+        (InterventionKind::Fireball, TargetSpec::SingleArea(area)) => {
+            // Resolve damage immediately. Severity per spec — Major default for v1.
+            // (TODO: derive from gauges.) Apply to tributes in area.
+            let area_str = area.0;
+            let victims_idx: Vec<usize> = self.tributes.iter().enumerate()
+                .filter(|(_, t)| !t.is_dead() && t.area.map(|a| a.to_string()) == Some(area_str.clone()))
+                .map(|(i, _)| i).collect();
+            let mut victims = vec![];
+            let mut survivors = vec![];
+            for vi in victims_idx {
+                let killed = self.tributes[vi].take_damage(40);
+                let r = self.tributes[vi].as_ref();
+                if killed { victims.push(r); } else { survivors.push(r); }
+            }
+            let any_kills = !victims.is_empty();
+            self.log_payload(
+                MessageSource::Game(self.identifier.clone()),
+                MessagePayload::FireballStrike {
+                    area: AreaRef { id: area_str.clone(), name: area_str.clone() },
+                    severity_label: "Major".into(),
+                    victims, survivors,
+                },
+            );
+            self.gamemaker.gauges.react_to(if any_kills {
+                &crate::gamemaker::gauges::GaugeReaction::InterventionResolvedWithKill
+            } else {
+                &crate::gamemaker::gauges::GaugeReaction::InterventionResolvedNoKill
+            });
+        }
+        (InterventionKind::MuttPack, TargetSpec::SingleArea(area)) => {
+            let area_str = area.0;
+            let kind_animal = crate::threats::animals::Animal::Wolf; // v1 default
+            let members = 4u8;
+            let max_hp_per_member = 20u32;
+            let hp = (members as u32) * max_hp_per_member;
+            self.gamemaker.active_effects.push(crate::gamemaker::ActiveIntervention::MuttSwarm {
+                area_id: area_str.clone(), kind: kind_animal, members, hp, max_hp_per_member,
+                phases_since_combat: 0, despawn_at_morning: false,
+            });
+            self.log_payload(
+                MessageSource::Game(self.identifier.clone()),
+                MessagePayload::MuttSwarmSpawned {
+                    area: AreaRef { id: area_str.clone(), name: area_str.clone() },
+                    kind_label: kind_animal.to_string(), members,
+                },
+            );
+            self.gamemaker.gauges.react_to(&crate::gamemaker::gauges::GaugeReaction::InterventionResolvedNoKill);
+        }
+        (InterventionKind::ForceFieldShift, TargetSpec::AreaSet { close, open }) => {
+            // Topology change. For v1, mark areas closed/open by mutating AreaDetails.events.
+            // (Apply bespoke in this match arm; consumers will see the closed/opened areas
+            // via existing announce_area_events path.)
+            self.log_payload(
+                MessageSource::Game(self.identifier.clone()),
+                MessagePayload::ForceFieldShifted {
+                    closed: close.iter().map(|c| AreaRef { id: c.0.clone(), name: c.0.clone() }).collect(),
+                    opened: open.iter().map(|o| AreaRef { id: o.0.clone(), name: o.0.clone() }).collect(),
+                    warning_phases: 1,
+                },
+            );
+            self.gamemaker.gauges.react_to(&crate::gamemaker::gauges::GaugeReaction::InterventionDisruptive);
+        }
+        (InterventionKind::AreaClosure, TargetSpec::SingleArea(area)) => {
+            let area_str = area.0;
+            self.gamemaker.active_effects.push(crate::gamemaker::ActiveIntervention::AreaClosure {
+                area_id: area_str.clone(), expires_at_phase: current_phase + 4, damage_per_phase: 10,
+            });
+            self.log_payload(
+                MessageSource::Game(self.identifier.clone()),
+                MessagePayload::AreaSealed {
+                    area: AreaRef { id: area_str.clone(), name: area_str.clone() },
+                    expires_at_phase: current_phase + 4,
+                },
+            );
+            self.gamemaker.gauges.react_to(&crate::gamemaker::gauges::GaugeReaction::InterventionDisruptive);
+        }
+        (InterventionKind::ConvergencePoint, TargetSpec::SingleArea(area)) => {
+            let area_str = area.0;
+            self.gamemaker.active_effects.push(crate::gamemaker::ActiveIntervention::ConvergencePoint {
+                area_id: area_str.clone(), lure: shared::messages::Lure::Feast,
+                expires_at_phase: current_phase + 4, payload: vec![],
+            });
+            self.log_payload(
+                MessageSource::Game(self.identifier.clone()),
+                MessagePayload::ConvergencePointAnnounced {
+                    area: AreaRef { id: area_str.clone(), name: area_str.clone() },
+                    lure: shared::messages::Lure::Feast,
+                    starts_at_phase: current_phase + 1,
+                },
+            );
+            self.gamemaker.gauges.react_to(&crate::gamemaker::gauges::GaugeReaction::InterventionConvergenceAnnounce);
+        }
+        (InterventionKind::WeatherOverride, TargetSpec::SingleArea(area)) => {
+            let area_str = area.0;
+            self.log_payload(
+                MessageSource::Game(self.identifier.clone()),
+                MessagePayload::WeatherOverridden {
+                    area: AreaRef { id: area_str.clone(), name: area_str.clone() },
+                    weather_label: "HeavyRain".into(),
+                    duration_phases: 2,
+                },
+            );
+            self.gamemaker.gauges.react_to(&crate::gamemaker::gauges::GaugeReaction::WeatherOverride);
+        }
+        // Mismatched (kind, target) shapes are unreachable given target_pref contracts.
+        (k, t) => unreachable!("mismatched kind {:?} / target {:?}", k, t),
+    }
+    self.gamemaker.record_intervention(kind, current_phase);
+}
+```
+
+NOTE: this references `self.log_payload(source, payload)`. Confirm the existing API or adapt — examples like `self.log_event(source, subject, GameEvent::...)` are in `games.rs` already. If a typed-payload logger doesn't exist, add one alongside `log_event`:
+
+```rust
+fn log_payload(&mut self, source: shared::messages::MessageSource, payload: shared::messages::MessagePayload) {
+    self.messages.push(shared::messages::GameMessage {
+        source,
+        phase: self.current_phase.clone(),
+        payload,
+        emit_index: self.emit_index,
+        // ... fill remaining fields per existing GameMessage shape
+    });
+    self.emit_index = self.emit_index.saturating_add(1);
+}
+```
+
+Inspect the actual `GameMessage` struct first via `grep -n "pub struct GameMessage" shared/src/messages.rs` and adjust.
+
+- [ ] **Step 6: Wire `tick_gamemaker` into `run_day_night_cycle`.** Add after `self.prepare_cycle(day)?;` and before `self.do_a_cycle(day)?;`:
+
+```rust
+let mut gm_rng = SmallRng::from_entropy();
+let phase_index = self.tick_counter.global_index(); // or compute from day + day/night flag
+self.tick_gamemaker(phase_index, &mut gm_rng);
+```
+
+(Use the actual phase-index source — read `tick_counter` impl or compute as `(day * 2) + if day_phase { 0 } else { 1 }`.)
+
+- [ ] **Step 7: Run full game tests:**
+
+```bash
+just test
+```
+
+Expected: pre-existing tests still pass; gamemaker doesn't break anything.
+
+- [ ] **Step 8: Commit:**
+
+```bash
+just fmt
+jj describe -m "feat(gamemaker): tick_gamemaker pipeline + run_day_night_cycle integration"
+jj new
+```
+
+---
+
+## Task 15: Integration test — full per-phase flow with gauge transitions
+
+**Files:**
+- Create: `game/tests/gamemaker_integration.rs`
+
+End-to-end: build a small game, force gauges high, run a phase, assert that an intervention fired and that recent_interventions/interventions_today/patience updated correctly.
+
+- [ ] **Step 1: Write the test:**
+
+```rust
+//! End-to-end gamemaker dispatch under controlled gauge state.
+
+use game::gamemaker::{Gauges, InterventionKind};
+use game::games::Game;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+#[test]
+fn high_pressure_triggers_intervention_and_resets_patience() {
+    let mut game = build_minimal_game(); // helper below
+    game.gamemaker.gauges = Gauges {
+        drama_pressure: 90,
+        bloodthirst: 50,
+        chaos: 40,
+        audience_attention: 60,
+        patience: 50,
+        body_count_debt: 0,
+    };
+    let mut rng = SmallRng::seed_from_u64(42);
+    game.tick_gamemaker(/*phase=*/ 3, &mut rng);
+
+    assert!(!game.gamemaker.recent_interventions.is_empty(), "expected an intervention");
+    assert_eq!(game.gamemaker.gauges.patience, 0);
+    assert_eq!(game.gamemaker.interventions_today, 1);
+}
+
+#[test]
+fn per_day_cap_blocks_third_intervention() {
+    let mut game = build_minimal_game();
+    game.gamemaker.interventions_today = game.gamemaker.profile.max_per_day;
+    game.gamemaker.gauges = Gauges { drama_pressure: 99, patience: 99, ..Gauges::STARTING };
+    let mut rng = SmallRng::seed_from_u64(0);
+    game.tick_gamemaker(2, &mut rng);
+    assert!(game.gamemaker.recent_interventions.is_empty(), "should be blocked");
+}
+
+#[test]
+fn day_rollover_resets_interventions_today() {
+    let mut game = build_minimal_game();
+    game.gamemaker.interventions_today = 2;
+    let mut rng = SmallRng::seed_from_u64(0);
+    // Even non-zero phase index triggers rollover.
+    game.tick_gamemaker(2, &mut rng);
+    assert_eq!(game.gamemaker.interventions_today, 0,
+        "expected day-rollover reset when current_phase is even and > 0");
+}
+
+fn build_minimal_game() -> Game {
+    // Use existing helpers if present; else inline. The minimal viable game
+    // has at least 2 areas (so target_pref has something to pick) and 4 tributes.
+    let mut game = Game::default();
+    // ... populate via test helpers; see other game/tests/*.rs files for patterns.
+    game
+}
+```
+
+- [ ] **Step 2: Inspect existing integration tests for population helpers:**
+
+```bash
+grep -rn "fn build_test_game\|fn make_game\|Game::default" game/tests/ | head -10
+```
+
+Adapt `build_minimal_game()` accordingly.
+
+- [ ] **Step 3: Run tests:**
+
+```bash
+cargo test --package game --test gamemaker_integration -- --nocapture
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit:**
+
+```bash
+just fmt
+jj describe -m "test(gamemaker): end-to-end pipeline integration tests"
+jj new
+```
+
+---
+
+## Self-Review
+
+Run through the spec section-by-section and verify each item has a task:
+
+- [x] `Gamemaker` struct on `Game` → Tasks 1-2
+- [x] Gauges (6 fields) + `STARTING` → Task 1, 3
+- [x] `GamemakerProfile` + `CASSANDRA` const → Task 1
+- [x] Per-phase tick (rises/decays) + late-game multiplier → Task 3
+- [x] Per-event reactions (8 reaction kinds) → Task 4
+- [x] 11 `MessagePayload` variants + `Lure` + `DespawnReason` + 3 cause constants → Task 5
+- [x] `should_intervene` eligibility gate → Task 6
+- [x] `InterventionLogic` trait + `GameSnapshot` → Task 7
+- [x] 6 intervention scorers + targeting → Task 8
+- [x] `ActiveIntervention` enum → Task 9
+- [x] Mutt evade bonus (shelter +5 / hide +2) → Task 11
+- [x] Brain integration (mutt-flee, sealed-area filter, convergence pull) → Task 12
+- [x] Active-effect tick (drain expired, resolve damage) → Tasks 13-14
+- [x] `tick_gamemaker` orchestrator + `run_day_night_cycle` integration → Task 14
+- [x] Per-day rollover (`interventions_today` reset) → Task 14, 15
+- [x] Recent-interventions cap + recent-penalty → Tasks 1, 10
+- [x] End-to-end integration test → Task 15
+
+**Open known-gaps to flag during implementation review:**
+
+1. Fireball severity is hard-coded to `"Major"` in Task 14; deriving from gauges + game state is a tuning task, not a structural one. File a follow-up bead if not done in PR1.
+2. MuttPack always spawns `Animal::Wolf` with 4 members in Task 14. Animal selection from gauges/terrain is a tuning task; file follow-up.
+3. WeatherOverride duration always 2 phases, weather always `HeavyRain` — same story. File follow-up.
+4. ForceFieldShift's actual area-state mutation (closing/opening areas) is deferred to the existing `AreaDetails.events`/`is_open()` machinery; verify it ties through correctly during integration testing.
+5. `area_id: String` is used throughout `ActiveIntervention` and emission helpers because `Area` is an enum and serialising as a string keeps the JSON stable. If `Area::from_str` is missing for any variant, add it (alphabetical, one match arm).
+6. The Fireball→wildfire chain (Q7) is **NOT** in this plan. It's flagged in the spec as droppable; defer to a follow-up bead unless playtest demands it.
+
+**Type consistency check:** all references to `AreaId`, `TargetSpec`, `GameSnapshot`, `InterventionKind`, `Lure`, `DespawnReason`, `Gauges`, `GamemakerProfile`, `Gamemaker`, `ActiveIntervention` use the same names defined in Task 1/5/7/9. Method names: `record_intervention`, `recent_count`, `tick_phase`, `react_to`, `should_intervene`, `select_intervention`, `build_snapshot`, `tick_gamemaker`, `drain_expired`, `apply_damage`, `mutt_should_despawn`, `evade_bonus`, `gamemaker_override`. All consistent.
+
+---
+
+## Hand-off
+
+After Task 15 commits cleanly, run:
+
+```bash
+just quality
+```
+
+Expected: clean. If anything fails, fix before opening the PR.
+
+PR1 lands gamemaker backend behind the scenes. PR2 (separate plan) wires the hex-map markers and timeline cards.

--- a/docs/superpowers/plans/2026-05-03-gamemaker-event-system-pr2-frontend.md
+++ b/docs/superpowers/plans/2026-05-03-gamemaker-event-system-pr2-frontend.md
@@ -1,0 +1,957 @@
+# Gamemaker Event System — Plan 2: Frontend Implementation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the gamemaker backend (PR1) in the Dioxus frontend: three new hex-map markers (mutt swarm pin, sealed-area shading, convergence point pin), and generic timeline cards for the 11 new gamemaker `MessagePayload` variants. No bespoke per-payload card layouts — every variant routes through one `GamemakerCard` component that uses category icon + stringified payload fields.
+
+**Architecture:** Add a `MessageKind::Gamemaker` variant to keep dispatch clean (the 11 variants don't fit existing categories). All map markers are SVG layers added to `web/src/components/map.rs`, sourced from `gamemaker.active_effects` exposed by the existing `Game` JSON (the `Gamemaker` struct from PR1 already serializes via `serde`). One generic `GamemakerCard` renders all 11 payloads via category-tagged metadata; matches the fallback-card pattern already used by `state_card.rs` for typed `AreaEvent` events. **No** Capitol Feed gauge panel — gauges remain spectator-hidden in v1 per spec.
+
+**Tech Stack:** Dioxus 0.7 (Rust → WASM), Tailwind CSS via the existing build pipeline, `dioxus-query` for fetching, `gloo-storage` for any persisted UI state. All shared types reach the frontend via the `game::` and `shared::` re-imports already in use.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-gamemaker-event-system-design.md`
+**Backend plan (predecessor):** `docs/superpowers/plans/2026-05-03-gamemaker-event-system-pr1-backend.md`
+**Beads issue:** `hangrier_games-5q9`
+
+---
+
+## Pre-flight Notes
+
+- Plan 2 must merge after Plan 1 (PR1 backend) lands. The frontend imports new fields, payload variants, and the `gamemaker.active_effects` data structure that PR1 introduces.
+- `web::` already re-imports `game::` types directly — Plan 1's `Gamemaker` struct (with `active_effects: Vec<ActiveIntervention>`) flows through the existing `Game` JSON contract automatically. No DTO bridging required.
+- Same applies to `MessagePayload` variants from Plan 1 — they flow through the existing `GameMessage` / `MessagePayload` re-imports already used by the timeline cards.
+- The 11 new variants need a routing destination. PR1 leaves `MessagePayload::kind()` returning fallback values. PR2 Task 1 fixes this by adding `MessageKind::Gamemaker` and routing all 11 variants to it. This is a `shared/` change PR2 owns end-to-end.
+- Run `just build-css` after any class changes that introduce new Tailwind utility classes (so the JIT pulls them).
+- Run `cd web && dx serve` for the live dev loop; smoke tests are manual at the end of each task.
+- All commits use the project's jj/git workflow per `AGENTS.md`.
+
+---
+
+## File Structure
+
+**New files:**
+- `web/src/components/map_gamemaker_overlay.rs` — three SVG marker layers (mutt swarm pin, sealed-area shading, convergence point pin), rendered when `Gamemaker.active_effects` is non-empty.
+- `web/src/components/timeline/cards/gamemaker_card.rs` — single generic timeline card for all 11 new gamemaker payloads.
+
+**Modified files:**
+- `shared/src/messages.rs` — add `MessageKind::Gamemaker`; route the 11 new payloads to it in `MessagePayload::kind()`; extend the `MessageKind` round-trip test fixture.
+- `web/src/components/mod.rs` — register `map_gamemaker_overlay`.
+- `web/src/components/map.rs` — accept `gamemaker_active_effects: Vec<ActiveIntervention>` prop (or read from `Game`); render the overlay layer above the existing affordance overlay.
+- `web/src/components/timeline/cards/mod.rs` — re-export `GamemakerCard`.
+- `web/src/components/timeline/event_card.rs` — add `MessageKind::Gamemaker => GamemakerCard { ... }` arm.
+- `web/src/components/timeline/filters.rs` — add a Gamemaker filter chip if filters are category-based.
+- `web/src/components/game_period_page.rs` (or wherever `Map` is rendered) — pass the new `gamemaker_active_effects` prop.
+
+---
+
+## Task Order Rationale
+
+Land the routing wiring first (`MessageKind::Gamemaker`) so subsequent timeline-card work has a real dispatch target. Then build the generic timeline card. Then add map markers, smallest-first (mutt swarm pin → sealed shading → convergence pin). End with WCAG check, visual smoke, self-review, PR.
+
+---
+
+## Task 1: Route 11 new payloads to `MessageKind::Gamemaker`
+
+**Files:**
+- Modify: `shared/src/messages.rs`
+
+- [ ] **Step 1: Write failing test** in `shared/src/messages.rs` (append to the existing `#[cfg(test)] mod tests` block):
+
+```rust
+#[test]
+fn gamemaker_kind_round_trip() {
+    let kinds = [
+        MessageKind::Death,
+        MessageKind::Combat,
+        MessageKind::CombatSwing,
+        MessageKind::Alliance,
+        MessageKind::Movement,
+        MessageKind::Item,
+        MessageKind::State,
+        MessageKind::Gamemaker,
+    ];
+    for k in kinds {
+        let s = serde_json::to_string(&k).unwrap();
+        let back: MessageKind = serde_json::from_str(&s).unwrap();
+        assert_eq!(k, back);
+    }
+}
+
+#[test]
+fn fireball_strike_routes_to_gamemaker_kind() {
+    let p = MessagePayload::FireballStrike {
+        area: AreaRef { id: "a1".into(), name: "Forest".into() },
+        severity_label: "Major".into(),
+        victims: vec![],
+        survivors: vec![],
+    };
+    assert_eq!(p.kind(), MessageKind::Gamemaker);
+}
+
+#[test]
+fn all_eleven_gamemaker_payloads_route_to_gamemaker_kind() {
+    use shared::messages::{Lure, DespawnReason};
+    let area = AreaRef { id: "a".into(), name: "A".into() };
+    let tref = TributeRef { id: "t".into(), name: "T".into() };
+    let cases: Vec<MessagePayload> = vec![
+        MessagePayload::FireballStrike { area: area.clone(), severity_label: "Major".into(), victims: vec![], survivors: vec![] },
+        MessagePayload::MuttSwarmSpawned { area: area.clone(), kind_label: "Wolf".into(), members: 4 },
+        MessagePayload::MuttSwarmAttack { area: area.clone(), kind_label: "Wolf".into(), victim: tref.clone(), damage: 20, killed: false },
+        MessagePayload::MuttSwarmDespawned { area: area.clone(), kind_label: "Wolf".into(), reason: DespawnReason::Morning },
+        MessagePayload::ForceFieldShifted { closed: vec![area.clone()], opened: vec![], warning_phases: 1 },
+        MessagePayload::AreaSealed { area: area.clone(), expires_at_phase: 8 },
+        MessagePayload::AreaUnsealed { area: area.clone() },
+        MessagePayload::AreaSealEntryDamage { area: area.clone(), tribute: tref.clone(), damage: 10 },
+        MessagePayload::ConvergencePointAnnounced { area: area.clone(), lure: Lure::Feast, starts_at_phase: 5 },
+        MessagePayload::ConvergencePointExpired { area: area.clone(), lure: Lure::Feast, claimed_by: vec![] },
+        MessagePayload::WeatherOverridden { area: area.clone(), weather_label: "HeavyRain".into(), duration_phases: 2 },
+    ];
+    assert_eq!(cases.len(), 11);
+    for p in cases {
+        assert_eq!(p.kind(), MessageKind::Gamemaker, "{:?} should route to Gamemaker", p);
+    }
+}
+```
+
+- [ ] **Step 2: Run; expected fail** (compile error: `MessageKind::Gamemaker` doesn't exist).
+
+```bash
+cargo test --package shared gamemaker_kind -- --nocapture
+```
+
+- [ ] **Step 3: Add the variant.** In `shared/src/messages.rs`, extend `MessageKind`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum MessageKind {
+    Death,
+    Combat,
+    CombatSwing,
+    Alliance,
+    Movement,
+    Item,
+    State,
+    Gamemaker,  // <-- add
+}
+```
+
+- [ ] **Step 4: Wire `kind()` for the 11 payloads.** In the `impl MessagePayload { pub fn kind(&self) -> MessageKind { ... } }` match, add an arm grouping all 11 variants together before the existing `_ => MessageKind::State` fallback:
+
+```rust
+| FireballStrike { .. }
+| MuttSwarmSpawned { .. }
+| MuttSwarmAttack { .. }
+| MuttSwarmDespawned { .. }
+| ForceFieldShifted { .. }
+| AreaSealed { .. }
+| AreaUnsealed { .. }
+| AreaSealEntryDamage { .. }
+| ConvergencePointAnnounced { .. }
+| ConvergencePointExpired { .. }
+| WeatherOverridden { .. } => MessageKind::Gamemaker,
+```
+
+(Read the existing match body in `shared/src/messages.rs` around line 261 first; insert the new arm in the same style as the existing arms.)
+
+- [ ] **Step 5: Update the existing `MessageKind` round-trip test fixture array** (around line 482-490) to include `MessageKind::Gamemaker`. The pre-existing test loops over a fixed list; without the new variant present the test passes but coverage is incomplete.
+
+- [ ] **Step 6: Run shared tests:**
+
+```bash
+cargo test --package shared -- --nocapture
+```
+
+Expected: all three new tests pass; existing tests unchanged.
+
+- [ ] **Step 7: Workspace check.** The `MessageKind` enum is used in exhaustive matches downstream — adding the variant may break `web/` and `api/`:
+
+```bash
+cargo check --workspace
+```
+
+If matches break, add `MessageKind::Gamemaker => { /* handled in Task 2 */ }` arms to any non-exhaustive matches. Locate via:
+
+```bash
+grep -rn "match.*MessageKind\|MessageKind::" web/ api/
+```
+
+Add minimal stub arms — Task 2 will replace any web-side stub with the real `GamemakerCard`.
+
+- [ ] **Step 8: Commit:**
+
+```bash
+jj describe -m "feat(shared): add MessageKind::Gamemaker and route 11 new payloads
+
+The gamemaker PR1 backend introduced 11 new MessagePayload variants for
+storyteller events (fireball, mutt swarm, force-field shift, area seal,
+convergence point, weather override). They were left routed via the
+default state-card fallback. Add a dedicated MessageKind::Gamemaker
+variant and route all 11 to it so PR2 can dispatch them to a typed
+GamemakerCard component.
+
+Refs: hangrier_games-5q9"
+jj new
+```
+
+---
+
+## Task 2: Generic `GamemakerCard` timeline component
+
+**Files:**
+- Create: `web/src/components/timeline/cards/gamemaker_card.rs`
+- Modify: `web/src/components/timeline/cards/mod.rs`
+- Modify: `web/src/components/timeline/event_card.rs`
+
+- [ ] **Step 1: Read the existing card pattern for style reference**
+
+```bash
+cat web/src/components/timeline/cards/state_card.rs
+cat web/src/components/timeline/cards/movement_card.rs
+```
+
+Confirm the pattern: a `#[component] pub fn FooCard(props: FooCardProps) -> Element` returning an `article` with theme-aware Tailwind classes (`bg-gray-50 theme2:bg-gray-900` etc.) and a leading emoji + body text.
+
+- [ ] **Step 2: Create the card** at `web/src/components/timeline/cards/gamemaker_card.rs`:
+
+```rust
+use dioxus::prelude::*;
+use shared::messages::{DespawnReason, GameMessage, Lure, MessagePayload};
+
+#[derive(Props, PartialEq, Clone)]
+pub struct GamemakerCardProps {
+    pub message: GameMessage,
+}
+
+/// Single generic card for all 11 gamemaker payload variants.
+///
+/// Each variant maps to:
+/// - A category icon (lethal=🔥, disruptive=⚡, convergence=⭐, atmospheric=☁️)
+/// - A border color matching the category
+/// - A stringified payload body
+#[component]
+pub fn GamemakerCard(props: GamemakerCardProps) -> Element {
+    let (icon, border, body) = match &props.message.payload {
+        // --- Lethal ---
+        MessagePayload::FireballStrike { area, severity_label, victims, survivors } => (
+            "🔥",
+            "border-red-500",
+            format!(
+                "Fireball ({}) hits {}: {} killed, {} survived",
+                severity_label,
+                area.name,
+                victims.len(),
+                survivors.len(),
+            ),
+        ),
+        MessagePayload::MuttSwarmSpawned { area, kind_label, members } => (
+            "🐺",
+            "border-red-500",
+            format!("{} swarm of {} spawns in {}", kind_label, members, area.name),
+        ),
+        MessagePayload::MuttSwarmAttack { area, kind_label, victim, damage, killed } => {
+            let suffix = if *killed { " (KILLED)" } else { "" };
+            (
+                "🐺",
+                "border-red-500",
+                format!(
+                    "{} swarm in {} attacks {} for {} damage{}",
+                    kind_label, area.name, victim.name, damage, suffix
+                ),
+            )
+        }
+        MessagePayload::MuttSwarmDespawned { area, kind_label, reason } => {
+            let why = match reason {
+                DespawnReason::Morning => "morning rollover",
+                DespawnReason::NoTargetsNearby => "no targets nearby",
+                DespawnReason::NoMembersLeft => "all members killed",
+            };
+            (
+                "🐺",
+                "border-stone-500",
+                format!("{} swarm in {} despawns ({})", kind_label, area.name, why),
+            )
+        }
+        // --- Disruptive ---
+        MessagePayload::ForceFieldShifted { closed, opened, warning_phases } => {
+            let closed_names: Vec<String> = closed.iter().map(|a| a.name.clone()).collect();
+            let opened_names: Vec<String> = opened.iter().map(|a| a.name.clone()).collect();
+            (
+                "⚡",
+                "border-amber-500",
+                format!(
+                    "Force field shifts: closing [{}], opening [{}] ({}-phase warning)",
+                    closed_names.join(", "),
+                    opened_names.join(", "),
+                    warning_phases,
+                ),
+            )
+        }
+        MessagePayload::AreaSealed { area, expires_at_phase } => (
+            "⚡",
+            "border-amber-500",
+            format!("{} sealed (until phase {})", area.name, expires_at_phase),
+        ),
+        MessagePayload::AreaUnsealed { area } => (
+            "⚡",
+            "border-stone-500",
+            format!("{} unsealed", area.name),
+        ),
+        MessagePayload::AreaSealEntryDamage { area, tribute, damage } => (
+            "⚡",
+            "border-amber-500",
+            format!("{} caught in {} seal: -{} HP", tribute.name, area.name, damage),
+        ),
+        // --- Convergence ---
+        MessagePayload::ConvergencePointAnnounced { area, lure, starts_at_phase } => {
+            let lure_label = match lure { Lure::Feast => "Feast" };
+            (
+                "⭐",
+                "border-yellow-500",
+                format!("{} announced at {} (starts phase {})", lure_label, area.name, starts_at_phase),
+            )
+        }
+        MessagePayload::ConvergencePointExpired { area, lure, claimed_by } => {
+            let lure_label = match lure { Lure::Feast => "Feast" };
+            let claimants: Vec<String> = claimed_by.iter().map(|t| t.name.clone()).collect();
+            let body_str = if claimants.is_empty() {
+                format!("{} at {} expires (unclaimed)", lure_label, area.name)
+            } else {
+                format!(
+                    "{} at {} expires; claimed by {}",
+                    lure_label, area.name, claimants.join(", ")
+                )
+            };
+            ("⭐", "border-stone-500", body_str)
+        }
+        // --- Atmospheric ---
+        MessagePayload::WeatherOverridden { area, weather_label, duration_phases } => (
+            "☁️",
+            "border-blue-500",
+            format!("{} weather forced to {} for {} phases", area.name, weather_label, duration_phases),
+        ),
+        // Defensive default — should be unreachable since dispatch in
+        // event_card.rs only routes Gamemaker-kind payloads here.
+        _ => ("🎬", "border-gray-400", "gamemaker event".to_string()),
+    };
+
+    rsx! {
+        article {
+            class: "rounded border-l-4 {border} bg-gray-50 theme2:bg-gray-900 p-2 text-sm",
+            "{icon} {body}"
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Re-export in `web/src/components/timeline/cards/mod.rs`:**
+
+Add the line (alphabetic position):
+
+```rust
+pub mod gamemaker_card;
+```
+
+(Match the existing module-declaration style in the file.)
+
+- [ ] **Step 4: Wire dispatch** in `web/src/components/timeline/event_card.rs`. Add the import:
+
+```rust
+use crate::components::timeline::cards::{
+    alliance_card::AllianceCard, combat_card::CombatCard, combat_swing_card::CombatSwingCard,
+    death_card::DeathCard, gamemaker_card::GamemakerCard, item_card::ItemCard,
+    movement_card::MovementCard, state_card::StateCard, survival_card::SurvivalCard,
+};
+```
+
+Add a new match arm for `MessageKind::Gamemaker` (place it before the closing `}` of the `match kind { ... }` block, alongside the other kind arms):
+
+```rust
+MessageKind::Gamemaker => rsx! { GamemakerCard { message: props.message.clone() } },
+```
+
+- [ ] **Step 5: Compile**
+
+```bash
+cd web && cargo check
+```
+
+Expected: clean. If a stub arm was added in Task 1 Step 7 referencing `MessageKind::Gamemaker`, replace it with the dispatch above.
+
+- [ ] **Step 6: Manual smoke**
+
+```bash
+cd web && dx serve
+```
+
+Open a game far enough into a run that gamemaker events have fired (or seed a test game). Confirm:
+- Fireball, mutt-swarm, area-seal, force-field, convergence, and weather-override events render with the correct emoji + border color.
+- No "gamemaker event" fallback string appears.
+
+- [ ] **Step 7: Commit:**
+
+```bash
+jj describe -m "feat(web): GamemakerCard for 11 storyteller-event payloads
+
+Generic timeline card renders all 11 new gamemaker MessagePayload
+variants with category icon (🔥 lethal, ⚡ disruptive, ⭐ convergence,
+☁️ atmospheric) and stringified payload bodies. Bespoke per-variant
+card layouts are filed as a follow-up bead.
+
+Refs: hangrier_games-5q9"
+jj new
+```
+
+---
+
+## Task 3: Mutt swarm pin map marker
+
+**Files:**
+- Create: `web/src/components/map_gamemaker_overlay.rs`
+- Modify: `web/src/components/mod.rs`
+- Modify: `web/src/components/map.rs`
+
+- [ ] **Step 1: Read existing affordance overlay for style reference**
+
+```bash
+cat web/src/components/map_affordance_overlay.rs
+```
+
+Note the SVG-positioning convention (cx, cy, size props) and how glyphs are drawn. Mirror that pattern.
+
+- [ ] **Step 2: Read where `Map` gets its data**
+
+```bash
+grep -rn "Map {" web/src/components/
+grep -rn "rsx! { Map" web/src/
+```
+
+Identify the call site (likely `game_period_page.rs` or similar). Note the parent's access to `game.gamemaker.active_effects` — the parent will pass it down as a new prop.
+
+- [ ] **Step 3: Create the overlay** at `web/src/components/map_gamemaker_overlay.rs` (start with mutt swarm only; add the other two markers in Tasks 4 and 5):
+
+```rust
+use dioxus::prelude::*;
+use game::gamemaker::ActiveIntervention;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct MapGamemakerOverlayProps {
+    pub cx: f64,
+    pub cy: f64,
+    pub size: f64,
+    pub area_id: String,
+    pub active_effects: Vec<ActiveIntervention>,
+}
+
+/// Renders gamemaker active-effect markers on a single hex.
+/// Currently supports: mutt swarm pin (Task 3).
+/// Tasks 4-5 add: sealed-area shading, convergence-point pin.
+#[component]
+pub fn MapGamemakerOverlay(props: MapGamemakerOverlayProps) -> Element {
+    let mutt = props.active_effects.iter().find_map(|eff| match eff {
+        ActiveIntervention::MuttSwarm { area_id, kind, members, .. }
+            if area_id == &props.area_id =>
+        {
+            Some((kind.to_string(), *members))
+        }
+        _ => None,
+    });
+
+    rsx! {
+        if let Some((kind_label, members)) = mutt {
+            // Pin offset upward and to the right of the hex center.
+            {
+                let px = props.cx + props.size * 0.35;
+                let py = props.cy - props.size * 0.35;
+                rsx! {
+                    g {
+                        // Red claw glyph
+                        text {
+                            x: "{px}",
+                            y: "{py}",
+                            text_anchor: "middle",
+                            dominant_baseline: "central",
+                            class: "fill-red-600 select-none pointer-events-none",
+                            font_size: "20",
+                            "🦊"
+                        }
+                        // Member count badge
+                        text {
+                            x: "{px + 10.0}",
+                            y: "{py + 10.0}",
+                            text_anchor: "middle",
+                            dominant_baseline: "central",
+                            class: "fill-white select-none pointer-events-none",
+                            font_size: "10",
+                            font_weight: "bold",
+                            title: "{kind_label} swarm: {members} members",
+                            "{members}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+(Note: `🦊` is a placeholder claw glyph. If a closer match exists in the project's icon set — e.g. `web/src/components/icons/` — substitute. Browse the icons directory first; if nothing fits, the emoji is acceptable for v1 and a follow-up bead can swap to a custom SVG.)
+
+- [ ] **Step 4: Register the module** in `web/src/components/mod.rs` (alphabetic position):
+
+```rust
+pub mod map_gamemaker_overlay;
+```
+
+- [ ] **Step 5: Pass the prop into `Map`** — modify `web/src/components/map.rs` signature:
+
+```rust
+#[component]
+pub fn Map(
+    areas: Vec<AreaDetails>,
+    #[props(default)] gamemaker_active_effects: Vec<game::gamemaker::ActiveIntervention>,
+) -> Element {
+```
+
+Inside the per-hex `g { ... }` block (after the existing affordance overlay rendering), add:
+
+```rust
+MapGamemakerOverlay {
+    cx: cx,
+    cy: cy,
+    size: HEX_SIZE,
+    area_id: area_name.to_lowercase().replace(' ', "-"),
+    active_effects: gamemaker_active_effects.clone(),
+}
+```
+
+Add the import at the top:
+
+```rust
+use crate::components::map_gamemaker_overlay::MapGamemakerOverlay;
+```
+
+- [ ] **Step 6: Pass the prop from the Map call site.** Find with:
+
+```bash
+grep -rn "rsx! { Map" web/src/
+```
+
+Modify each call site to include:
+
+```rust
+Map {
+    areas: areas.clone(),
+    gamemaker_active_effects: game.gamemaker.active_effects.clone(),
+}
+```
+
+(Adjust to actual field-access path.)
+
+- [ ] **Step 7: Compile**
+
+```bash
+cd web && cargo check
+```
+
+Expected: clean.
+
+- [ ] **Step 8: Manual smoke**
+
+```bash
+just build-css
+cd web && dx serve
+```
+
+Trigger a mutt-swarm event in a running game (force one via test-fixture seed if needed). Confirm:
+- A red glyph + small numeric badge appears on the hex where the swarm is active.
+- When the swarm despawns, the marker disappears within one phase tick.
+
+- [ ] **Step 9: Commit:**
+
+```bash
+jj describe -m "feat(web): mutt swarm pin marker on hex map
+
+Renders a red glyph + member-count badge on hexes where a MuttSwarm
+ActiveIntervention is active. Fed by Game.gamemaker.active_effects
+populated by PR1.
+
+Refs: hangrier_games-5q9"
+jj new
+```
+
+---
+
+## Task 4: Sealed-area shading map marker
+
+**Files:**
+- Modify: `web/src/components/map_gamemaker_overlay.rs`
+
+- [ ] **Step 1: Extend `MapGamemakerOverlay`** to render sealed-area shading. Below the mutt-swarm rsx block, add a polygon overlay when an `AreaClosure` matches:
+
+```rust
+let is_sealed = props.active_effects.iter().any(|eff| matches!(
+    eff,
+    ActiveIntervention::AreaClosure { area_id, .. } if area_id == &props.area_id
+));
+
+// ... inside the rsx! { } below the mutt block:
+if is_sealed {
+    // Render hex-shape overlay; reuse hex_corners helper from map.rs by
+    // accepting a precomputed `points` string as a prop, or duplicate the
+    // small helper inline. Simpler: accept points as an optional prop
+    // OR compute the polygon path here.
+    {
+        // Inline hex corners (matches map.rs hex_corners output).
+        let mut pts = String::new();
+        for i in 0..6 {
+            let angle_deg = 60.0 * (i as f64) + 30.0;
+            let a = angle_deg.to_radians();
+            let x = props.cx + props.size * a.cos();
+            let y = props.cy + props.size * a.sin();
+            if i > 0 { pts.push(' '); }
+            pts.push_str(&format!("{x:.2},{y:.2}"));
+        }
+        rsx! {
+            polygon {
+                points: "{pts}",
+                class: "fill-red-500/30 stroke-red-700 pointer-events-none",
+                stroke_width: "2",
+                stroke_dasharray: "4 2",
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Hoist `hex_corners` if duplication bothers you** — move the helper from `web/src/components/map.rs` into a shared module (e.g. `web/src/components/hex_geometry.rs`) and import in both `map.rs` and `map_gamemaker_overlay.rs`. Optional refactor; the inline version is acceptable for v1.
+
+- [ ] **Step 3: Compile**
+
+```bash
+cd web && cargo check
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Manual smoke**
+
+Trigger an `AreaClosure` event. Confirm:
+- The closed hex gets a translucent red overlay with dashed red border.
+- When the seal expires (PR1 emits `AreaUnsealed`), the overlay disappears within one phase.
+- The overlay is `pointer-events-none` so it doesn't break hex clicks.
+
+- [ ] **Step 5: Commit:**
+
+```bash
+jj describe -m "feat(web): sealed-area shading on hex map
+
+Adds translucent red overlay with dashed border to hexes under an
+AreaClosure ActiveIntervention. Pointer-events disabled so click-to-
+select still works through the overlay.
+
+Refs: hangrier_games-5q9"
+jj new
+```
+
+---
+
+## Task 5: Convergence point pin map marker
+
+**Files:**
+- Modify: `web/src/components/map_gamemaker_overlay.rs`
+
+- [ ] **Step 1: Extend `MapGamemakerOverlay`** to render the convergence pin. Below the sealed-area block, add:
+
+```rust
+let convergence = props.active_effects.iter().find_map(|eff| match eff {
+    ActiveIntervention::ConvergencePoint { area_id, lure, .. }
+        if area_id == &props.area_id =>
+    {
+        Some(lure.clone())
+    }
+    _ => None,
+});
+
+// ... inside the rsx! { }:
+if let Some(lure) = convergence {
+    let lure_glyph = match lure {
+        shared::messages::Lure::Feast => "🍖",
+    };
+    {
+        let px = props.cx - props.size * 0.35;
+        let py = props.cy - props.size * 0.35;
+        rsx! {
+            g {
+                text {
+                    x: "{px}",
+                    y: "{py}",
+                    text_anchor: "middle",
+                    dominant_baseline: "central",
+                    class: "fill-yellow-500 select-none pointer-events-none",
+                    font_size: "20",
+                    "⭐"
+                }
+                text {
+                    x: "{px + 12.0}",
+                    y: "{py + 12.0}",
+                    text_anchor: "middle",
+                    dominant_baseline: "central",
+                    font_size: "12",
+                    class: "select-none pointer-events-none",
+                    "{lure_glyph}"
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Compile**
+
+```bash
+cd web && cargo check
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Manual smoke**
+
+Trigger a `ConvergencePointAnnounced` event. Confirm:
+- A gold star + lure micro-icon (🍖 for Feast) appears on the announced hex.
+- When the convergence expires, the marker disappears within one phase.
+
+- [ ] **Step 4: Commit:**
+
+```bash
+jj describe -m "feat(web): convergence point pin on hex map
+
+Gold star + lure-specific glyph (🍖 Feast) on hexes hosting a
+ConvergencePoint ActiveIntervention. Future Lure variants extend
+the glyph match.
+
+Refs: hangrier_games-5q9"
+jj new
+```
+
+---
+
+## Task 6: WCAG contrast check + accessibility pass
+
+**Files:** none modified directly; remediation may touch Tasks 3-5 outputs.
+
+- [ ] **Step 1: Visually inspect each new map marker against both terrain themes.**
+
+```bash
+just build-css
+cd web && dx serve
+```
+
+Switch between the available Tailwind themes (default + `theme2:` + `theme3:` if present). For each marker:
+- Mutt swarm pin: red glyph against stone-200 / stone-400 hex fills — confirm legibility.
+- Sealed-area shading: `fill-red-500/30` over closed-hex `fill-red-500` may stack red-on-red and reduce legibility. Verify; if unreadable on closed hexes specifically, consider `fill-amber-500/40` instead.
+- Convergence pin: gold star + lure glyph against stone hexes — confirm visibility (the lure glyph defaults to inherit; force `class: "fill-stone-900"` if needed).
+
+- [ ] **Step 2: Add `<title>` accessibility tooltips** to each marker (matches the `title:` attribute already used on the mutt-swarm member badge). Aim for descriptive text screen readers can announce:
+
+```rust
+title { "Mutt swarm: {kind_label}, {members} members" }
+title { "Area sealed by gamemaker; entering takes damage" }
+title { "Convergence point: {lure_label}" }
+```
+
+(Use SVG `<title>` child element, not the HTML `title` attribute, since these are SVG nodes.)
+
+- [ ] **Step 3: Confirm screen-reader announcement** with VoiceOver (macOS) or NVDA (Windows) over a representative hex.
+
+- [ ] **Step 4: Commit any remediation:**
+
+```bash
+jj describe -m "fix(web): WCAG remediation for gamemaker map markers
+
+- Adjust sealed-area overlay color to maintain contrast on closed
+  (already-red) hexes
+- Add SVG <title> tooltips for screen-reader announcement
+
+Refs: hangrier_games-5q9"
+jj new
+```
+
+(Skip the commit if no remediation needed.)
+
+---
+
+## Task 7: Visual integration tests + filter chip + final pass + PR
+
+**Files:**
+- Modify: `web/src/components/timeline/filters.rs` (if filters are category-based)
+
+- [ ] **Step 1: Confirm filter chip wiring**
+
+```bash
+cat web/src/components/timeline/filters.rs
+```
+
+If the existing filters are keyed off `MessageKind` (likely, given `tribute_filter_chips.rs` exists), add a `Gamemaker` chip alongside the others:
+
+```rust
+// In the chip list, alongside Death/Combat/Movement/etc:
+FilterChip {
+    label: "Gamemaker",
+    kind: MessageKind::Gamemaker,
+    icon: "🎬",
+}
+```
+
+(Match the existing chip-render pattern; the snippet above is approximate. Read the file first.)
+
+- [ ] **Step 2: Visual integration tests**
+
+If the project uses `#[component]` testing (Dioxus 0.7's `dioxus_testing` or `dioxus-cli`'s component test runner), add tests in `web/src/components/timeline/cards/gamemaker_card.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::messages::{AreaRef, GameMessage, MessagePayload, MessageSource};
+
+    fn msg_with(payload: MessagePayload) -> GameMessage {
+        GameMessage {
+            source: MessageSource::Game("test".into()),
+            payload,
+            timestamp: 0,
+            emit_index: 0,
+            day: 0,
+            phase: 0,
+        }
+        // (Adjust to actual GameMessage shape; read shared/src/messages.rs first.)
+    }
+
+    #[test]
+    fn fireball_strike_renders_fire_emoji() {
+        let m = msg_with(MessagePayload::FireballStrike {
+            area: AreaRef { id: "a".into(), name: "Forest".into() },
+            severity_label: "Major".into(),
+            victims: vec![],
+            survivors: vec![],
+        });
+        // If a render-to-string helper exists in the project, use it; otherwise this
+        // test ensures the props at minimum compile with the variant shape.
+        let _ = GamemakerCardProps { message: m };
+    }
+}
+```
+
+(If no existing render-test infrastructure exists in `web/`, skip this step and rely on manual smoke from Tasks 2-5. File a follow-up bead to add component-render tests if it's a recurring need.)
+
+- [ ] **Step 3: Format and lint**
+
+```bash
+just fmt
+just quality
+```
+
+Expected: clean — formatter no-op, no clippy warnings, all tests pass.
+
+- [ ] **Step 4: CSS rebuild**
+
+```bash
+just build-css
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Manual end-to-end smoke**
+
+Run `just dev`. With a fresh game, push it forward several days and confirm:
+1. As the gamemaker fires interventions, all 11 payload variants render in the timeline with category-correct icons and borders.
+2. Filtering by the Gamemaker chip isolates only those events.
+3. Mutt-swarm pins, sealed-area shading, and convergence pins appear on the correct hexes and disappear when the underlying active effect resolves.
+4. The hex-click selection (terrain affordance overlay from shelter PR2) still works through gamemaker overlays.
+5. Console (browser devtools) shows no errors.
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+jj git fetch
+jj rebase -d main@origin
+bd backup export-git --branch beads-backup
+jj bookmark create feat-gamemaker-frontend -r @-
+jj git push --bookmark feat-gamemaker-frontend
+gh pr create --base main --head feat-gamemaker-frontend \
+  --title "feat(web): gamemaker event system frontend (PR2)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Frontend slice of the gamemaker event system spec. Pairs with PR1 (backend, already merged).
+
+- Adds `MessageKind::Gamemaker` and routes the 11 new gamemaker payloads to it
+- Generic `GamemakerCard` renders all 11 storyteller-event variants with category icon (🔥 lethal, ⚡ disruptive, ⭐ convergence, ☁️ atmospheric) and stringified bodies
+- Three new hex-map markers fed by `Game.gamemaker.active_effects`:
+  - Mutt swarm pin (claw glyph + member count)
+  - Sealed-area shading (translucent red overlay with dashed border)
+  - Convergence point pin (gold star + lure glyph)
+- WCAG-friendly: SVG `<title>` tooltips on markers; pointer-events disabled on overlays so hex selection still works
+- Optional Gamemaker filter chip in the timeline filter strip
+
+## Spec
+docs/superpowers/specs/2026-05-03-gamemaker-event-system-design.md
+
+## Verification
+- `just quality` — clean
+- `just build-css` — clean
+- Manual smoke: all 11 payloads render correctly; map markers appear/disappear in sync with active effects; hex selection unaffected
+
+## Follow-ups
+- Bespoke per-payload card layouts (file as bead) — current generic card is functional but could be richer
+- Custom SVG glyph for mutt swarm (currently 🦊 emoji placeholder)
+- Capitol Feed gauge panel (deferred per spec — gauges remain spectator-hidden in v1)
+- Extra `Lure` variants (water cache, airdrop cluster, capitol summons) and corresponding glyphs
+EOF
+)"
+```
+
+- [ ] **Step 7: Update beads**
+
+```bash
+bd update hangrier_games-5q9 --status closed --notes "Completed: Plan 1 + Plan 2 merged. PR2: <PR URL>"
+```
+
+(Now `hangrier_games-5q9` can close — the spec's full v1 scope is shipped.)
+
+---
+
+## Self-Review
+
+**Spec coverage check (frontend section of the spec):**
+- Hex map — mutt swarm pin: Task 3 ✓
+- Hex map — sealed-area shading: Task 4 ✓
+- Hex map — convergence point pin: Task 5 ✓
+- Timeline — generic rendering for all 11 new payloads: Tasks 1-2 ✓
+- Category icons (lethal=flame, disruptive=forcefield-shimmer, convergence=star, atmospheric=cloud): Task 2 ✓
+- Stringified payload fields + standard timeline-card chrome: Task 2 ✓
+- No Capitol Feed panel (spec explicitly deferred): respected ✓
+- Bespoke per-payload card layouts (spec: filed as follow-up): documented in PR description ✓
+- WCAG check: Task 6 ✓
+
+**Placeholder scan:** all RSX blocks and component implementations are concrete; pseudo-shapes (e.g. "adapt to actual loop variable names" in Task 7 Step 1) are clearly labeled where the engineer must read the existing site first. No `TBD` / `TODO` / "implement appropriately" placeholders other than the explicitly-flagged 🦊 emoji glyph (with a follow-up note).
+
+**Type consistency check:**
+- `GamemakerCardProps`: `message: GameMessage` — same in Tasks 2, 7.
+- `MapGamemakerOverlayProps`: `cx: f64, cy: f64, size: f64, area_id: String, active_effects: Vec<ActiveIntervention>` — same in Tasks 3, 4, 5.
+- `Map` prop addition: `gamemaker_active_effects: Vec<ActiveIntervention>` — Task 3.
+- `MessageKind::Gamemaker` referenced in Tasks 1, 2, 7 — added in Task 1.
+- `MessagePayload` variants used (`FireballStrike`, `MuttSwarmSpawned`, `MuttSwarmAttack`, `MuttSwarmDespawned`, `ForceFieldShifted`, `AreaSealed`, `AreaUnsealed`, `AreaSealEntryDamage`, `ConvergencePointAnnounced`, `ConvergencePointExpired`, `WeatherOverridden`) match exactly the 11 variants PR1 Task 5 introduces.
+- `ActiveIntervention` variants used (`MuttSwarm { area_id, kind, members, .. }`, `AreaClosure { area_id, .. }`, `ConvergencePoint { area_id, lure, .. }`) match exactly PR1 Task 9.
+- `Lure` variants used (`Feast`) match PR1 Task 5.
+- `DespawnReason` variants used (`Morning`, `NoTargetsNearby`, `NoMembersLeft`) match PR1 Task 5.
+
+**Known gaps (filed in PR description as follow-ups):**
+1. 🦊 emoji as mutt-swarm glyph placeholder — swap to custom SVG when icon-set work is scheduled.
+2. Generic GamemakerCard — bespoke per-payload card layouts deferred.
+3. Capitol Feed gauge panel — spectator-hidden in v1 per spec; defer to a future spec.
+4. Visual integration tests in Task 7 Step 2 are conditional on existing test infrastructure; if absent, manual smoke + future test-infra bead suffices.
+5. `hex_corners` duplication between `map.rs` and `map_gamemaker_overlay.rs` is left optional in Task 4 Step 2.
+
+**Backend coupling sanity check:**
+- All `ActiveIntervention` field names (`area_id`, `kind`, `members`, `lure`) match PR1 Task 9 exactly. Verified against PR1 plan lines 2400-2470.
+- `Animal::to_string()` is used to derive `kind_label` — relies on `Display` impl on `threats::animals::Animal` (already exists per PR1 Task 5 narrative).
+- `Game.gamemaker` field path matches PR1 Task 2 — single source of truth for active-effect rendering.

--- a/docs/superpowers/plans/2026-05-03-shelter-hunger-thirst-pr1-backend.md
+++ b/docs/superpowers/plans/2026-05-03-shelter-hunger-thirst-pr1-backend.md
@@ -1,0 +1,2082 @@
+# Shelter + Hunger/Thirst — Plan 1: Backend Implementation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the entire backend slice of the shelter + hunger/thirst system: counters, ticks, statuses, Brain overrides, items, actions, traits, looting, and events. Frontend (pips, drilldown, map overlays) ships separately in Plan 2.
+
+**Architecture:** Pure-function modules under `game/src/areas/` for shelter / forage / water tables; new `game/src/tributes/survival.rs` for the tick + drain logic. New typed message payloads in `shared/src/messages.rs`. Brain override list interleaves before existing weighted scoring. A *minimal* `Weather` enum (`Clear | HeavyRain | Heatwave | Blizzard`) is introduced as a stub producer (returns `Clear` everywhere) so the consumer wiring is real and the future weather spec can swap producers without touching consumers. Looting-on-death is wired in lifecycle as part of this plan.
+
+**Tech Stack:** Rust 2024, `serde` with `serde(default)` for save/load migration, `rstest` for inline unit + integration tests, SurrealDB schema definitions in `schemas/*.surql`.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-shelter-hunger-thirst-design.md`
+
+**Beads issue:** `hangrier_games-0yz`
+
+---
+
+## Pre-flight notes
+
+- All code in this plan lives in the `game/`, `shared/`, and `api/` crates. No `web/` changes — those land in Plan 2.
+- Run `just test` (game crate) and `just quality` (full workspace) at major checkpoints.
+- Commits are frequent and small. Each task ends with a commit.
+- The `Weather` enum is intentionally minimal here. The full weather spec implementation will *grow* the enum and replace the stub producer; plan 1 must not lock in any weather details beyond the four variants this spec needs.
+- All new fields use `#[serde(default)]` so existing JSON game saves load cleanly. SurrealDB schema additions also use `DEFAULT` clauses for the same reason.
+
+---
+
+## File Structure
+
+**New files:**
+- `game/src/areas/weather.rs` — minimal `Weather` enum + stub `current_weather(area) -> Weather`.
+- `game/src/areas/shelter.rs` — `shelter_quality(terrain, weather) -> u8`.
+- `game/src/areas/forage.rs` — `forage_richness(terrain) -> u8`.
+- `game/src/areas/water.rs` — `water_source(terrain, weather) -> u8`.
+- `game/src/tributes/survival.rs` — survival tick + drain logic + band enums.
+
+**Modified files:**
+- `game/src/tributes/mod.rs` — new fields on `Tribute`; expose new modules.
+- `game/src/tributes/statuses.rs` — no struct change; only Display/FromStr already cover Starving/Dehydrated.
+- `game/src/tributes/actions.rs` — new `Action` variants: `SeekShelter`, `Forage`, `Eat(Item)`, `Drink(DrinkSource)`.
+- `game/src/tributes/brains.rs` — survival override branch ahead of normal scoring.
+- `game/src/tributes/lifecycle.rs` — drop tribute items into the area on `RecentlyDead → Dead`.
+- `game/src/tributes/traits.rs` — add `Builder`, `ResourcefulForager`.
+- `game/src/items/mod.rs` — `ItemType::Food(u8)`, `ItemType::Water(u8)`; helpers.
+- `game/src/areas/mod.rs` — re-export the new submodules.
+- `game/src/games.rs` — call survival tick once per phase per tribute; wire new events through.
+- `shared/src/messages.rs` — new payloads: `HungerBandChanged`, `ThirstBandChanged`, `ShelterSought`, `Foraged`, `Drank`, `Ate`. Constants for new `cause` strings.
+- `schemas/tribute.surql` (or equivalent) — add new persisted fields with defaults.
+
+---
+
+## Task Order Rationale
+
+Tasks build the data substrate first (Tasks 1–3), then the survival mechanics (4–7), then the action-and-Brain integration (8–10), then lifecycle/events glue (11–12), then integration tests (13). Each task is independently shippable and reviewable. TDD throughout: failing test first.
+
+---
+
+## Task 1: Minimal `Weather` enum + stub producer
+
+**Why first:** every survival module takes `&Weather` as input. Define the type and a stub source so all subsequent modules can compile against the real consumer signature.
+
+**Files:**
+- Create: `game/src/areas/weather.rs`
+- Modify: `game/src/areas/mod.rs` (add `pub mod weather;` + re-export)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `game/src/areas/weather.rs` (file does not yet exist):
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub enum Weather {
+    #[default]
+    Clear,
+    HeavyRain,
+    Heatwave,
+    Blizzard,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn weather_default_is_clear() {
+        assert_eq!(Weather::default(), Weather::Clear);
+    }
+
+    #[test]
+    fn current_weather_stub_returns_clear() {
+        // Stub producer until full weather spec lands.
+        assert_eq!(current_weather(), Weather::Clear);
+    }
+}
+```
+
+(The test references `current_weather()` which we have not yet defined — that is the failing call.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --package game --lib areas::weather -- --nocapture`
+Expected: FAIL — `cannot find function 'current_weather' in this scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `game/src/areas/weather.rs`, insert above the `#[cfg(test)]` block:
+
+```rust
+/// Stub producer. Always returns `Weather::Clear` until the full weather
+/// system (see `2026-05-02-weather-system-design.md`) replaces this.
+///
+/// Consumers must call this (not hardcode `Weather::Clear`) so the future
+/// weather implementation needs only a producer-side change.
+pub fn current_weather() -> Weather {
+    Weather::Clear
+}
+```
+
+Edit `game/src/areas/mod.rs`, add at the top of the module (alongside other `pub mod`s):
+
+```rust
+pub mod weather;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib areas::weather`
+Expected: PASS — both tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(game): add minimal Weather enum + stub producer
+
+Introduces game/src/areas/weather.rs with a four-variant Weather enum
+(Clear, HeavyRain, Heatwave, Blizzard) and a stub current_weather()
+producer that always returns Clear. Consumers in subsequent tasks
+take &Weather as input so the future full weather implementation
+needs only a producer-side change.
+
+Refs: hangrier_games-0yz"
+```
+
+(Or equivalent `jj` commit-creation flow — the project uses jj with git coexistence.)
+
+---
+
+## Task 2: `shelter_quality(terrain, weather)` pure function
+
+**Files:**
+- Create: `game/src/areas/shelter.rs`
+- Modify: `game/src/areas/mod.rs` (add `pub mod shelter;`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `game/src/areas/shelter.rs` with:
+
+```rust
+use crate::areas::weather::Weather;
+use crate::terrain::types::BaseTerrain;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(BaseTerrain::UrbanRuins, Weather::Clear, 3)]
+    #[case(BaseTerrain::Forest,     Weather::Clear, 2)]
+    #[case(BaseTerrain::Jungle,     Weather::Clear, 2)]
+    #[case(BaseTerrain::Mountains,  Weather::Clear, 2)]
+    #[case(BaseTerrain::Geothermal, Weather::Clear, 2)]
+    #[case(BaseTerrain::Wetlands,   Weather::Clear, 1)]
+    #[case(BaseTerrain::Highlands,  Weather::Clear, 1)]
+    #[case(BaseTerrain::Clearing,   Weather::Clear, 1)]
+    #[case(BaseTerrain::Grasslands, Weather::Clear, 1)]
+    #[case(BaseTerrain::Badlands,   Weather::Clear, 1)]
+    #[case(BaseTerrain::Tundra,     Weather::Clear, 0)]
+    #[case(BaseTerrain::Desert,     Weather::Clear, 0)]
+    fn shelter_quality_clear_weather_table(
+        #[case] terrain: BaseTerrain,
+        #[case] weather: Weather,
+        #[case] expected: u8,
+    ) {
+        assert_eq!(shelter_quality(terrain, &weather), expected);
+    }
+
+    #[rstest]
+    #[case(BaseTerrain::Forest,     Weather::HeavyRain, 1)] // 2 - 1
+    #[case(BaseTerrain::UrbanRuins, Weather::HeavyRain, 2)] // 3 - 1
+    #[case(BaseTerrain::Desert,     Weather::HeavyRain, 0)] // floors at 0
+    #[case(BaseTerrain::Forest,     Weather::Blizzard,  1)]
+    #[case(BaseTerrain::Tundra,     Weather::Blizzard,  0)]
+    fn shelter_quality_storm_modifier(
+        #[case] terrain: BaseTerrain,
+        #[case] weather: Weather,
+        #[case] expected: u8,
+    ) {
+        assert_eq!(shelter_quality(terrain, &weather), expected);
+    }
+
+    #[rstest]
+    #[case(BaseTerrain::UrbanRuins, 3)]
+    #[case(BaseTerrain::Mountains,  2)]
+    #[case(BaseTerrain::Geothermal, 2)]
+    #[case(BaseTerrain::Forest,     2)]
+    #[case(BaseTerrain::Jungle,     2)]
+    #[case(BaseTerrain::Tundra,     0)]
+    #[case(BaseTerrain::Desert,     0)]
+    fn shelter_quality_heatwave_keeps_stone_and_canopy(
+        #[case] terrain: BaseTerrain,
+        #[case] expected: u8,
+    ) {
+        assert_eq!(shelter_quality(terrain, &Weather::Heatwave), expected);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --package game --lib areas::shelter`
+Expected: FAIL — `cannot find function 'shelter_quality' in this scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `game/src/areas/shelter.rs` above the test module:
+
+```rust
+/// Pure derivation of an area's shelter quality from terrain and current weather.
+/// 0 = no shelter possible. 4 = excellent shelter. See spec table.
+pub fn shelter_quality(terrain: BaseTerrain, weather: &Weather) -> u8 {
+    let base = match terrain {
+        BaseTerrain::UrbanRuins => 3,
+        BaseTerrain::Forest
+        | BaseTerrain::Jungle
+        | BaseTerrain::Mountains
+        | BaseTerrain::Geothermal => 2,
+        BaseTerrain::Wetlands
+        | BaseTerrain::Highlands
+        | BaseTerrain::Clearing
+        | BaseTerrain::Grasslands
+        | BaseTerrain::Badlands => 1,
+        BaseTerrain::Tundra | BaseTerrain::Desert => 0,
+    };
+
+    match weather {
+        Weather::Clear => base,
+        Weather::HeavyRain | Weather::Blizzard => base.saturating_sub(1),
+        Weather::Heatwave => match terrain {
+            BaseTerrain::UrbanRuins
+            | BaseTerrain::Mountains
+            | BaseTerrain::Geothermal
+            | BaseTerrain::Forest
+            | BaseTerrain::Jungle => base,
+            BaseTerrain::Tundra | BaseTerrain::Desert => 0,
+            _ => base,
+        },
+    }
+}
+```
+
+Edit `game/src/areas/mod.rs`, add: `pub mod shelter;`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib areas::shelter`
+Expected: PASS — all rstest cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(game): add shelter_quality pure function
+
+Derives an area's shelter quality (0-4) from BaseTerrain + Weather.
+Full coverage of all 12 BaseTerrain variants. Storm weathers (HeavyRain,
+Blizzard) apply -1 to the roll target; Heatwave preserves stone/canopy.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 3: `forage_richness` and `water_source` pure functions
+
+**Files:**
+- Create: `game/src/areas/forage.rs`
+- Create: `game/src/areas/water.rs`
+- Modify: `game/src/areas/mod.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `game/src/areas/forage.rs`:
+
+```rust
+use crate::terrain::types::BaseTerrain;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(BaseTerrain::Wetlands,   3)]
+    #[case(BaseTerrain::Jungle,     3)]
+    #[case(BaseTerrain::Forest,     2)]
+    #[case(BaseTerrain::UrbanRuins, 2)]
+    #[case(BaseTerrain::Mountains,  1)]
+    #[case(BaseTerrain::Highlands,  1)]
+    #[case(BaseTerrain::Clearing,   1)]
+    #[case(BaseTerrain::Grasslands, 1)]
+    #[case(BaseTerrain::Geothermal, 1)]
+    #[case(BaseTerrain::Badlands,   0)]
+    #[case(BaseTerrain::Tundra,     0)]
+    #[case(BaseTerrain::Desert,     0)]
+    fn forage_richness_table(#[case] terrain: BaseTerrain, #[case] expected: u8) {
+        assert_eq!(forage_richness(terrain), expected);
+    }
+}
+```
+
+Create `game/src/areas/water.rs`:
+
+```rust
+use crate::areas::weather::Weather;
+use crate::terrain::types::BaseTerrain;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(BaseTerrain::Wetlands,   Weather::Clear, 3)]
+    #[case(BaseTerrain::Forest,     Weather::Clear, 2)]
+    #[case(BaseTerrain::Jungle,     Weather::Clear, 2)]
+    #[case(BaseTerrain::Mountains,  Weather::Clear, 2)]
+    #[case(BaseTerrain::Geothermal, Weather::Clear, 2)]
+    #[case(BaseTerrain::Highlands,  Weather::Clear, 1)]
+    #[case(BaseTerrain::Clearing,   Weather::Clear, 1)]
+    #[case(BaseTerrain::UrbanRuins, Weather::Clear, 1)]
+    #[case(BaseTerrain::Tundra,     Weather::Clear, 1)]
+    #[case(BaseTerrain::Grasslands, Weather::Clear, 0)]
+    #[case(BaseTerrain::Badlands,   Weather::Clear, 0)]
+    #[case(BaseTerrain::Desert,     Weather::Clear, 0)]
+    fn water_source_clear_table(
+        #[case] terrain: BaseTerrain,
+        #[case] weather: Weather,
+        #[case] expected: u8,
+    ) {
+        assert_eq!(water_source(terrain, &weather), expected);
+    }
+
+    #[rstest]
+    #[case(BaseTerrain::Wetlands,   3)]
+    #[case(BaseTerrain::Forest,     3)]
+    #[case(BaseTerrain::Jungle,     3)]
+    #[case(BaseTerrain::Grasslands, 2)]
+    #[case(BaseTerrain::Mountains,  2)]
+    #[case(BaseTerrain::Desert,     1)]
+    #[case(BaseTerrain::Tundra,     1)]
+    fn water_source_heavy_rain_boosts(
+        #[case] terrain: BaseTerrain,
+        #[case] expected: u8,
+    ) {
+        assert_eq!(water_source(terrain, &Weather::HeavyRain), expected);
+    }
+
+    #[rstest]
+    #[case(BaseTerrain::Wetlands, 1)] // 3 / 2 = 1
+    #[case(BaseTerrain::Mountains, 1)] // 2 / 2 = 1
+    #[case(BaseTerrain::Highlands, 0)] // 1 / 2 = 0
+    #[case(BaseTerrain::Desert, 0)]
+    fn water_source_heatwave_halves_base(
+        #[case] terrain: BaseTerrain,
+        #[case] expected: u8,
+    ) {
+        assert_eq!(water_source(terrain, &Weather::Heatwave), expected);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --package game --lib 'areas::(forage|water)'`
+Expected: FAIL — both functions undefined.
+
+- [ ] **Step 3: Write minimal implementations**
+
+Add to `game/src/areas/forage.rs` above the test module:
+
+```rust
+/// Pure derivation of an area's forage richness from terrain.
+/// 0 = barren. 4 = abundant. See spec table.
+pub fn forage_richness(terrain: BaseTerrain) -> u8 {
+    match terrain {
+        BaseTerrain::Wetlands | BaseTerrain::Jungle => 3,
+        BaseTerrain::Forest | BaseTerrain::UrbanRuins => 2,
+        BaseTerrain::Mountains
+        | BaseTerrain::Highlands
+        | BaseTerrain::Clearing
+        | BaseTerrain::Grasslands
+        | BaseTerrain::Geothermal => 1,
+        BaseTerrain::Badlands | BaseTerrain::Tundra | BaseTerrain::Desert => 0,
+    }
+}
+```
+
+Add to `game/src/areas/water.rs` above the test module:
+
+```rust
+/// Pure derivation of an area's water-source strength from terrain + weather.
+/// 0 = no water available. 3 = abundant.
+pub fn water_source(terrain: BaseTerrain, weather: &Weather) -> u8 {
+    let base = match terrain {
+        BaseTerrain::Wetlands => 3,
+        BaseTerrain::Forest
+        | BaseTerrain::Jungle
+        | BaseTerrain::Mountains
+        | BaseTerrain::Geothermal => 2,
+        BaseTerrain::Highlands
+        | BaseTerrain::Clearing
+        | BaseTerrain::UrbanRuins
+        | BaseTerrain::Tundra => 1,
+        BaseTerrain::Grasslands | BaseTerrain::Badlands | BaseTerrain::Desert => 0,
+    };
+
+    match weather {
+        Weather::Clear | Weather::Blizzard => base,
+        Weather::HeavyRain => (base + 2).min(3),
+        Weather::Heatwave => base / 2,
+    }
+}
+```
+
+Edit `game/src/areas/mod.rs`, add: `pub mod forage; pub mod water;`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib 'areas::(forage|water)'`
+Expected: PASS — all cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(game): add forage_richness + water_source pure functions
+
+Derive area resource availability from terrain + weather. Full coverage
+of all 12 BaseTerrain variants. HeavyRain boosts water; Heatwave halves
+it (rounding down).
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 4: New `Tribute` survival fields + serde defaults
+
+**Files:**
+- Modify: `game/src/tributes/mod.rs:131-200` (the `pub struct Tribute` definition; line range approximate — locate `pub items: Vec<Item>` and add nearby).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing `#[cfg(test)] mod tests { ... }` block in `game/src/tributes/mod.rs` (locate near the bottom of the file):
+
+```rust
+#[test]
+fn tribute_default_survival_fields_are_zero_and_none() {
+    let t = Tribute::new("Test".to_string(), None, None);
+    assert_eq!(t.hunger, 0, "hunger starts at 0 (Sated)");
+    assert_eq!(t.thirst, 0, "thirst starts at 0 (Sated)");
+    assert_eq!(t.sheltered_until, None, "starts exposed");
+    assert_eq!(t.starvation_drain_step, 0);
+    assert_eq!(t.dehydration_drain_step, 0);
+}
+
+#[test]
+fn tribute_legacy_json_loads_with_defaults() {
+    // JSON missing the new fields entirely (simulates a saved game from
+    // before this feature landed). serde(default) must populate them.
+    let legacy = r#"{
+        "name": "Legacy",
+        "district": null,
+        "avatar": null,
+        "items": [],
+        "is_hidden": false,
+        "attributes": {
+            "health": 100, "stamina": 50, "sanity": 50,
+            "strength": 50, "defense": 50, "bravery": 50, "intelligence": 50
+        },
+        "status": "Healthy"
+    }"#;
+    let t: Tribute = serde_json::from_str(legacy).expect("legacy load must succeed");
+    assert_eq!(t.hunger, 0);
+    assert_eq!(t.thirst, 0);
+    assert_eq!(t.sheltered_until, None);
+    assert_eq!(t.starvation_drain_step, 0);
+    assert_eq!(t.dehydration_drain_step, 0);
+}
+```
+
+(The legacy JSON shape may need adjusting to match the actual `Tribute` minimum required fields — read the existing struct first and trim or extend the JSON to match. The point is: a doc with no survival fields must deserialize.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --package game --lib tributes::tests::tribute_default_survival_fields_are_zero_and_none tributes::tests::tribute_legacy_json_loads_with_defaults`
+Expected: FAIL — `no field 'hunger' on type 'Tribute'`.
+
+- [ ] **Step 3: Add the fields**
+
+In `game/src/tributes/mod.rs`, in the `pub struct Tribute { ... }` definition, add (placement near the other tribute state fields):
+
+```rust
+    #[serde(default)]
+    pub hunger: u8,
+    #[serde(default)]
+    pub thirst: u8,
+    #[serde(default)]
+    pub sheltered_until: Option<u32>,
+    #[serde(default)]
+    pub starvation_drain_step: u8,
+    #[serde(default)]
+    pub dehydration_drain_step: u8,
+```
+
+In `Tribute::new(...)` (around line 229), add field initializers (all zero / None):
+
+```rust
+            hunger: 0,
+            thirst: 0,
+            sheltered_until: None,
+            starvation_drain_step: 0,
+            dehydration_drain_step: 0,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib tributes::tests`
+Expected: PASS — both new tests green; existing tribute tests still green.
+
+- [ ] **Step 5: Update SurrealDB schema**
+
+Locate the tribute schema file (`schemas/tribute.surql` or similar — `ls schemas/`). Add (with permissive defaults so existing rows load):
+
+```surql
+DEFINE FIELD hunger                  ON TABLE tribute TYPE int DEFAULT 0;
+DEFINE FIELD thirst                  ON TABLE tribute TYPE int DEFAULT 0;
+DEFINE FIELD sheltered_until         ON TABLE tribute TYPE option<int>;
+DEFINE FIELD starvation_drain_step   ON TABLE tribute TYPE int DEFAULT 0;
+DEFINE FIELD dehydration_drain_step  ON TABLE tribute TYPE int DEFAULT 0;
+```
+
+Add a new migration definition file under `migrations/definitions/` if the project requires explicit migration steps (check the `surrealdb-migrations` setup before deciding). If migrations run at startup against the existing db, that is sufficient.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(game): add hunger/thirst/shelter fields to Tribute
+
+Adds the persistent state for the survival system to the Tribute struct
+with serde(default) so existing JSON saves load cleanly. SurrealDB
+schema updated with DEFAULT values.
+
+Fields:
+- hunger: u8 (debt counter, 0 = Sated)
+- thirst: u8 (debt counter, 0 = Sated)
+- sheltered_until: Option<u32> (phase index)
+- starvation_drain_step: u8 (escalating HP drain counter)
+- dehydration_drain_step: u8 (escalating HP drain counter)
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 5: Hunger/Thirst band enums + classification
+
+**Files:**
+- Create: `game/src/tributes/survival.rs`
+- Modify: `game/src/tributes/mod.rs` (add `pub mod survival;`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `game/src/tributes/survival.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum HungerBand {
+    Sated,
+    Peckish,
+    Hungry,
+    Starving,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ThirstBand {
+    Sated,
+    Thirsty,
+    Parched,
+    Dehydrated,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(0, HungerBand::Sated)]
+    #[case(1, HungerBand::Peckish)]
+    #[case(2, HungerBand::Peckish)]
+    #[case(3, HungerBand::Hungry)]
+    #[case(4, HungerBand::Hungry)]
+    #[case(5, HungerBand::Starving)]
+    #[case(99, HungerBand::Starving)]
+    fn hunger_band_thresholds(#[case] value: u8, #[case] expected: HungerBand) {
+        assert_eq!(hunger_band(value), expected);
+    }
+
+    #[rstest]
+    #[case(0, ThirstBand::Sated)]
+    #[case(1, ThirstBand::Thirsty)]
+    #[case(2, ThirstBand::Parched)]
+    #[case(3, ThirstBand::Dehydrated)]
+    #[case(99, ThirstBand::Dehydrated)]
+    fn thirst_band_thresholds(#[case] value: u8, #[case] expected: ThirstBand) {
+        assert_eq!(thirst_band(value), expected);
+    }
+
+    #[test]
+    fn hunger_starving_is_publicly_visible() {
+        assert!(hunger_band_is_public(HungerBand::Starving));
+        assert!(hunger_band_is_public(HungerBand::Hungry));
+        assert!(!hunger_band_is_public(HungerBand::Peckish));
+        assert!(!hunger_band_is_public(HungerBand::Sated));
+    }
+
+    #[test]
+    fn thirst_dehydrated_is_publicly_visible() {
+        assert!(thirst_band_is_public(ThirstBand::Dehydrated));
+        assert!(thirst_band_is_public(ThirstBand::Parched));
+        assert!(!thirst_band_is_public(ThirstBand::Thirsty));
+        assert!(!thirst_band_is_public(ThirstBand::Sated));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --package game --lib tributes::survival`
+Expected: FAIL — `hunger_band` / `thirst_band` / `hunger_band_is_public` / `thirst_band_is_public` undefined.
+
+- [ ] **Step 3: Implement**
+
+Add to `game/src/tributes/survival.rs` above the test module:
+
+```rust
+pub fn hunger_band(value: u8) -> HungerBand {
+    match value {
+        0 => HungerBand::Sated,
+        1..=2 => HungerBand::Peckish,
+        3..=4 => HungerBand::Hungry,
+        _ => HungerBand::Starving,
+    }
+}
+
+pub fn thirst_band(value: u8) -> ThirstBand {
+    match value {
+        0 => ThirstBand::Sated,
+        1 => ThirstBand::Thirsty,
+        2 => ThirstBand::Parched,
+        _ => ThirstBand::Dehydrated,
+    }
+}
+
+/// True if a band-change event into this band should be surfaced in the
+/// public timeline (Action panel). Lower bands are private/Inspect-only.
+pub fn hunger_band_is_public(band: HungerBand) -> bool {
+    matches!(band, HungerBand::Hungry | HungerBand::Starving)
+}
+
+pub fn thirst_band_is_public(band: ThirstBand) -> bool {
+    matches!(band, ThirstBand::Parched | ThirstBand::Dehydrated)
+}
+```
+
+In `game/src/tributes/mod.rs`, add to the module declarations (with the other `pub mod`s):
+
+```rust
+pub mod survival;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib tributes::survival`
+Expected: PASS — all band tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(game): add HungerBand/ThirstBand classification
+
+Pure functions mapping debt-counter values to bands and identifying
+which band crossings are publicly visible vs private/Inspect-only.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 6: Survival tick (counters + weather/shelter modulation)
+
+**Files:**
+- Modify: `game/src/tributes/survival.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `game/src/tributes/survival.rs` test module:
+
+```rust
+    use crate::areas::weather::Weather;
+    use crate::tributes::Tribute;
+
+    fn baseline_tribute() -> Tribute {
+        let mut t = Tribute::new("Test".to_string(), None, None);
+        // Mid-range strength + stamina: baseline ticks.
+        t.attributes.strength = 50;
+        t.attributes.stamina = 50;
+        t
+    }
+
+    #[test]
+    fn survival_tick_baseline_clear_exposed() {
+        let mut t = baseline_tribute();
+        tick_survival(&mut t, &Weather::Clear, /* sheltered = */ false);
+        assert_eq!(t.hunger, 1);
+        assert_eq!(t.thirst, 1);
+    }
+
+    #[test]
+    fn survival_tick_heatwave_exposed_adds_thirst() {
+        let mut t = baseline_tribute();
+        tick_survival(&mut t, &Weather::Heatwave, false);
+        assert_eq!(t.hunger, 1);
+        assert_eq!(t.thirst, 2, "heatwave + exposed adds +1 thirst");
+    }
+
+    #[test]
+    fn survival_tick_blizzard_exposed_adds_hunger() {
+        let mut t = baseline_tribute();
+        tick_survival(&mut t, &Weather::Blizzard, false);
+        assert_eq!(t.hunger, 2, "blizzard + exposed adds +1 hunger");
+        assert_eq!(t.thirst, 1);
+    }
+
+    #[test]
+    fn survival_tick_sheltered_suppresses_weather_modifier() {
+        let mut t = baseline_tribute();
+        tick_survival(&mut t, &Weather::Heatwave, true);
+        assert_eq!(t.thirst, 1, "shelter suppresses heatwave bonus");
+        let mut t2 = baseline_tribute();
+        tick_survival(&mut t2, &Weather::Blizzard, true);
+        assert_eq!(t2.hunger, 1, "shelter suppresses blizzard bonus");
+    }
+
+    #[test]
+    fn survival_tick_high_strength_increases_hunger() {
+        let mut t = baseline_tribute();
+        t.attributes.strength = 80; // high
+        tick_survival(&mut t, &Weather::Clear, false);
+        assert_eq!(t.hunger, 2, "high-strength bodies burn more calories");
+    }
+
+    #[test]
+    fn survival_tick_high_stamina_increases_thirst() {
+        let mut t = baseline_tribute();
+        t.attributes.stamina = 80;
+        tick_survival(&mut t, &Weather::Clear, false);
+        assert_eq!(t.thirst, 2);
+    }
+
+    #[test]
+    fn survival_tick_low_strength_skips_hunger_every_other_phase() {
+        let mut t = baseline_tribute();
+        t.attributes.strength = 20; // low
+        // Phase 1: skip
+        tick_survival(&mut t, &Weather::Clear, false);
+        assert_eq!(t.hunger, 0, "low-strength skips first phase");
+        // Phase 2: tick
+        tick_survival(&mut t, &Weather::Clear, false);
+        assert_eq!(t.hunger, 1, "low-strength ticks every other phase");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --package game --lib tributes::survival::tests::survival_tick`
+Expected: FAIL — `tick_survival` undefined.
+
+- [ ] **Step 3: Implement**
+
+Add to `game/src/tributes/survival.rs` above the test module:
+
+```rust
+use crate::areas::weather::Weather;
+use crate::tributes::Tribute;
+
+const HIGH_ATTR_THRESHOLD: u32 = 75;
+const LOW_ATTR_THRESHOLD: u32 = 25;
+
+/// Mutates `tribute` in place to advance one phase of survival (hunger + thirst).
+///
+/// Tick rules (per spec):
+/// - Base +1 hunger and +1 thirst per phase.
+/// - High strength (>= HIGH_ATTR_THRESHOLD) adds +1 hunger.
+/// - Low strength (<= LOW_ATTR_THRESHOLD) ticks hunger every other phase.
+/// - High stamina adds +1 thirst; low stamina ticks thirst every other phase.
+/// - If exposed (not sheltered) AND weather is Blizzard: +1 hunger.
+/// - If exposed AND weather is Heatwave: +1 thirst.
+///
+/// Whether HP loss is applied for Starving/Dehydrated states is handled by
+/// `apply_starvation_drain` / `apply_dehydration_drain`, called separately.
+pub fn tick_survival(tribute: &mut Tribute, weather: &Weather, sheltered: bool) {
+    let strength = tribute.attributes.strength;
+    let stamina = tribute.attributes.stamina;
+
+    let hunger_delta: u8 = if strength <= LOW_ATTR_THRESHOLD {
+        // Tick every other phase: use the parity of the existing counter as
+        // a deterministic skip mechanism.
+        if tribute.hunger % 2 == 0 { 0 } else { 1 }
+    } else if strength >= HIGH_ATTR_THRESHOLD {
+        2
+    } else {
+        1
+    };
+
+    let thirst_delta: u8 = if stamina <= LOW_ATTR_THRESHOLD {
+        if tribute.thirst % 2 == 0 { 0 } else { 1 }
+    } else if stamina >= HIGH_ATTR_THRESHOLD {
+        2
+    } else {
+        1
+    };
+
+    let weather_hunger_bonus: u8 = if !sheltered && matches!(weather, Weather::Blizzard) { 1 } else { 0 };
+    let weather_thirst_bonus: u8 = if !sheltered && matches!(weather, Weather::Heatwave) { 1 } else { 0 };
+
+    tribute.hunger = tribute.hunger.saturating_add(hunger_delta + weather_hunger_bonus);
+    tribute.thirst = tribute.thirst.saturating_add(thirst_delta + weather_thirst_bonus);
+}
+```
+
+**Note on the low-attribute "every other phase" mechanic:** the parity-of-counter trick is deterministic and avoids needing extra state. The first tick is skipped; subsequent ticks alternate. This means a freshly-created tribute with low strength will skip its first hunger tick, then tick on subsequent phases as parity dictates. The low-strength test above relies on that order.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib tributes::survival`
+Expected: PASS — all tick tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(game): implement survival tick (hunger + thirst)
+
+Mutates a Tribute's hunger and thirst counters per phase based on
+attribute modulation (strength <-> hunger, stamina <-> thirst) and
+weather/shelter modifiers (Blizzard, Heatwave). Pure with respect to
+external state aside from the tribute mutation.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 7: Escalating starvation/dehydration drain
+
+**Files:**
+- Modify: `game/src/tributes/survival.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `game/src/tributes/survival.rs` test module:
+
+```rust
+    fn starving_tribute() -> Tribute {
+        let mut t = baseline_tribute();
+        t.hunger = 5; // Starving band
+        t.attributes.health = 100;
+        t.starvation_drain_step = 0;
+        t
+    }
+
+    #[test]
+    fn starvation_drain_escalates_each_phase() {
+        let mut t = starving_tribute();
+        let lost1 = apply_starvation_drain(&mut t);
+        assert_eq!(lost1, 1, "first phase: -1 HP");
+        assert_eq!(t.attributes.health, 99);
+        assert_eq!(t.starvation_drain_step, 1);
+
+        let lost2 = apply_starvation_drain(&mut t);
+        assert_eq!(lost2, 2, "second phase: -2 HP");
+        assert_eq!(t.attributes.health, 97);
+        assert_eq!(t.starvation_drain_step, 2);
+
+        let lost3 = apply_starvation_drain(&mut t);
+        assert_eq!(lost3, 3);
+        assert_eq!(t.attributes.health, 94);
+    }
+
+    #[test]
+    fn starvation_drain_no_op_when_not_starving() {
+        let mut t = baseline_tribute();
+        t.hunger = 3; // Hungry, not Starving
+        let lost = apply_starvation_drain(&mut t);
+        assert_eq!(lost, 0);
+        assert_eq!(t.starvation_drain_step, 0);
+    }
+
+    #[test]
+    fn eating_food_resets_drain_step_and_reduces_hunger() {
+        let mut t = starving_tribute();
+        apply_starvation_drain(&mut t); // drain_step = 1
+        apply_starvation_drain(&mut t); // drain_step = 2
+        eat_food(&mut t, 3);
+        assert_eq!(t.hunger, 2, "5 - 3 = 2 (Peckish band)");
+        assert_eq!(t.starvation_drain_step, 0, "eating resets drain");
+    }
+
+    #[test]
+    fn dehydration_drain_escalates_independently_of_starvation() {
+        let mut t = baseline_tribute();
+        t.thirst = 3;
+        t.hunger = 5;
+        let h1 = apply_dehydration_drain(&mut t);
+        let s1 = apply_starvation_drain(&mut t);
+        assert_eq!(h1, 1);
+        assert_eq!(s1, 1);
+        assert_eq!(t.attributes.health, 98, "stacked drain: -2 HP first phase");
+    }
+
+    #[test]
+    fn drink_water_resets_dehydration_step() {
+        let mut t = baseline_tribute();
+        t.thirst = 3;
+        apply_dehydration_drain(&mut t);
+        drink_water(&mut t, 2);
+        assert_eq!(t.thirst, 1);
+        assert_eq!(t.dehydration_drain_step, 0);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --package game --lib tributes::survival`
+Expected: FAIL — `apply_starvation_drain` / `apply_dehydration_drain` / `eat_food` / `drink_water` undefined.
+
+- [ ] **Step 3: Implement**
+
+Append to `game/src/tributes/survival.rs` above the test module:
+
+```rust
+/// Applies escalating starvation HP drain. Returns HP lost this phase (0 if
+/// the tribute is not in the Starving band).
+pub fn apply_starvation_drain(tribute: &mut Tribute) -> u32 {
+    if hunger_band(tribute.hunger) != HungerBand::Starving {
+        return 0;
+    }
+    tribute.starvation_drain_step = tribute.starvation_drain_step.saturating_add(1);
+    let lost = tribute.starvation_drain_step as u32;
+    tribute.attributes.health = tribute.attributes.health.saturating_sub(lost);
+    lost
+}
+
+/// Applies escalating dehydration HP drain. Returns HP lost this phase.
+pub fn apply_dehydration_drain(tribute: &mut Tribute) -> u32 {
+    if thirst_band(tribute.thirst) != ThirstBand::Dehydrated {
+        return 0;
+    }
+    tribute.dehydration_drain_step = tribute.dehydration_drain_step.saturating_add(1);
+    let lost = tribute.dehydration_drain_step as u32;
+    tribute.attributes.health = tribute.attributes.health.saturating_sub(lost);
+    lost
+}
+
+/// Reduces hunger by `amount`, resetting the starvation drain counter.
+pub fn eat_food(tribute: &mut Tribute, amount: u8) {
+    tribute.hunger = tribute.hunger.saturating_sub(amount);
+    tribute.starvation_drain_step = 0;
+}
+
+/// Reduces thirst by `amount`, resetting the dehydration drain counter.
+pub fn drink_water(tribute: &mut Tribute, amount: u8) {
+    tribute.thirst = tribute.thirst.saturating_sub(amount);
+    tribute.dehydration_drain_step = 0;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib tributes::survival`
+Expected: PASS — all drain tests green; previous tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(game): implement escalating starvation/dehydration drain
+
+Each phase a tribute remains in Starving or Dehydrated, HP drain
+increases by 1 (-1, -2, -3...). Eating/drinking resets the drain step.
+Hunger and thirst drains stack independently.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 8: `ItemType` Food/Water variants + helpers
+
+**Files:**
+- Modify: `game/src/items/mod.rs:340-380` (the `ItemType` enum + `Display`/`FromStr` impls)
+
+- [ ] **Step 1: Audit the existing ItemType serialization shape first**
+
+Run: `cargo test --package game --lib items 2>&1 | tail -20` — verify existing tests pass.
+
+Check how `Item.item_type` round-trips:
+
+Run: `grep -n "serde" game/src/items/mod.rs | head -10`
+
+The struct uses derived `Serialize`/`Deserialize`. With unit variants the JSON form is the variant name as a string (`"Consumable"`). Adding tuple variants `Food(u8)` and `Water(u8)` will serialize as `{"Food": 3}` — a different shape. This affects backward compat for any persisted items.
+
+Decision for v1: add the new variants and accept that existing rows continue to work (they're still `"Consumable"` / `"Weapon"` strings). New rows containing food/water will be `{"Food": 3}` / `{"Water": 2}`. Round-trip the new shapes in tests.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to the existing `#[cfg(test)] mod tests { ... }` block in `game/src/items/mod.rs`:
+
+```rust
+#[test]
+fn item_type_food_serializes_round_trip() {
+    let it = ItemType::Food(3);
+    let json = serde_json::to_string(&it).unwrap();
+    let back: ItemType = serde_json::from_str(&json).unwrap();
+    assert_eq!(it, back);
+}
+
+#[test]
+fn item_type_water_serializes_round_trip() {
+    let it = ItemType::Water(2);
+    let json = serde_json::to_string(&it).unwrap();
+    let back: ItemType = serde_json::from_str(&json).unwrap();
+    assert_eq!(it, back);
+}
+
+#[test]
+fn item_type_legacy_consumable_string_still_loads() {
+    let back: ItemType = serde_json::from_str("\"Consumable\"").unwrap();
+    assert_eq!(back, ItemType::Consumable);
+}
+
+#[test]
+fn item_type_food_helpers() {
+    assert!(ItemType::Food(3).is_food());
+    assert_eq!(ItemType::Food(3).food_value(), Some(3));
+    assert_eq!(ItemType::Water(2).water_value(), Some(2));
+    assert!(!ItemType::Weapon.is_food());
+    assert_eq!(ItemType::Consumable.food_value(), None);
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test --package game --lib items::tests`
+Expected: FAIL — `Food` / `Water` / `is_food` etc. undefined.
+
+- [ ] **Step 4: Implement**
+
+In `game/src/items/mod.rs`, modify the `ItemType` enum:
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ItemType {
+    Consumable,
+    Weapon,
+    Food(u8),
+    Water(u8),
+}
+```
+
+Update the `random()`, `Display`, and `FromStr` impls. For `FromStr`, parse `food:N` / `water:N` forms. For `Display`, render as `food(3)` etc. Example replacement:
+
+```rust
+impl ItemType {
+    pub fn random() -> ItemType {
+        let mut rng = SmallRng::from_rng(&mut rand::rng());
+        // Weighted distribution: weapons and consumables remain dominant; food
+        // and water enter the spawn pool but are rarer.
+        match rng.random_range(0..10) {
+            0..=3 => ItemType::Consumable,
+            4..=6 => ItemType::Weapon,
+            7..=8 => ItemType::Food(rng.random_range(1..=5)),
+            _ => ItemType::Water(rng.random_range(1..=3)),
+        }
+    }
+
+    pub fn is_food(&self) -> bool {
+        matches!(self, ItemType::Food(_))
+    }
+
+    pub fn is_water(&self) -> bool {
+        matches!(self, ItemType::Water(_))
+    }
+
+    pub fn food_value(&self) -> Option<u8> {
+        if let ItemType::Food(n) = self { Some(*n) } else { None }
+    }
+
+    pub fn water_value(&self) -> Option<u8> {
+        if let ItemType::Water(n) = self { Some(*n) } else { None }
+    }
+}
+```
+
+Update `Display`:
+
+```rust
+impl Display for ItemType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ItemType::Consumable => write!(f, "consumable"),
+            ItemType::Weapon => write!(f, "weapon"),
+            ItemType::Food(n) => write!(f, "food({})", n),
+            ItemType::Water(n) => write!(f, "water({})", n),
+        }
+    }
+}
+```
+
+Update `FromStr` to parse the new shapes:
+
+```rust
+impl FromStr for ItemType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lower = s.to_lowercase();
+        if let Some(inner) = lower.strip_prefix("food(").and_then(|x| x.strip_suffix(')')) {
+            return inner.parse::<u8>().map(ItemType::Food).map_err(|e| e.to_string());
+        }
+        if let Some(inner) = lower.strip_prefix("water(").and_then(|x| x.strip_suffix(')')) {
+            return inner.parse::<u8>().map(ItemType::Water).map_err(|e| e.to_string());
+        }
+        match lower.as_str() {
+            "consumable" => Ok(ItemType::Consumable),
+            "weapon" => Ok(ItemType::Weapon),
+            _ => Err("Invalid item type".to_string()),
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib items`
+Expected: PASS — new and existing item tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(game): add Food(u8)/Water(u8) ItemType variants
+
+Food(n) and Water(n) variants represent portable hunger/thirst debt
+relief. Helpers is_food(), food_value(), is_water(), water_value().
+Display renders 'food(3)' / 'water(2)'; FromStr parses the same.
+Legacy 'Consumable'/'Weapon' string-tag rows continue to load.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 9: New `Action` variants for survival
+
+**Files:**
+- Modify: `game/src/tributes/actions.rs:21-35` (the `Action` enum)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing test module in `game/src/tributes/actions.rs` (or create one if absent):
+
+```rust
+#[cfg(test)]
+mod survival_action_tests {
+    use super::*;
+
+    #[test]
+    fn survival_actions_exist_and_serialize() {
+        let actions = vec![
+            Action::SeekShelter,
+            Action::Forage,
+            Action::DrinkFromTerrain,
+        ];
+        for a in actions {
+            let json = serde_json::to_string(&a).unwrap();
+            let back: Action = serde_json::from_str(&json).unwrap();
+            assert_eq!(format!("{:?}", a), format!("{:?}", back));
+        }
+    }
+
+    #[test]
+    fn eat_action_carries_item_value() {
+        // Construct Eat with a Food item; round-trip.
+        // (Item construction details depend on the existing Item::new signature;
+        //  the engineer should construct a minimal Food(3) item per the codebase's
+        //  Item::new helper.)
+        // Smoke test: variant exists.
+        let _ = Action::Eat(None);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --package game --lib tributes::actions::survival_action_tests`
+Expected: FAIL — `SeekShelter` / `Forage` / `DrinkFromTerrain` / `Eat` variants undefined.
+
+- [ ] **Step 3: Implement**
+
+In `game/src/tributes/actions.rs`, extend the `Action` enum:
+
+```rust
+pub enum Action {
+    None,
+    Move(Option<Area>),
+    Rest,
+    UseItem(Option<Item>),
+    Attack,
+    Hide,
+    TakeItem,
+    // ... existing variants kept in order
+    ProposeAlliance,
+
+    // Survival actions (added by shelter+hunger/thirst spec).
+    SeekShelter,
+    Forage,
+    DrinkFromTerrain,
+    Eat(Option<Item>),
+    DrinkItem(Option<Item>),
+}
+```
+
+(Verify the existing variants list is preserved exactly; only append the new ones.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib tributes::actions`
+Expected: PASS — survival tests green; existing action tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(game): add survival Action variants
+
+Five new actions: SeekShelter, Forage, DrinkFromTerrain (no item),
+Eat(item), DrinkItem(item). Wiring into Brain happens in Task 10.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 10: Brain survival overrides
+
+**Files:**
+- Modify: `game/src/tributes/brains.rs`
+
+- [ ] **Step 1: Read the existing Brain decision flow**
+
+Run: `grep -nE "fn (decide|choose|select|pick|next_action)" game/src/tributes/brains.rs | head -20`
+
+Read the function that produces an `Action` from a tribute + context. Note its signature and where to insert the override checks (before existing weighted scoring).
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to the existing `#[cfg(test)]` block in `game/src/tributes/brains.rs`:
+
+```rust
+#[cfg(test)]
+mod survival_override_tests {
+    use super::*;
+    use crate::areas::weather::Weather;
+    use crate::items::{Item, ItemType};
+    use crate::terrain::types::BaseTerrain;
+    use crate::tributes::Tribute;
+    use crate::tributes::actions::Action;
+
+    fn dehydrated_at_water(terrain: BaseTerrain) -> Tribute {
+        let mut t = Tribute::new("Test".to_string(), None, None);
+        t.thirst = 3; // Dehydrated
+        // place tribute at an area whose terrain has water_source > 0;
+        // implementation-specific helper is invoked by survival_override(...)
+        t
+    }
+
+    #[test]
+    fn override_dehydrated_at_water_terrain_picks_drink() {
+        let t = dehydrated_at_water(BaseTerrain::Wetlands);
+        let action = survival_override(&t, BaseTerrain::Wetlands, &Weather::Clear, /* in_combat */ false);
+        assert_eq!(action, Some(Action::DrinkFromTerrain));
+    }
+
+    #[test]
+    fn override_dehydrated_with_water_item_picks_drink_item() {
+        let mut t = dehydrated_at_water(BaseTerrain::Desert);
+        let water = Item::new_simple_water(2); // helper to be added inline if missing
+        t.items.push(water);
+        let action = survival_override(&t, BaseTerrain::Desert, &Weather::Clear, false);
+        assert!(matches!(action, Some(Action::DrinkItem(_))));
+    }
+
+    #[test]
+    fn override_starving_with_food_picks_eat() {
+        let mut t = Tribute::new("Test".to_string(), None, None);
+        t.hunger = 5;
+        let food = Item::new_simple_food(3);
+        t.items.push(food);
+        let action = survival_override(&t, BaseTerrain::Desert, &Weather::Clear, false);
+        assert!(matches!(action, Some(Action::Eat(_))));
+    }
+
+    #[test]
+    fn override_starving_at_forageable_terrain_no_inventory_picks_forage() {
+        let mut t = Tribute::new("Test".to_string(), None, None);
+        t.hunger = 5;
+        let action = survival_override(&t, BaseTerrain::Wetlands, &Weather::Clear, false);
+        assert_eq!(action, Some(Action::Forage));
+    }
+
+    #[test]
+    fn override_starving_in_combat_returns_none() {
+        let mut t = Tribute::new("Test".to_string(), None, None);
+        t.hunger = 5;
+        let action = survival_override(&t, BaseTerrain::Wetlands, &Weather::Clear, /* in_combat */ true);
+        assert_eq!(action, None);
+    }
+
+    #[test]
+    fn override_hungry_not_starving_returns_none() {
+        let mut t = Tribute::new("Test".to_string(), None, None);
+        t.hunger = 3; // Hungry, not Starving
+        let action = survival_override(&t, BaseTerrain::Wetlands, &Weather::Clear, false);
+        assert_eq!(action, None);
+    }
+}
+```
+
+(`Item::new_simple_food(n)` and `Item::new_simple_water(n)` may need to be added to `game/src/items/mod.rs` as small test-friendly constructors if the existing `Item::new` is inconvenient. Add them as part of this task if needed.)
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test --package game --lib tributes::brains::survival_override_tests`
+Expected: FAIL — `survival_override` undefined.
+
+- [ ] **Step 4: Implement**
+
+Add to `game/src/tributes/brains.rs`:
+
+```rust
+use crate::areas::water::water_source;
+use crate::areas::forage::forage_richness;
+use crate::areas::weather::Weather;
+use crate::terrain::types::BaseTerrain;
+use crate::tributes::Tribute;
+use crate::tributes::actions::Action;
+use crate::tributes::survival::{hunger_band, thirst_band, HungerBand, ThirstBand};
+
+/// Survival override branch. Returns Some(action) to short-circuit the
+/// Brain's normal weighted scoring; returns None to fall through.
+///
+/// Order (per spec):
+/// 1. Dehydrated + at water-source terrain -> Drink(area).
+/// 2. Dehydrated + Water item in inventory -> Drink(item).
+/// 3. Starving + Food item in inventory -> Eat(item).
+/// 4. Starving + at forageable terrain + not in combat -> Forage.
+///
+/// Active combat suppresses all overrides (the existing combat handling
+/// preempts decision-making upstream — this is a defensive guard).
+pub fn survival_override(
+    tribute: &Tribute,
+    terrain: BaseTerrain,
+    weather: &Weather,
+    in_combat: bool,
+) -> Option<Action> {
+    if in_combat {
+        return None;
+    }
+
+    let dehydrated = thirst_band(tribute.thirst) == ThirstBand::Dehydrated;
+    let starving = hunger_band(tribute.hunger) == HungerBand::Starving;
+
+    if dehydrated && water_source(terrain, weather) > 0 {
+        return Some(Action::DrinkFromTerrain);
+    }
+    if dehydrated {
+        if let Some(item) = tribute.items.iter().find(|i| i.item_type.is_water()).cloned() {
+            return Some(Action::DrinkItem(Some(item)));
+        }
+    }
+    if starving {
+        if let Some(item) = tribute.items.iter().find(|i| i.item_type.is_food()).cloned() {
+            return Some(Action::Eat(Some(item)));
+        }
+        if forage_richness(terrain) > 0 {
+            return Some(Action::Forage);
+        }
+    }
+
+    None
+}
+```
+
+Then locate the existing Brain entry point that produces an `Action` and insert a call to `survival_override(...)` ahead of the normal scoring path. Pseudo-shape:
+
+```rust
+// In the existing `decide` (or equivalent) function:
+if let Some(action) = survival_override(tribute, current_terrain, &Weather::current_weather_for(area), in_combat) {
+    return action;
+}
+// ... existing weighted scoring ...
+```
+
+The exact wiring depends on the existing function signature; the engineer should extract the necessary inputs (current area's terrain, weather lookup, combat flag) at the call site without restructuring the surrounding decision flow.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib tributes::brains`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(game): wire survival override branch into Brain
+
+Survival overrides are checked before the existing weighted scoring:
+1. Dehydrated + water-source terrain -> Drink(area)
+2. Dehydrated + Water item in inventory -> Drink(item)
+3. Starving + Food item in inventory -> Eat(item)
+4. Starving + forageable terrain + not in combat -> Forage
+
+Active combat suppresses all survival overrides.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 11: New `MessagePayload` events + `cause` constants
+
+**Files:**
+- Modify: `shared/src/messages.rs:117-205` (the `MessagePayload` enum and its `kind()` impl)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to (or create) the test module in `shared/src/messages.rs`:
+
+```rust
+#[cfg(test)]
+mod survival_event_tests {
+    use super::*;
+
+    #[test]
+    fn shelter_sought_round_trip() {
+        let p = MessagePayload::ShelterSought {
+            tribute: TributeRef { id: "t1".into(), name: "Cato".into() },
+            area: AreaRef { id: "a1".into(), name: "Forest".into() },
+            success: true,
+            roll: 2,
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: MessagePayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(format!("{:?}", p), format!("{:?}", back));
+    }
+
+    #[test]
+    fn band_change_payloads_exist() {
+        let _ = MessagePayload::HungerBandChanged {
+            tribute: TributeRef { id: "t1".into(), name: "Cato".into() },
+            from: "Sated".into(),
+            to: "Hungry".into(),
+        };
+        let _ = MessagePayload::ThirstBandChanged {
+            tribute: TributeRef { id: "t1".into(), name: "Cato".into() },
+            from: "Sated".into(),
+            to: "Parched".into(),
+        };
+    }
+
+    #[test]
+    fn cause_constants_exist() {
+        assert_eq!(CAUSE_STARVATION, "starvation");
+        assert_eq!(CAUSE_DEHYDRATION, "dehydration");
+    }
+}
+```
+
+(Adjust `TributeRef`/`AreaRef` construction to whatever the actual struct definitions in shared accept. Read those structs first.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --package shared --lib survival_event_tests`
+Expected: FAIL — variants and constants undefined.
+
+- [ ] **Step 3: Implement**
+
+In `shared/src/messages.rs`, add the new variants to `MessagePayload`:
+
+```rust
+    HungerBandChanged {
+        tribute: TributeRef,
+        from: String,
+        to: String,
+    },
+    ThirstBandChanged {
+        tribute: TributeRef,
+        from: String,
+        to: String,
+    },
+    ShelterSought {
+        tribute: TributeRef,
+        area: AreaRef,
+        success: bool,
+        roll: u8,
+    },
+    Foraged {
+        tribute: TributeRef,
+        area: AreaRef,
+        success: bool,
+        debt_recovered: u8,
+    },
+    Drank {
+        tribute: TributeRef,
+        source: DrinkSource,
+        debt_recovered: u8,
+    },
+    Ate {
+        tribute: TributeRef,
+        item: ItemRef,
+        debt_recovered: u8,
+    },
+```
+
+Add a sibling enum for the drink source:
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum DrinkSource {
+    Terrain { area: AreaRef },
+    Item { item: ItemRef },
+}
+```
+
+Add the cause constants at the top (or near the existing message kind constants):
+
+```rust
+pub const CAUSE_STARVATION: &str = "starvation";
+pub const CAUSE_DEHYDRATION: &str = "dehydration";
+```
+
+Update the `MessagePayload::kind()` impl to map the new variants to appropriate `MessageKind`s (likely `MessageKind::State` for band changes and survival actions; the engineer should pick consistent kinds based on the existing pattern).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --package shared --lib`
+Expected: PASS — all messages tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(shared): add survival message payloads + cause constants
+
+New MessagePayload variants for the shelter+hunger/thirst spec:
+HungerBandChanged, ThirstBandChanged, ShelterSought, Foraged, Drank, Ate.
+Adds DrinkSource enum and CAUSE_STARVATION/CAUSE_DEHYDRATION constants
+for use in TributeKilled events.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 12: Loot drop on death + survival tick wiring
+
+**Files:**
+- Modify: `game/src/tributes/lifecycle.rs` (drop items on RecentlyDead → Dead transition)
+- Modify: `game/src/games.rs` (call survival tick once per phase per tribute; emit band-change events; route starvation/dehydration deaths)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `game/src/tributes/lifecycle.rs` test module, add:
+
+```rust
+#[test]
+fn dead_tribute_drops_items_into_area() {
+    use crate::items::{Item, ItemType};
+
+    let mut tribute = Tribute::new("Doomed".to_string(), None, None);
+    tribute.items.push(Item::new_simple_food(3));
+    tribute.items.push(Item::new_simple_water(2));
+    tribute.attributes.health = 0;
+    tribute.status = TributeStatus::RecentlyDead;
+
+    let mut area_items: Vec<Item> = vec![];
+    drop_items_to_area(&mut tribute, &mut area_items);
+
+    assert_eq!(tribute.items.len(), 0, "tribute inventory cleared");
+    assert_eq!(area_items.len(), 2, "items moved to area");
+}
+
+#[test]
+fn drop_items_no_op_when_alive() {
+    use crate::items::{Item, ItemType};
+
+    let mut tribute = Tribute::new("Alive".to_string(), None, None);
+    tribute.items.push(Item::new_simple_food(3));
+    let mut area_items: Vec<Item> = vec![];
+    drop_items_to_area(&mut tribute, &mut area_items);
+
+    assert_eq!(tribute.items.len(), 1, "alive tribute keeps inventory");
+    assert_eq!(area_items.len(), 0);
+}
+```
+
+In `game/src/games.rs` test module, add a small integration test:
+
+```rust
+#[test]
+fn survival_tick_fires_once_per_phase_per_living_tribute() {
+    let mut game = Game::new("test");
+    // (use the existing helpers in this file for game/tribute setup)
+    // bootstrap two living tributes; call the per-phase survival entry
+    // point; assert hunger and thirst incremented by exactly 1 each.
+    // The exact phase entry function name lives in this file — locate it
+    // via grep for "process_turn_phase" or "advance_phase".
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --package game --lib lifecycle 2>&1 | tail -20`
+Expected: FAIL — `drop_items_to_area` undefined.
+
+- [ ] **Step 3: Implement loot drop**
+
+In `game/src/tributes/lifecycle.rs`:
+
+```rust
+use crate::items::Item;
+
+/// Moves all items from a freshly-dead tribute into the supplied area item
+/// vector. No-op for living tributes (Healthy/Wounded/etc.).
+pub fn drop_items_to_area(tribute: &mut Tribute, area_items: &mut Vec<Item>) {
+    use crate::tributes::TributeStatus;
+    if !matches!(tribute.status, TributeStatus::RecentlyDead | TributeStatus::Dead) {
+        return;
+    }
+    area_items.extend(tribute.items.drain(..));
+}
+```
+
+Then locate the lifecycle transition from `RecentlyDead` → `Dead` (or the kill site) in `lifecycle.rs` / `combat.rs` / `games.rs`. At the right moment (when a tribute is confirmed dead and the area is in scope), call `drop_items_to_area(&mut tribute, &mut area.items)`.
+
+- [ ] **Step 4: Wire the survival tick into the per-phase game loop**
+
+Find the per-phase loop in `game/src/games.rs` (search for `process_turn_phase`, `for tribute in`, or the top-level day/night cycle entry point). For every living tribute each phase:
+
+```rust
+// Pseudo-shape — adapt to actual loop variable names.
+let weather = current_weather(); // Task 1 stub
+let sheltered = tribute.sheltered_until.map_or(false, |until| until > self.current_phase_index());
+
+let prior_hunger_band = hunger_band(tribute.hunger);
+let prior_thirst_band = thirst_band(tribute.thirst);
+
+tick_survival(tribute, &weather, sheltered);
+
+let hp_lost_starv = apply_starvation_drain(tribute);
+let hp_lost_dehy = apply_dehydration_drain(tribute);
+
+// Emit band-change events if the band moved (filter by *_band_is_public for
+// publishing into the public timeline; private band changes still get logged
+// to the per-tribute Inspect feed in Plan 2).
+let new_hunger_band = hunger_band(tribute.hunger);
+if new_hunger_band != prior_hunger_band {
+    emit(MessagePayload::HungerBandChanged {
+        tribute: tribute.as_ref(),
+        from: format!("{:?}", prior_hunger_band),
+        to: format!("{:?}", new_hunger_band),
+    });
+    // Update TributeStatus::Starving on entry; clear on exit to a lower band.
+    if new_hunger_band == HungerBand::Starving {
+        tribute.status = TributeStatus::Starving;
+    } else if prior_hunger_band == HungerBand::Starving {
+        tribute.status = TributeStatus::Healthy;
+    }
+}
+// (Same shape for thirst.)
+
+// Death routing: if HP hit 0 *and* either drain landed, route through
+// TributeKilled with the appropriate cause.
+if tribute.attributes.health == 0 {
+    let cause = if hp_lost_dehy > 0 {
+        CAUSE_DEHYDRATION
+    } else if hp_lost_starv > 0 {
+        CAUSE_STARVATION
+    } else {
+        // existing causes
+        ""
+    };
+    if !cause.is_empty() {
+        emit(MessagePayload::TributeKilled {
+            victim: tribute.as_ref(),
+            killer: None,
+            cause: cause.to_string(),
+        });
+        tribute.status = TributeStatus::RecentlyDead;
+        // Drop items now that the tribute is dead.
+        drop_items_to_area(tribute, &mut area.items);
+    }
+}
+```
+
+The exact plumbing to access `area.items` from inside the per-tribute loop depends on how `games.rs` iterates. The engineer should reach for the same access pattern existing combat code uses to update area state.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cargo test --package game --lib`
+Expected: PASS — all new tests green; existing tests still green.
+
+Run: `cargo test --package shared --lib`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(game): wire survival tick + loot drop into game loop
+
+Per phase, each living tribute:
+- ticks hunger and thirst (Task 6)
+- applies escalating starvation/dehydration drain (Task 7)
+- emits HungerBandChanged/ThirstBandChanged on band crossing
+- updates TributeStatus::Starving/Dehydrated on band entry/exit
+- routes 0-HP-while-starving deaths through TributeKilled with
+  CAUSE_STARVATION / CAUSE_DEHYDRATION
+
+Lifecycle: on RecentlyDead/Dead, drop_items_to_area drains the
+tribute's inventory into the area's item vector.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 13: Add `Builder` and `ResourcefulForager` traits
+
+**Files:**
+- Modify: `game/src/tributes/traits.rs:9-30` (the `Trait` enum)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing test module in `game/src/tributes/traits.rs`:
+
+```rust
+#[test]
+fn survival_traits_round_trip() {
+    use serde_json;
+    for t in [Trait::Builder, Trait::ResourcefulForager] {
+        let json = serde_json::to_string(&t).unwrap();
+        let back: Trait = serde_json::from_str(&json).unwrap();
+        assert_eq!(t, back);
+    }
+}
+
+#[test]
+fn builder_and_forager_dont_conflict_with_each_other() {
+    // Convention check: traits should not conflict-pair with themselves
+    // in CONFLICTS table. Adapt to whatever conflict-checking helper exists.
+    // If CONFLICTS is a static array, scan it for these new entries.
+    let conflict_targets_for_builder = conflicts_of(Trait::Builder);
+    assert!(!conflict_targets_for_builder.contains(&Trait::ResourcefulForager));
+}
+```
+
+(`conflicts_of` is illustrative — use whatever conflict-query helper actually exists in the file. Replace with a direct CONFLICTS scan if needed.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --package game --lib tributes::traits`
+Expected: FAIL — `Builder` / `ResourcefulForager` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `game/src/tributes/traits.rs`, extend the `Trait` enum:
+
+```rust
+pub enum Trait {
+    // ...existing variants...
+    Asthmatic,
+    Nearsighted,
+    Tough,
+
+    // Survival traits (added by shelter+hunger/thirst spec).
+    Builder,
+    ResourcefulForager,
+}
+```
+
+Update any pattern matches on `Trait` that the compiler now flags as non-exhaustive. The simplest treatment: in any catch-all default-zero modifier function, no change needed; in any feature-specific match, add no-op arms unless the trait should affect that feature.
+
+Apply the trait's spec'd effects in the relevant call sites (these are spread across actions):
+
+In `game/src/tributes/brains.rs` (or wherever `SeekShelter` is rolled — see Plan 2 frontend smoke or earlier wiring):
+
+```rust
+fn shelter_trait_modifier(tribute: &Tribute) -> u8 {
+    if tribute.traits.contains(&Trait::Builder) { 1 } else { 0 }
+}
+
+fn forage_trait_modifier(tribute: &Tribute) -> u8 {
+    if tribute.traits.contains(&Trait::ResourcefulForager) { 1 } else { 0 }
+}
+```
+
+(Adapt to actual trait-list field name. The full action-roll wiring for `SeekShelter` / `Forage` / `Drink` / food-poisoning rolls happens at the action-resolution site; if that site does not yet exist for these new actions, this task or Plan 2 should add minimal stub resolvers that consult these modifiers.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --package game --lib tributes::traits`
+Expected: PASS.
+
+Run: `cargo test --package game --lib`
+Expected: PASS — workspace still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(game): add Builder + ResourcefulForager traits
+
+Builder: +1 to SeekShelter roll, +1 phase to successful shelter duration.
+ResourcefulForager: +1 to Forage roll, halved food-poisoning chance.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 14: Integration tests (deterministic survival runs)
+
+**Files:**
+- Create: `game/tests/survival_integration.rs` (or extend an existing integration-tests file under `game/tests/` if the project already houses one).
+
+- [ ] **Step 1: Check for an existing integration test directory**
+
+Run: `ls game/tests/ 2>/dev/null && cat game/tests/*.rs 2>/dev/null | head -40`
+
+If `game/tests/` does not exist, the engineer should create the file there. Tests in `game/tests/` are workspace-level integration tests and have access only to `pub` items.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `game/tests/survival_integration.rs`:
+
+```rust
+use game::areas::weather::Weather;
+use game::tributes::Tribute;
+use game::tributes::survival::{
+    apply_dehydration_drain, apply_starvation_drain, hunger_band, thirst_band,
+    drink_water, eat_food, tick_survival, HungerBand, ThirstBand,
+};
+
+#[test]
+fn no_food_no_water_dies_of_dehydration_first() {
+    let mut t = Tribute::new("Test".to_string(), None, None);
+    t.attributes.health = 100;
+    t.attributes.strength = 50;
+    t.attributes.stamina = 50;
+    let mut phases_to_dehydrated_band = 0u32;
+    for phase in 1..=20 {
+        tick_survival(&mut t, &Weather::Clear, false);
+        if thirst_band(t.thirst) == ThirstBand::Dehydrated && phases_to_dehydrated_band == 0 {
+            phases_to_dehydrated_band = phase;
+        }
+        let _ = apply_dehydration_drain(&mut t);
+        let _ = apply_starvation_drain(&mut t);
+        if t.attributes.health == 0 {
+            // Confirm thirst drove the death, not starvation.
+            assert_eq!(thirst_band(t.thirst), ThirstBand::Dehydrated);
+            assert!(
+                phases_to_dehydrated_band > 0
+                    && phases_to_dehydrated_band < phase,
+                "must reach Dehydrated before death"
+            );
+            return;
+        }
+    }
+    panic!("tribute did not die in 20 phases");
+}
+
+#[test]
+fn carrying_water_extends_survival() {
+    use game::tributes::Tribute;
+
+    fn run_to_death(start_thirst_relief: u8) -> u32 {
+        let mut t = Tribute::new("Test".to_string(), None, None);
+        t.attributes.health = 100;
+        t.attributes.strength = 50;
+        t.attributes.stamina = 50;
+        // Pre-stock relief: drink it up at phase 0 to reset the clock.
+        if start_thirst_relief > 0 {
+            t.thirst = 3; // Dehydrated, then drink to reset
+            drink_water(&mut t, start_thirst_relief);
+        }
+        for phase in 1..=30 {
+            tick_survival(&mut t, &Weather::Clear, false);
+            apply_dehydration_drain(&mut t);
+            apply_starvation_drain(&mut t);
+            if t.attributes.health == 0 {
+                return phase;
+            }
+        }
+        30
+    }
+
+    let baseline = run_to_death(0);
+    let with_water = run_to_death(3);
+    assert!(
+        with_water > baseline + 2,
+        "carrying water should extend life by at least 2 phases (baseline={baseline}, with_water={with_water})"
+    );
+}
+
+#[test]
+fn sheltered_in_heatwave_does_not_accrue_weather_thirst() {
+    let mut t_sheltered = Tribute::new("S".to_string(), None, None);
+    t_sheltered.attributes.strength = 50;
+    t_sheltered.attributes.stamina = 50;
+    let mut t_exposed = Tribute::new("E".to_string(), None, None);
+    t_exposed.attributes.strength = 50;
+    t_exposed.attributes.stamina = 50;
+
+    for _ in 0..3 {
+        tick_survival(&mut t_sheltered, &Weather::Heatwave, true);
+        tick_survival(&mut t_exposed, &Weather::Heatwave, false);
+    }
+    assert!(t_exposed.thirst > t_sheltered.thirst,
+        "exposed tribute should accrue more thirst (sheltered={}, exposed={})",
+        t_sheltered.thirst, t_exposed.thirst);
+}
+```
+
+(Skip the death-cause-routing and band-event-publication tests for this task if the per-phase loop wiring in `games.rs` is hard to drive headlessly — call those out as follow-ups in `bd` if so. The three tests above cover the core deterministic behaviors.)
+
+- [ ] **Step 3: Run tests to verify they fail (or pass, as appropriate)**
+
+Run: `cargo test --package game --test survival_integration`
+Expected: PASS — by this point all helpers exist. If any test fails, fix the helper or test logic before moving on.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "test(game): integration tests for survival system
+
+Three deterministic integration tests:
+- no food/water -> dies of dehydration first
+- carrying water extends survival by >= 2 phases
+- shelter suppresses weather thirst modifier in Heatwave
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 15: Final quality pass + bookmark + PR
+
+- [ ] **Step 1: Format and lint**
+
+Run: `just fmt`
+Run: `just quality`
+Expected: clean — formatter no-op, no clippy warnings, all tests pass.
+
+- [ ] **Step 2: Verify SurrealDB migration applies cleanly**
+
+Run: `just dev` (in another terminal) and manually create a fresh game; confirm the new tribute fields persist and load. If a migration definition was added under `migrations/definitions/`, confirm `surrealdb-migrations` runs it on startup.
+
+If there is no fresh-db smoke check available, run the existing API integration tests:
+Run: `cargo test --package api --lib`
+Expected: PASS.
+
+- [ ] **Step 3: Verify in-flight game compatibility**
+
+Manually load a saved game from before the change (or use a JSON fixture in `game/tests/fixtures/` if present). The game should load, all tributes should report `hunger=0, thirst=0, sheltered_until=None`, and the next phase should tick survival forward without panic.
+
+- [ ] **Step 4: Open the PR**
+
+Per project convention (see `AGENTS.md` "Pull Request Workflow"):
+
+```bash
+jj git fetch
+jj rebase -d main@origin
+bd backup export-git --branch beads-backup
+jj bookmark create feat-shelter-hunger-backend -r @-
+jj git push --bookmark feat-shelter-hunger-backend
+gh pr create --base main --head feat-shelter-hunger-backend \
+  --title "feat(game): shelter + hunger/thirst backend (PR1)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Backend slice of the shelter + hunger/thirst spec. Frontend (pips, Inspect drilldown, map overlays) ships separately in a follow-up PR.
+
+- New survival counters and bands on Tribute (hunger/thirst as debt counters; existing TributeStatus::Starving/Dehydrated finally driven)
+- Pure derivations for shelter_quality / forage_richness / water_source per terrain × weather
+- Brain survival override branch (Eat / Drink / Forage / fall-through)
+- New Action variants: SeekShelter, Forage, DrinkFromTerrain, Eat, DrinkItem
+- New ItemType::Food(u8) and Water(u8); legacy "Consumable"/"Weapon" rows still load
+- Loot drop on RecentlyDead → Dead transition (adjacent fix; food economy depends on it)
+- Six new MessagePayload variants for survival events (band changes are public; rolls are private/Inspect-only)
+- Two new Traits: Builder, ResourcefulForager
+- Minimal Weather enum + stub producer (full weather subsystem swaps producer side later)
+
+## Spec
+docs/superpowers/specs/2026-05-03-shelter-hunger-thirst-design.md
+
+## Verification
+- `just test` — all unit tests pass
+- `just quality` — clean
+- `cargo test --package game --test survival_integration` — pass
+- Manual: fresh game + load existing saved-game JSON, both behave correctly
+
+## Follow-ups
+- Plan 2: frontend (pips, Inspect drilldown survival panel, map terrain overlays)
+- hangrier_games-ex3f (resource sharing between allied tributes)
+- hangrier_games-xfi (announcer prompts consume new survival events)
+EOF
+)"
+```
+
+- [ ] **Step 5: Update beads**
+
+```bash
+bd update hangrier_games-0yz --status in-progress --notes "PR1 backend opened: <PR URL>"
+```
+
+(Do not close `hangrier_games-0yz` — it covers both the spec *and* the frontend; close it when Plan 2 lands.)
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+- Shelter (action + per-tribute state + area-derived quality): Tasks 2, 9, 13, 12 ✓
+- Hunger/thirst counters + bands + tick + drain: Tasks 4–7 ✓
+- Items (Food/Water): Task 8 ✓
+- Brain overrides: Task 10 ✓
+- Looting on death: Task 12 ✓
+- New events (6) + cause constants: Task 11 ✓
+- Traits (Builder, ResourcefulForager): Task 13 ✓
+- Migration / serde defaults / SurrealDB: Task 4 ✓
+- Tests (≈30 unit + integration): Tasks 1–13 (unit), 14 (integration) ✓
+- Frontend: deliberately deferred to Plan 2 ✓
+
+**Placeholder scan:** all code blocks contain runnable code; pseudo-shapes are clearly marked as "adapt to actual ..." where the engineer must consult the existing call site. No "TBD" / "TODO" / "implement appropriately" placeholders.
+
+**Type consistency check:**
+- `tick_survival(&mut Tribute, &Weather, bool)` signature consistent across Tasks 6, 12, 14.
+- `apply_starvation_drain(&mut Tribute) -> u32` consistent across Tasks 7, 12, 14.
+- `survival_override(&Tribute, BaseTerrain, &Weather, bool) -> Option<Action>` consistent across Tasks 10, 12 (call site).
+- `drop_items_to_area(&mut Tribute, &mut Vec<Item>)` consistent across Tasks 12, lifecycle integration.
+- `hunger_band(u8) -> HungerBand` and `thirst_band(u8) -> ThirstBand` consistent across Tasks 5, 6, 7, 10, 12, 14.
+- `Action::Eat(Option<Item>)` / `Action::DrinkItem(Option<Item>)` / `Action::DrinkFromTerrain` / `Action::Forage` / `Action::SeekShelter` consistent across Tasks 9, 10.
+- `MessagePayload::ShelterSought { tribute, area, success, roll }` consistent across Task 11 and the field set is what the action-resolution code in Task 12 (or Plan 2 wiring) will emit.

--- a/docs/superpowers/plans/2026-05-03-shelter-hunger-thirst-pr2-frontend.md
+++ b/docs/superpowers/plans/2026-05-03-shelter-hunger-thirst-pr2-frontend.md
@@ -1,0 +1,848 @@
+# Shelter + Hunger/Thirst — Plan 2: Frontend Implementation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the shelter + hunger/thirst backend in the Dioxus frontend: a generic tribute state strip with hunger/thirst pips and a shelter glyph; a Survival section in the tribute detail page; survival event cards in the timeline; and terrain affordance overlays on the hex map when a tribute is selected.
+
+**Architecture:** Build a small reusable `tribute_state_strip.rs` component now, populated only with survival pips for v1 — emotion pips slot in cleanly later without refactor. The Survival section lives directly inside the existing `tribute_detail.rs` page (no separate Inspect drilldown abstraction; YAGNI). New timeline cards plug into the existing `state_card.rs` / `death_card.rs` dispatch. Map gets a per-hex affordance overlay layer that lights up when a tribute is selected; selection state is local to the map for v1.
+
+**Tech Stack:** Dioxus 0.7 (Rust → WASM), Tailwind CSS via the existing build pipeline, `dioxus-query` for fetching, `gloo-storage` for any persisted UI state. All shared types reach the frontend via the `game::` and `shared::` re-imports already in use.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-shelter-hunger-thirst-design.md`
+**Backend plan (predecessor):** `docs/superpowers/plans/2026-05-03-shelter-hunger-thirst-pr1-backend.md`
+**Beads issue:** `hangrier_games-0yz`
+
+---
+
+## Pre-flight Notes
+
+- Plan 2 must merge after Plan 1 (PR1 backend) lands. The frontend imports new fields and message variants that PR1 introduces.
+- `web::` already re-imports `game::tributes::Tribute` directly — Plan 1's new fields (`hunger`, `thirst`, `sheltered_until`, etc.) flow through the existing `TributeQ` JSON contract automatically. No DTO bridging required.
+- Same applies to `MessagePayload` variants from Plan 1 — they flow through `GameMessage` / `MessagePayload` re-imports already used by the timeline cards.
+- Pure-function calls (`shelter_quality`, `forage_richness`, `water_source`, `hunger_band`, `thirst_band`) live in `game::areas::*` and `game::tributes::survival` — also directly available.
+- Run `just build-css` after any class changes that introduce new Tailwind utility classes (so the JIT pulls them).
+- Run `cd web && dx serve` for the live dev loop; smoke tests are manual at the end of each task.
+- All commits use the project's jj/git workflow per `AGENTS.md`.
+
+---
+
+## File Structure
+
+**New files:**
+- `web/src/components/tribute_state_strip.rs` — generic state strip component; v1 renders survival pips only.
+- `web/src/components/tribute_survival_section.rs` — Survival section rendered inside `tribute_detail.rs`.
+- `web/src/components/timeline/cards/survival_card.rs` — timeline cards for `HungerBandChanged`, `ThirstBandChanged`, `ShelterSought`, `Foraged`, `Drank`, `Ate`.
+- `web/src/components/map_affordance_overlay.rs` — per-hex 💧/🌿/🏠 glyph layer rendered when a tribute is selected on the map.
+
+**Modified files:**
+- `web/src/components/mod.rs` — register the new components.
+- `web/src/components/tribute_detail.rs` — render `TributeStateStrip` near the status block; add `TributeSurvivalSection` to the body.
+- `web/src/components/game_tributes.rs` (or wherever the tribute card list renders) — render the `TributeStateStrip` on each card.
+- `web/src/components/map.rs` — accept an optional `selected_tribute: Option<TributeRef>` prop; render the affordance overlay layer when set; expose a click handler that toggles selection (selection state can be `Signal`-local or lifted to the page if it's needed elsewhere).
+- `web/src/components/timeline/cards/mod.rs` — re-export the new survival card.
+- `web/src/components/timeline/event_card.rs` — dispatch the new `MessagePayload` variants to the survival card.
+- `web/src/components/timeline/cards/death_card.rs` — render `cause = "starvation"` / `"dehydration"` with appropriate copy and styling.
+- `web/src/components/timeline/cards/state_card.rs` — confirm existing `TributeStarved` / `TributeDehydrated` rendering still applies (no change needed unless dispatch routing changes).
+- `web/src/components/timeline/filters.rs` — add a survival filter category if filters are category-based.
+
+---
+
+## Task Order Rationale
+
+Build the smallest reusable piece first (state strip), then the page-level use of it (tribute detail Survival section), then timeline cards, then the map overlay (most ambitious, depends on the map's existing component shape). Each task is independently mergeable and visually verifiable.
+
+---
+
+## Task 1: Generic `TributeStateStrip` component (survival pips only)
+
+**Files:**
+- Create: `web/src/components/tribute_state_strip.rs`
+- Modify: `web/src/components/mod.rs`
+
+- [ ] **Step 1: Read the existing tribute card render to understand the visual context**
+
+Run: `grep -n "TributeStatusIcon" web/src/components/*.rs`
+
+Open the tribute card render site (likely `game_tributes.rs` or inside `tribute_detail.rs`) and note where the status icon currently sits. The state strip will live nearby.
+
+- [ ] **Step 2: Write the component**
+
+Create `web/src/components/tribute_state_strip.rs`:
+
+```rust
+use dioxus::prelude::*;
+use game::tributes::Tribute;
+use game::tributes::survival::{
+    hunger_band, thirst_band, HungerBand, ThirstBand,
+};
+
+/// Generic state strip for a tribute's at-a-glance state pips. v1 renders
+/// only survival (hunger, thirst, shelter) pips; emotion pips slot in here
+/// when the emotion frontend lands.
+///
+/// The strip renders nothing when every pip is in its hidden state (e.g.,
+/// Sated hunger, Sated thirst, no shelter), so a healthy tribute card stays
+/// visually clean.
+#[component]
+pub fn TributeStateStrip(tribute: Tribute, current_phase: Option<u32>) -> Element {
+    let h_band = hunger_band(tribute.hunger);
+    let t_band = thirst_band(tribute.thirst);
+    let sheltered_phases_left = match (tribute.sheltered_until, current_phase) {
+        (Some(until), Some(now)) if until > now => Some(until - now),
+        _ => None,
+    };
+
+    let any_visible = h_band != HungerBand::Sated
+        || t_band != ThirstBand::Sated
+        || sheltered_phases_left.is_some();
+
+    if !any_visible {
+        return rsx! {};
+    }
+
+    rsx! {
+        div {
+            class: "flex flex-row gap-2 items-center text-sm select-none",
+            // Hunger pip
+            if h_band != HungerBand::Sated {
+                HungerPip { band: h_band, raw: tribute.hunger }
+            }
+            // Thirst pip
+            if t_band != ThirstBand::Sated {
+                ThirstPip { band: t_band, raw: tribute.thirst }
+            }
+            // Shelter glyph
+            if let Some(left) = sheltered_phases_left {
+                ShelterPip { phases_left: left }
+            }
+        }
+    }
+}
+
+#[component]
+fn HungerPip(band: HungerBand, raw: u8) -> Element {
+    let (cls, label) = match band {
+        HungerBand::Peckish => ("text-amber-300/60", "Peckish"),
+        HungerBand::Hungry => ("text-amber-400", "Hungry"),
+        HungerBand::Starving => ("text-red-500 animate-pulse", "Starving"),
+        HungerBand::Sated => return rsx! {},
+    };
+    rsx! {
+        span {
+            class: "inline-flex items-center gap-1 {cls}",
+            "aria-label": "Hunger: {label}",
+            title: "Hunger {raw} — {label}",
+            span { class: "text-base", "🍗" }
+            span { class: "text-xs uppercase tracking-wide", "{label}" }
+        }
+    }
+}
+
+#[component]
+fn ThirstPip(band: ThirstBand, raw: u8) -> Element {
+    let (cls, label) = match band {
+        ThirstBand::Thirsty => ("text-sky-300/60", "Thirsty"),
+        ThirstBand::Parched => ("text-sky-400", "Parched"),
+        ThirstBand::Dehydrated => ("text-red-500 animate-pulse", "Dehydrated"),
+        ThirstBand::Sated => return rsx! {},
+    };
+    rsx! {
+        span {
+            class: "inline-flex items-center gap-1 {cls}",
+            "aria-label": "Thirst: {label}",
+            title: "Thirst {raw} — {label}",
+            span { class: "text-base", "💧" }
+            span { class: "text-xs uppercase tracking-wide", "{label}" }
+        }
+    }
+}
+
+#[component]
+fn ShelterPip(phases_left: u32) -> Element {
+    rsx! {
+        span {
+            class: "inline-flex items-center gap-1 text-emerald-300",
+            "aria-label": "Sheltered for {phases_left} more phases",
+            title: "Sheltered for {phases_left} more phases",
+            span { class: "text-base", "🏠" }
+            span { class: "text-xs", "{phases_left}" }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Register the module**
+
+Edit `web/src/components/mod.rs`, add:
+
+```rust
+pub mod tribute_state_strip;
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `cd web && cargo check`
+Expected: clean compile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(web): generic TributeStateStrip with survival pips
+
+New reusable component renders at-a-glance state pips for a tribute.
+v1 renders only survival pips (hunger, thirst, shelter). Future
+emotion frontend slots its pips into the same strip.
+
+The strip self-hides when every pip is in its 'hidden' state, so
+healthy tribute cards stay visually clean.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 2: Wire `TributeStateStrip` into the tribute card list
+
+**Files:**
+- Modify: `web/src/components/game_tributes.rs` (or whatever component renders the per-tribute card row on the game page).
+
+- [ ] **Step 1: Locate the card render site**
+
+Run: `grep -n "tribute" web/src/components/game_tributes.rs | head -20`
+
+Find the loop or component that renders a tribute summary card. Identify the cleanest place to insert `TributeStateStrip` (typically after the name + status icon row).
+
+- [ ] **Step 2: Determine `current_phase` source**
+
+The shelter pip needs the current phase index to compute remaining phases. Locate how the existing tribute or game data exposes the current phase (likely on `DisplayGame` or via a query — search for `current_phase` / `day` / `cycle`).
+
+If the page already fetches a `Game` or has `current_day` / `current_phase_index` available, pass it through. If not, pass `None` — the shelter pip will then render with `phases_left = ?` placeholder; in that case render the glyph with no number.
+
+- [ ] **Step 3: Write the failing visual smoke test**
+
+Visual smoke: there is no automated test for this — verify by `cd web && dx serve` and looking at the page after the backend lands.
+
+For *type* safety, run `cd web && cargo check` — if the import / props are wrong it will fail at compile.
+
+- [ ] **Step 4: Insert the component**
+
+In `web/src/components/game_tributes.rs`, import:
+
+```rust
+use crate::components::tribute_state_strip::TributeStateStrip;
+```
+
+Inside the per-tribute render block, add (adapting the surrounding `rsx!` shape):
+
+```rust
+TributeStateStrip {
+    tribute: tribute.clone(),
+    current_phase: current_phase_signal(),  // adapt to actual source
+}
+```
+
+If no current-phase source exists yet, pass `None` and update the `ShelterPip` to handle the case (already handled — the strip just doesn't render the shelter pip when `current_phase` is `None`).
+
+- [ ] **Step 5: Build CSS and check**
+
+Run: `just build-css`
+Run: `cd web && cargo check`
+Expected: clean.
+
+- [ ] **Step 6: Manual smoke**
+
+Run `just dev` (in another terminal). Open a game in the browser. With Plan 1 backend live, kick a game forward enough phases that some tribute crosses into Hungry / Parched (or use the dev DB to bump `tribute.hunger = 5` directly). Confirm the pips appear on the card.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "feat(web): show TributeStateStrip on game tributes list
+
+The per-tribute card on the game page now renders survival pips when
+a tribute is hungry, thirsty, or sheltered. Healthy tributes show
+nothing extra.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 3: Survival section on tribute detail page
+
+**Files:**
+- Create: `web/src/components/tribute_survival_section.rs`
+- Modify: `web/src/components/mod.rs`
+- Modify: `web/src/components/tribute_detail.rs`
+
+- [ ] **Step 1: Write the new section component**
+
+Create `web/src/components/tribute_survival_section.rs`:
+
+```rust
+use dioxus::prelude::*;
+use game::tributes::Tribute;
+use game::tributes::survival::{
+    hunger_band, thirst_band, HungerBand, ThirstBand,
+};
+
+/// Survival panel inside the tribute detail page. Always renders (so the
+/// page has a stable shape); shows "Sated" / "Exposed" labels when nothing
+/// dramatic is happening.
+#[component]
+pub fn TributeSurvivalSection(tribute: Tribute, current_phase: Option<u32>) -> Element {
+    let h_band = hunger_band(tribute.hunger);
+    let t_band = thirst_band(tribute.thirst);
+    let sheltered_phases_left = match (tribute.sheltered_until, current_phase) {
+        (Some(until), Some(now)) if until > now => Some(until - now),
+        _ => None,
+    };
+
+    let starvation_drain_line: Option<String> = if h_band == HungerBand::Starving {
+        Some(format!(
+            "Starving — losing {} HP/phase (next phase: {})",
+            tribute.starvation_drain_step,
+            tribute.starvation_drain_step.saturating_add(1),
+        ))
+    } else { None };
+
+    let dehydration_drain_line: Option<String> = if t_band == ThirstBand::Dehydrated {
+        Some(format!(
+            "Dehydrated — losing {} HP/phase (next phase: {})",
+            tribute.dehydration_drain_step,
+            tribute.dehydration_drain_step.saturating_add(1),
+        ))
+    } else { None };
+
+    let h_label = format!("{:?}", h_band);
+    let t_label = format!("{:?}", t_band);
+
+    rsx! {
+        section {
+            class: "rounded-lg border border-stone-700/40 bg-stone-900/30 p-4 mt-4",
+            h3 {
+                class: "text-lg font-semibold mb-2 text-stone-100",
+                "Survival"
+            }
+            dl {
+                class: "grid grid-cols-2 gap-y-1 text-sm",
+                dt { class: "text-stone-400", "Hunger" }
+                dd { class: "text-stone-100", "{tribute.hunger} ({h_label})" }
+                dt { class: "text-stone-400", "Thirst" }
+                dd { class: "text-stone-100", "{tribute.thirst} ({t_label})" }
+                dt { class: "text-stone-400", "Shelter" }
+                dd {
+                    class: "text-stone-100",
+                    if let Some(left) = sheltered_phases_left {
+                        "Sheltered for {left} more phases"
+                    } else {
+                        "Exposed"
+                    }
+                }
+            }
+            if let Some(line) = starvation_drain_line {
+                p { class: "mt-2 text-sm text-red-400", "{line}" }
+            }
+            if let Some(line) = dehydration_drain_line {
+                p { class: "mt-1 text-sm text-red-400", "{line}" }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `web/src/components/mod.rs`, add:
+
+```rust
+pub mod tribute_survival_section;
+```
+
+- [ ] **Step 3: Insert into tribute detail page**
+
+In `web/src/components/tribute_detail.rs`, import:
+
+```rust
+use crate::components::tribute_survival_section::TributeSurvivalSection;
+```
+
+Inside the `Settled { res: Ok(tribute), .. }` render block (around line 124+), find the existing block that renders status / attributes and add the survival section after it:
+
+```rust
+TributeSurvivalSection {
+    tribute: (**tribute).clone(),
+    current_phase: None,  // wire to real phase source if available; see Task 2
+}
+```
+
+- [ ] **Step 4: Compile and smoke**
+
+Run: `cd web && cargo check`
+Expected: clean.
+
+Run `just dev`, open a tribute detail page. Confirm the Survival section renders. Bump a tribute to `hunger=5` via the dev DB; confirm the drain line appears in red.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(web): add Survival section to tribute detail page
+
+New TributeSurvivalSection component inside tribute_detail.rs shows
+hunger/thirst counters and bands, shelter status with phases remaining,
+and an escalating-drain line when the tribute is Starving/Dehydrated.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 4: Survival timeline event cards
+
+**Files:**
+- Create: `web/src/components/timeline/cards/survival_card.rs`
+- Modify: `web/src/components/timeline/cards/mod.rs`
+- Modify: `web/src/components/timeline/event_card.rs`
+
+- [ ] **Step 1: Read the existing card-dispatch pattern**
+
+Open `web/src/components/timeline/event_card.rs` and read how it dispatches `MessagePayload` variants to per-card components (e.g. `state_card`, `combat_card`).
+
+- [ ] **Step 2: Write the new card module**
+
+Create `web/src/components/timeline/cards/survival_card.rs`:
+
+```rust
+use dioxus::prelude::*;
+use shared::messages::MessagePayload;
+
+#[component]
+pub fn SurvivalCard(payload: MessagePayload) -> Element {
+    match payload {
+        MessagePayload::HungerBandChanged { tribute, from, to } => rsx! {
+            p {
+                class: hunger_class(&to),
+                "{tribute.name} is now "
+                strong { "{to}" }
+                span { class: "text-xs text-stone-500 ml-1", "(was {from})" }
+            }
+        },
+        MessagePayload::ThirstBandChanged { tribute, from, to } => rsx! {
+            p {
+                class: thirst_class(&to),
+                "{tribute.name} is now "
+                strong { "{to}" }
+                span { class: "text-xs text-stone-500 ml-1", "(was {from})" }
+            }
+        },
+        MessagePayload::ShelterSought { tribute, area, success, roll: _ } => rsx! {
+            p {
+                class: "text-xs text-stone-400",
+                if success {
+                    "{tribute.name} found shelter in {area.name}."
+                } else {
+                    "{tribute.name} failed to find shelter in {area.name}."
+                }
+            }
+        },
+        MessagePayload::Foraged { tribute, area, success, debt_recovered } => rsx! {
+            p {
+                class: "text-xs text-stone-400",
+                if success {
+                    "{tribute.name} foraged in {area.name} (+{debt_recovered} hunger relief)."
+                } else {
+                    "{tribute.name} foraged in {area.name} but found nothing."
+                }
+            }
+        },
+        MessagePayload::Drank { tribute, source: _, debt_recovered } => rsx! {
+            p {
+                class: "text-xs text-stone-400",
+                "{tribute.name} drank (+{debt_recovered} thirst relief)."
+            }
+        },
+        MessagePayload::Ate { tribute, item: _, debt_recovered } => rsx! {
+            p {
+                class: "text-xs text-stone-400",
+                "{tribute.name} ate (+{debt_recovered} hunger relief)."
+            }
+        },
+        _ => rsx! {},  // not a survival payload
+    }
+}
+
+fn hunger_class(band: &str) -> &'static str {
+    match band {
+        "Hungry" => "text-amber-400",
+        "Starving" => "text-red-500 font-semibold",
+        _ => "text-stone-400",
+    }
+}
+
+fn thirst_class(band: &str) -> &'static str {
+    match band {
+        "Parched" => "text-sky-400",
+        "Dehydrated" => "text-red-500 font-semibold",
+        _ => "text-stone-400",
+    }
+}
+```
+
+- [ ] **Step 3: Register the new card**
+
+Edit `web/src/components/timeline/cards/mod.rs`, add:
+
+```rust
+pub mod survival_card;
+```
+
+- [ ] **Step 4: Wire dispatch in `event_card.rs`**
+
+In `web/src/components/timeline/event_card.rs`, find the dispatch match and add arms (or extend the existing one) for the survival payloads. Pseudo-shape:
+
+```rust
+use crate::components::timeline::cards::survival_card::SurvivalCard;
+
+// In the match on `payload.kind()` or directly on `payload`:
+MessagePayload::HungerBandChanged { .. }
+| MessagePayload::ThirstBandChanged { .. }
+| MessagePayload::ShelterSought { .. }
+| MessagePayload::Foraged { .. }
+| MessagePayload::Drank { .. }
+| MessagePayload::Ate { .. } => rsx! { SurvivalCard { payload: payload.clone() } },
+```
+
+- [ ] **Step 5: Death card extension for new causes**
+
+In `web/src/components/timeline/cards/death_card.rs`, locate where `cause` is rendered. If it currently renders the raw string, that already works — `"starvation"` and `"dehydration"` from `shared::messages::CAUSE_STARVATION` / `CAUSE_DEHYDRATION` will display. Optionally style:
+
+```rust
+let cause_class = match props.cause.as_str() {
+    "starvation" | "dehydration" => "text-amber-400 italic",
+    _ => "text-gray-600",
+};
+// ...render with class
+```
+
+- [ ] **Step 6: Compile and smoke**
+
+Run: `cd web && cargo check`
+Expected: clean.
+
+Smoke: with Plan 1 live, run a game until band crossings and starvation deaths happen. Confirm the cards render in the timeline.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "feat(web): timeline cards for survival events + death causes
+
+New SurvivalCard renders HungerBandChanged, ThirstBandChanged,
+ShelterSought, Foraged, Drank, and Ate payloads. Death cards style
+starvation/dehydration causes with appropriate emphasis.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 5: Optional — survival filter category in the timeline
+
+**Files:**
+- Modify: `web/src/components/timeline/filters.rs`
+
+This task is *optional* — file as a follow-up bead and skip if the timeline-filter system isn't trivially extensible (the spec did not require it).
+
+- [ ] **Step 1: Read the existing filter category model**
+
+Run: `grep -nE "enum.*Filter|filter_categories|category" web/src/components/timeline/filters.rs | head -20`
+
+If the filter system is category-driven and survival fits cleanly as a new category, proceed. If it's a more rigid taxonomy, file `bd create "Add 'Survival' filter chip to game timeline"` and stop here.
+
+- [ ] **Step 2: Add a Survival category if applicable**
+
+Pattern depends on the existing filter shape. Wire the survival `MessagePayload` variants to the new category and add a chip to the filter UI matching the existing style.
+
+- [ ] **Step 3: Commit (if implemented)**
+
+```bash
+jj describe -m "feat(web): add Survival filter chip to timeline
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 6: Map terrain affordance overlay
+
+**Files:**
+- Create: `web/src/components/map_affordance_overlay.rs`
+- Modify: `web/src/components/map.rs`
+
+- [ ] **Step 1: Decide the selection-state model**
+
+Selection is local to the map for v1: a `Signal<Option<Area>>` inside `Map` that toggles when a hex is clicked. (The existing `onclick` already logs; replace the log with a selection toggle.)
+
+When `selected.is_some()`, render the affordance overlay; when `None`, don't.
+
+- [ ] **Step 2: Write the overlay component**
+
+Create `web/src/components/map_affordance_overlay.rs`:
+
+```rust
+use dioxus::prelude::*;
+use game::areas::AreaDetails;
+use game::areas::forage::forage_richness;
+use game::areas::shelter::shelter_quality;
+use game::areas::water::water_source;
+use game::areas::weather::{current_weather, Weather};
+
+/// Renders 💧 / 🌿 / 🏠 glyphs on hexes when an area is selected, hinting at
+/// terrain affordances (water source, forage, shelter quality).
+///
+/// `cx`, `cy`, `size` are the hex centroid + size in SVG units; `area` is the
+/// AreaDetails for that hex.
+#[component]
+pub fn MapAffordanceOverlay(cx: f64, cy: f64, size: f64, area: AreaDetails) -> Element {
+    let weather = current_weather();
+    let terrain = area.terrain.base;
+    let water = water_source(terrain, &weather);
+    let forage = forage_richness(terrain);
+    let shelter = shelter_quality(terrain, &weather);
+
+    // Glyphs anchor in a horizontal row across the bottom of the hex.
+    let glyph_size = size * 0.20;
+    let row_y = cy + size * 0.55;
+    let mut x_off = -glyph_size;
+
+    rsx! {
+        g {
+            class: "pointer-events-none",
+            if water > 0 {
+                {
+                    let x = cx + x_off;
+                    x_off += glyph_size * 1.2;
+                    rsx! {
+                        text {
+                            x: "{x}",
+                            y: "{row_y}",
+                            text_anchor: "middle",
+                            font_size: "{glyph_size}",
+                            "💧"
+                        }
+                    }
+                }
+            }
+            if forage > 0 {
+                {
+                    let x = cx + x_off;
+                    x_off += glyph_size * 1.2;
+                    rsx! {
+                        text {
+                            x: "{x}",
+                            y: "{row_y}",
+                            text_anchor: "middle",
+                            font_size: "{glyph_size}",
+                            "🌿"
+                        }
+                    }
+                }
+            }
+            if shelter >= 2 {
+                {
+                    let x = cx + x_off;
+                    rsx! {
+                        text {
+                            x: "{x}",
+                            y: "{row_y}",
+                            text_anchor: "middle",
+                            font_size: "{glyph_size}",
+                            "🏠"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Register the module**
+
+Edit `web/src/components/mod.rs`, add:
+
+```rust
+pub mod map_affordance_overlay;
+```
+
+- [ ] **Step 4: Wire the overlay into `Map`**
+
+Edit `web/src/components/map.rs`. At the top of the function add a selection signal:
+
+```rust
+use crate::components::map_affordance_overlay::MapAffordanceOverlay;
+use game::areas::Area;
+use std::rc::Rc;
+
+let mut selected: Signal<Option<Area>> = use_signal(|| None);
+```
+
+Replace the existing per-hex `on_click` body to toggle selection:
+
+```rust
+let area_for_click = *area;
+let on_click = move |_| {
+    selected.with_mut(|s| {
+        if *s == Some(area_for_click) {
+            *s = None;
+        } else {
+            *s = Some(area_for_click);
+        }
+    });
+};
+```
+
+Inside the per-hex `g { ... }` block, after the existing `text { ... }`, conditionally render the overlay when this hex matches selection:
+
+```rust
+if selected.read().is_some() {
+    if let Some(ad) = areas.iter().find(|ad| ad.area == Some(*area)) {
+        MapAffordanceOverlay {
+            cx: cx,
+            cy: cy,
+            size: HEX_SIZE,
+            area: (*ad).clone(),
+        }
+    }
+}
+```
+
+(Render the overlay on *every* hex when *any* hex is selected — matches the spec wording "highlight surrounding hexes" — so all affordances within the player's mental field of view appear at once. If you'd rather only highlight neighbors of the selected hex, file that as a follow-up.)
+
+Add a visible "selected" outline on the polygon when this hex is the selected one:
+
+```rust
+let is_selected = selected.read().as_ref() == Some(area);
+let stroke_class = if is_selected {
+    "stroke-emerald-400"
+} else {
+    "stroke-stone-700"
+};
+// apply via class on the polygon
+```
+
+- [ ] **Step 5: Build CSS and compile**
+
+Run: `just build-css`
+Run: `cd web && cargo check`
+Expected: clean.
+
+- [ ] **Step 6: Manual smoke**
+
+Run `just dev`. Open a game's map. Click a hex; confirm:
+- Selected hex gets an emerald outline.
+- Every hex with non-zero water_source / forage_richness / shelter_quality (≥ 2) shows the corresponding glyph(s).
+- Clicking the same hex again clears selection and removes overlays.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "feat(web): map terrain affordance overlay on tribute hex select
+
+Clicking a hex on the game map toggles selection. While any hex is
+selected, every hex renders 💧 (water_source > 0), 🌿 (forage_richness > 0),
+and 🏠 (shelter_quality >= 2) glyphs to make terrain affordances legible.
+
+Refs: hangrier_games-0yz"
+```
+
+---
+
+## Task 7: Final quality pass + bookmark + PR
+
+- [ ] **Step 1: Format and lint**
+
+Run: `just fmt`
+Run: `just quality`
+Expected: clean — formatter no-op, no clippy warnings, all tests pass.
+
+- [ ] **Step 2: CSS rebuild**
+
+Run: `just build-css`
+Expected: clean.
+
+- [ ] **Step 3: Manual end-to-end smoke**
+
+Run `just dev`. With a fresh game:
+1. Verify game tributes list cards stay clean (no pips) for healthy tributes.
+2. Push the game forward several phases. Confirm pips appear on hungry/thirsty tributes.
+3. Open a tribute detail page; confirm the Survival section renders correctly.
+4. Look at the timeline; confirm `HungerBandChanged` and `ThirstBandChanged` cards appear at band crossings, that starvation/dehydration deaths render with the new cause copy.
+5. Click a hex on the map; confirm affordance overlays appear and clear correctly.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+jj git fetch
+jj rebase -d main@origin
+bd backup export-git --branch beads-backup
+jj bookmark create feat-shelter-hunger-frontend -r @-
+jj git push --bookmark feat-shelter-hunger-frontend
+gh pr create --base main --head feat-shelter-hunger-frontend \
+  --title "feat(web): shelter + hunger/thirst frontend (PR2)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Frontend slice of the shelter + hunger/thirst spec. Pairs with PR1 (backend, already merged).
+
+- Generic TributeStateStrip component renders survival pips (🍗 hunger, 💧 thirst, 🏠 shelter) on tribute cards; future emotion frontend slots its pips into the same strip
+- TributeSurvivalSection on tribute detail page exposes hunger/thirst counters, bands, shelter status, and the escalating-drain line when relevant
+- New SurvivalCard handles HungerBandChanged / ThirstBandChanged / ShelterSought / Foraged / Drank / Ate timeline events; death cards style starvation/dehydration causes
+- Map terrain affordance overlay: clicking a hex reveals 💧 / 🌿 / 🏠 glyphs across the map so terrain choices are legible at a glance
+
+## Spec
+docs/superpowers/specs/2026-05-03-shelter-hunger-thirst-design.md
+
+## Verification
+- `just quality` — clean
+- `just build-css` — clean
+- Manual smoke: pips appear/disappear correctly across band crossings, drain line shows when Starving/Dehydrated, timeline cards render, map overlays toggle on selection
+
+## Follow-ups
+- hangrier_games-ex3f (resource sharing between allied tributes)
+- hangrier_games-xfi (announcer prompts consume new survival events)
+- (consider filing) Survival filter chip in timeline (Task 5 was optional)
+- (consider filing) Successful SeekShelter glyph/animation on the hex (spec open question)
+EOF
+)"
+```
+
+- [ ] **Step 5: Update beads**
+
+```bash
+bd update hangrier_games-0yz --status closed --notes "Completed: Plan 1 + Plan 2 merged. PR2: <PR URL>"
+```
+
+(Now `hangrier_games-0yz` can close — the spec's full v1 scope is shipped.)
+
+---
+
+## Self-Review
+
+**Spec coverage check (frontend section of the spec):**
+- Tribute card — bottom state strip with hunger/thirst pips + house glyph: Tasks 1–2 ✓
+- Tribute Inspect drilldown — Survival panel: Task 3 (rendered inline in tribute_detail.rs per the agreed YAGNI scoping) ✓
+- Map panel — terrain affordance hints (💧 / 🌿 / 🏠): Task 6 ✓
+- Action panel — band-change and death event lines: Task 4 ✓
+- Sponsor UI affordance — forward-compat only, no v1 work needed ✓
+- Accessibility — aria-labels on pips, text label paired with color: covered in Task 1 ✓
+- Open frontend questions (seek-shelter glyph, low-supply toast): explicitly deferred to follow-ups in PR description ✓
+
+**Placeholder scan:** all RSX blocks and component implementations are concrete; pseudo-shapes (e.g. "adapt to actual loop variable names") are clearly labeled where the engineer must read the existing site first. No `TBD` / `TODO` / "implement appropriately" placeholders.
+
+**Type consistency check:**
+- `TributeStateStrip` props: `tribute: Tribute, current_phase: Option<u32>` — same in Tasks 1, 2.
+- `TributeSurvivalSection` props: `tribute: Tribute, current_phase: Option<u32>` — Task 3.
+- `MapAffordanceOverlay` props: `cx: f64, cy: f64, size: f64, area: AreaDetails` — Task 6.
+- `SurvivalCard` props: `payload: MessagePayload` — Task 4.
+- `MessagePayload` variants used (`HungerBandChanged`, `ThirstBandChanged`, `ShelterSought`, `Foraged`, `Drank`, `Ate`) match exactly the variants Plan 1 Task 11 introduces.
+- Pure functions used (`hunger_band`, `thirst_band`, `shelter_quality`, `forage_richness`, `water_source`, `current_weather`) match exactly the Plan 1 module paths.
+- Tribute fields accessed (`hunger`, `thirst`, `sheltered_until`, `starvation_drain_step`, `dehydration_drain_step`) match exactly Plan 1 Task 4.

--- a/docs/superpowers/specs/2026-05-02-progressive-display-design.md
+++ b/docs/superpowers/specs/2026-05-02-progressive-display-design.md
@@ -1,0 +1,291 @@
+# Progressive Display — Design
+
+**Status:** Draft
+**Date:** 2026-05-02
+**Crate(s) primarily affected:** `web/`
+**Related specs:** `2026-04-26-game-event-enum.md`, `2026-04-26-game-timeline-redesign.md`
+
+## Goals
+
+Add a paced event-reveal mode to the existing `Timeline` component so:
+
+1. **Live games feel like sportscasts.** As websocket events arrive during a game in progress, they appear one-by-one with dramatic pacing — not dumped instantly.
+2. **Past phases can be replayed on demand.** Static event lists are the default for past days, but a Replay button arms playback controls so users can re-experience the phase as it unfolded.
+3. **Users have full transport control during replay.** Phase-jump map, scrubber, transport buttons (back-to-start, prev/next event, play/pause, jump-to-end), and a speed multiplier.
+4. **Live navigation is preserved.** During a live game, the user can scrub back to past phases without losing the live stream — new events queue silently and a "Live ●" badge offers one-click return.
+
+Non-goals:
+
+- Replacing the existing `Timeline` rendering of individual `EventCard`s. This spec adds a *delivery* mode on top of the existing card components; it does not change how individual events look (beyond a fade-in entrance).
+- Streaming text within a single announcer message (token-level streaming). Reveal pacing is event-level only.
+- Server-side change to broadcast pacing. The server emits events as fast as they happen; the client decides reveal cadence.
+- Audio cues, screen shake, or stronger per-event-type animation. Future work.
+
+## Two Display Modes
+
+The same `Timeline` component supports two modes via a new prop:
+
+```rust
+pub enum TimelineMode {
+    Static,    // Show all events immediately. Default for past phases.
+    Reveal,    // Drip events one at a time with dwell timing + transport controls.
+    Live,      // Drip events as they arrive via websocket; phase chips only (no transport).
+}
+```
+
+| Context | Default mode | User can switch to |
+|---|---|---|
+| Past phase, finished game | Static | Reveal (Replay button) |
+| Past phase, live game | Static | Reveal (Replay button) |
+| Current phase, live game | Live | — (always live) |
+| Future phase | n/a | n/a (chip is grayed out) |
+
+### Mode Asymmetry
+
+- **Static** is a no-op rendering pass — same as today.
+- **Reveal** renders only the events up to a current cursor index, advancing on a dwell timer and exposing a transport bar.
+- **Live** renders events up to the head of an arriving websocket queue, also using the dwell timer, but the transport bar collapses to phase chips only — there's no scrubbing through events that haven't happened yet.
+
+If the user navigates from a current-phase Live view to a past phase, the Live phase keeps queueing events in the background; the Live ● badge surfaces them.
+
+## Pacing Model
+
+Per-event dwell time uses model **D — length-based with a per-card-type minimum floor**:
+
+```
+text_dwell  = text_length * 30ms + 500ms
+raw_dwell   = max(min_dwell_for(event_card_type), text_dwell)
+final_dwell = max(150ms, raw_dwell / speed_multiplier)
+```
+
+The 150ms hard floor prevents events from flying past unreadably fast even at 4x with a short text body. Speed multiplier is applied last; per-card minimums scale with multiplier but never below 150ms.
+
+### Per-Card-Type Minimums
+
+A new method (or free function) returns the minimum dwell per event variant:
+
+```rust
+fn min_dwell_ms(event: &GameEvent) -> u32;
+```
+
+Starter values (final tuning during implementation):
+
+| Event category | Min dwell |
+|---|---|
+| Death (any cause) | 2500 |
+| Combat (kill, decisive win) | 2000 |
+| Combat (normal win, wound, miss) | 1200 |
+| Alliance formed / broken | 1500 |
+| Betrayal | 1800 |
+| Item picked up / used | 700 |
+| Movement | 300 |
+| Hide / Rest | 400 |
+| State change (status, weather, area event) | 1000 |
+| Emotion label change *(if surfaced as an event card)* | 1200 |
+
+These are **floors** — a long announcer message will use its text-length-based dwell. The floors prevent short messages on dramatic events from blipping by.
+
+### Speed Multiplier
+
+User-controlled speed in replay mode: **0.5x / 1x / 2x / 4x**. Applied to the dwell formula above. Speed changes take effect on the *next* event's dwell, not by accelerating the timer that's already running (avoids jarring mid-event time warps). Live mode also respects the speed multiplier (set via the same selector if surfaced; otherwise defaults to 1x for live).
+
+## Transport Controls (Replay Mode)
+
+```
+[ D1  N1  D2  N2  D3  N3  D4 ... ]    Phase chips
+[▬▬▬▬●▬▬▬▬▬▬▬▬]  Event 14 of 47       Scrubber
+[⏮]  [⏪]  [▶/⏸]  [⏩]  [⏭]   [1x ▾]    Transport + speed
+```
+
+### Phase Chips (Top Row — Always Visible)
+
+Compact horizontal row of chips, one per phase across the entire game:
+
+- **Visited phase** (current cursor is past it, or the phase is fully complete): clickable; clicking jumps cursor to event 0 of that phase and switches the timeline view to that phase in Reveal mode.
+- **Current phase** (the one being displayed): visually highlighted; pulses softly during Live mode to indicate "this is happening right now."
+- **Future phase** (game hasn't reached it): grayed out, not clickable.
+
+Phase chips are the only transport surface visible in Live mode.
+
+### Scrubber (Replay Only)
+
+A draggable progress bar showing event N of M for the current phase. Click to jump to position; drag to scrub. Live mode does not show the scrubber (there's nothing yet-to-scrub-through).
+
+Companion label: `Event 14 of 47 · Day 3 (Day phase)`.
+
+### Transport Buttons (Replay Only)
+
+| Control | Behavior |
+|---|---|
+| `⏮` Back to start | Reset cursor to event 0 of current phase. Preserves play/pause state. |
+| `⏪` Previous event | Step cursor back 1. Always pauses if playing. |
+| `▶ / ⏸` Play / Pause | Toggle auto-advance at current speed multiplier. |
+| `⏩` Next event | Step cursor forward 1. Always pauses if playing. |
+| `⏭` Jump to end | Reveal all remaining events instantly. Pauses at end. |
+| Speed `1x ▾` | Dropdown or pill row: 0.5x / 1x / 2x / 4x. |
+
+Stepping (⏪ ⏩) always pauses to avoid the confusing "I clicked next and then it advanced again" double-step on click during play.
+
+### Replay Threshold
+
+Phases with fewer than **3 events** skip the Replay button — not worth the transport ceremony for a single combat or two movement events. Threshold tunable.
+
+## Live Mode
+
+When the user is on the current phase of a game in progress:
+
+- `TimelineMode::Live` is active by default.
+- Websocket events from `use_game_websocket` feed directly into the reveal queue.
+- Each new event respects the dwell timer — events arriving in a burst (server emits 5 in 100ms) reveal one at a time with proper pacing, not in a flash.
+- Phase chips are the only navigation surface visible.
+- No scrubber, no transport, no speed selector by default. (Speed selector may be exposed in Live as a "settings" pop-out — out of scope for v1; Live is fixed at 1x.)
+
+### Live Queue Behavior
+
+The reveal pipeline holds an internal queue. When a new websocket event arrives:
+
+1. **If no event is currently dwelling** (queue was empty and reveal is idle): the new event reveals immediately, then its dwell timer starts.
+2. **If an event is currently dwelling**: the new event is appended to the queue. When the current dwell completes, the next queued event reveals; the queue drains one event per dwell-tick until empty.
+3. **The currently-dwelling event is never preempted** — its full dwell completes regardless of how many new arrivals queue up behind it. (Otherwise a burst of arrivals would visually skip past important events.)
+
+If the queue grows long (e.g., server backlog of 20+ events), reveal pacing alone can't keep up. For Live mode, we accept that — the queue drains at normal pace and the user sees a slightly delayed-but-still-paced stream. (The fast-forward shortcut from "Live ● Backlog Handling" applies only when *returning* to Live after scrubbing away, not to natural Live arrival bursts.)
+
+If the user clicks a past phase chip while in Live mode:
+
+1. Timeline view switches to that past phase in Reveal mode.
+2. Live websocket events keep arriving on the underlying signal but are not rendered.
+3. The Live ● badge appears in the header.
+
+## Live ● Badge
+
+A persistent badge that surfaces only when the user has scrubbed away from the current live phase.
+
+```
+┌─────────────────────────────────────────┐
+│ Live ●  Day 4 — 3 new events            │
+└─────────────────────────────────────────┘
+```
+
+- Renders in the page header (above the phase chips).
+- Red dot to signal "live."
+- Counter shows queued events accumulated since the user left live ("3 new events"), or omitted if none.
+- Click jumps the timeline to the current live phase, switches mode to Live, and flushes the queue (revealed at speed, not all-at-once — same as a normal Live arrival, just with a starting backlog).
+
+The badge is the *only* live signal while scrubbing — no banner, no inline ticker. Single focal point.
+
+### Backlog Handling on Return
+
+When the user clicks the badge, the queued events drain into the reveal pipeline. To avoid a 30-event drain feeling tedious:
+
+- If queue length ≤ 5 events: drain at normal pace.
+- If queue length > 5 events: pre-render the first `(queue_len - 5)` events as already-shown (instant), then drain the last 5 with normal pacing. User catches up to "live in the last few seconds" without watching a long replay of the gap.
+
+Implementation tunable; the principle is "don't punish leaving live."
+
+## Reveal Animation
+
+Each event card animates in via fade + slide-up:
+
+- Initial state: `opacity: 0; transform: translateY(8px);`
+- Final state: `opacity: 1; transform: translateY(0);`
+- Duration: ~200ms with `ease-out`.
+- Implemented with Tailwind transition utilities + a transient class swap on mount; no JS animation library.
+
+Cards already in the list don't re-animate when new ones arrive. Only the entering card animates.
+
+## Layout & Scrolling
+
+Append-and-grow vertical list (matches today's `Timeline` shape):
+
+- Newest event always appears at the bottom.
+- Page extends as events arrive; user scrolls down to follow.
+- **Auto-scroll-to-latest** is engaged by default — when a new event reveals, the page scrolls to keep it in view.
+- **Auto-scroll disengages** when the user manually scrolls upward (intent: read something earlier without being yanked back).
+- **Auto-scroll re-engages** when the user manually scrolls back to within ~100px of the bottom.
+
+Standard chat-app behavior (Discord, Slack pattern).
+
+## Data Model & Wiring
+
+### Timeline Component (`web/src/components/timeline/timeline.rs`)
+
+New props:
+
+```rust
+#[derive(Props, ...)]
+pub struct TimelineProps {
+    pub events: Vec<GameMessage>,         // Existing
+    pub mode: TimelineMode,               // NEW
+    pub live_events: Option<Signal<Vec<GameEvent>>>,   // NEW; populated for Live mode only
+    pub current_phase: Option<PhaseRef>,  // NEW; needed for chip highlighting & badge
+    pub all_phases: Vec<PhaseRef>,        // NEW; drives chip row
+    pub on_phase_change: Option<EventHandler<PhaseRef>>,  // NEW; user clicked a chip
+}
+```
+
+`PhaseRef` is whatever existing identifier already names a (game, day, phase) tuple in the codebase — likely derived from the timeline-summary endpoint's existing fields.
+
+### New Files
+
+- `web/src/components/timeline/reveal.rs` — reveal-mode state machine: cursor index, dwell timer (`use_future` + `gloo-timers::future::TimeoutFuture`), play/pause state, speed multiplier, queue management for live arrivals.
+- `web/src/components/timeline/transport.rs` — transport bar component: phase chips, scrubber, buttons, speed selector. Receives callbacks for cursor manipulation.
+- `web/src/components/timeline/live_badge.rs` — the badge component with click-to-return.
+- `web/src/components/timeline/dwell.rs` — pure functions: `min_dwell_ms(event)`, `compute_dwell(event, speed) -> Duration`.
+
+### Modified Files
+
+- `web/src/components/timeline/timeline.rs` — accept the new props; dispatch to Static / Reveal / Live render paths.
+- `web/src/components/game_detail.rs` — when current phase is being viewed during a live game, pass `TimelineMode::Live` and the websocket signal; otherwise `TimelineMode::Static`. Wire phase navigation.
+- `web/src/components/game_period_page.rs` — host the Replay button alongside the existing day-log render; on click, switch to `TimelineMode::Reveal`.
+- `web/src/hooks/use_game_websocket.rs` — currently caps at `MAX_EVENTS = 200` ring buffer; verify this cap is high enough for the Live ● badge backlog use case, or expose a "since cursor" subscription if needed.
+
+## Integration Points
+
+- **Existing websocket plumbing.** `use_game_websocket` already streams `GameEvent`s into a `Signal<Vec<GameEvent>>`. Live mode subscribes to this signal directly; reveal-mode dwelling sits on top.
+- **Existing event ordering.** `GameMessage` has `(tick, emit_index)` — used today by `Timeline` for sorting. The reveal cursor is an index into the *sorted* list; same ordering invariants apply.
+- **Existing card components.** `cards/{combat,death,movement,item,alliance,state}_card.rs` are unchanged. They get a thin animation wrapper from the reveal component (CSS transition classes added on mount).
+- **Existing timeline-summary endpoint.** Provides per-phase event counts already; this is what powers the phase chips and the "skip Replay if < 3 events" threshold.
+- **No server changes** required. Server keeps broadcasting events as fast as they happen; client decides cadence.
+
+## Testing Strategy
+
+Web crate doesn't have heavy test infrastructure today, so testing is mostly pure-function + manual. Where unit tests are practical:
+
+- **`compute_dwell`** — given a known event and speed, returns the documented dwell. Floor honored at 4x for short events. Speed multiplier divides correctly.
+- **Reveal cursor logic** — pure state machine functions for next/prev/jump/play-pause produce expected cursor positions and play states.
+- **Phase chip state** — given a list of phases and a current cursor, returns correct visited/current/future classification.
+- **Backlog drain logic** — given a queue length, produces the right "instant N, drain last 5" split.
+
+Manual / visual verification:
+
+- Live mode: mock a stream of 10 events bursting in 100ms; verify they reveal one-by-one with proper pacing.
+- Replay mode: scrub forward and back across phase boundaries.
+- Live ● badge: navigate away from live phase, simulate event arrivals, verify badge counter updates and click-to-return drains correctly.
+- Auto-scroll: scroll up mid-reveal, verify auto-scroll disengages; scroll back to bottom, verify it re-engages.
+
+## Migration / Backward Compatibility
+
+- **Default mode is Static.** Any existing call site of `Timeline` that doesn't pass the new mode prop continues to work as today (assume `mode: TimelineMode::Static`, `live_events: None`).
+- **API DTOs** — no change. All required data already present.
+- **Browser compatibility** — `gloo-timers` already in the dependency tree (used elsewhere in the web crate); no new build deps for v1. CSS transitions are universally supported.
+
+## Open Questions for Implementation
+
+These don't block writing the implementation plan but the implementer will resolve them:
+
+- Final per-card-type `min_dwell_ms` values (the table is starting-point, not gospel).
+- Whether the speed selector appears in Live mode or stays Replay-only for v1.
+- Whether the phase chip row needs to handle very long games (e.g., 30+ phases) with horizontal scroll or wrapping. (Most games likely under 20 phases, but should not break if larger.)
+- Exact backlog-drain threshold (`> 5` events trigger fast-forward) — UX-tunable.
+- Whether `EmotionLabel` transitions (from emotions spec) and `WeatherChanged` (from weather spec) become rendered event cards. If yes, they need entries in the `min_dwell_ms` table. (Recommendation: yes, both — they're narrative beats — but coordinate with whichever spec lands first.)
+- Whether replay state (current cursor, paused/playing) persists across page navigation or resets on each entry. (Recommendation: reset — replay is an explicit user action, not a saved view state.)
+
+## Out of Scope
+
+- Token-level streaming of announcer message text (streaming-LLM-style typewriter effect).
+- Audio cues per event type.
+- Per-card-type entrance animations beyond the universal fade + slide.
+- Saving replay state across browser sessions.
+- Sharing a "replay link" with a starting cursor position.
+- Speed multiplier preferences saved to user profile / localStorage.
+- Mobile-specific transport layout (chips and transport will reflow with Tailwind defaults; bespoke mobile UX is future work).

--- a/docs/superpowers/specs/2026-05-02-progressive-display-design.md
+++ b/docs/superpowers/specs/2026-05-02-progressive-display-design.md
@@ -239,6 +239,160 @@ pub struct TimelineProps {
 - `web/src/components/game_period_page.rs` — host the Replay button alongside the existing day-log render; on click, switch to `TimelineMode::Reveal`.
 - `web/src/hooks/use_game_websocket.rs` — currently caps at `MAX_EVENTS = 200` ring buffer; verify this cap is high enough for the Live ● badge backlog use case, or expose a "since cursor" subscription if needed.
 
+## Frontend Presentation
+
+The progressive timeline UI is designed against the spectator skin (see `2026-05-02-spectator-skin-layout-design.md` and `2026-05-02-spectator-skin-visuals-design.md`). It owns the entire **Action panel** of the broadcast composition.
+
+### Refined user-facing playback model
+
+The original three-mode enum (Static / Reveal / Live) is collapsed at the user-facing level into a simpler **playback / navigation** model. The enum remains as the underlying state machine; the UI presents three states to the user:
+
+- **Live (current).** Auto-advancing in sync with the WebSocket stream. Live ● badge on. User is at the present moment.
+- **Live (catching-up).** Auto-advancing through buffered/historical events at dwell rate. Live badge off. User is watching the show but is currently behind the present.
+- **Paused.** User has clicked a specific event in the ticker or scrubbed; auto-advance is stopped. Live badge off. Click "play" to resume from the current selection.
+
+The user can:
+
+- Pause anywhere by clicking an event in the ticker or scrubbing.
+- Resume from any point by clicking "play" — playback continues forward from the current selection at dwell rate.
+- Jump to the live edge with a "Jump to Live" button — instantly seeks to the present and switches to Live (current).
+- Adjust playback speed (per the original spec's speed multiplier).
+
+**Default state on page load: Live with dwell** — the user is watching a broadcast already in progress.
+
+Internally, this maps to the existing `TimelineMode` enum as: `Static` → "Paused (auto-advance off)"; `Reveal` → "Live (catching-up)"; `Live` → "Live (current)". The data model is unchanged; the UX vocabulary is unified.
+
+### Action panel layout — three regions
+
+The Action panel divides vertically into three regions, top to bottom:
+
+1. **Now-playing hero card** — the broadcast graphic insert showing the currently-playing or currently-selected event in full.
+2. **Transport region** — playback controls, scrubber, phase chips, live indicator.
+3. **History ticker** — chronological condensed log of all completed events, growing downward.
+
+### Region 1: Now-playing hero card
+
+**Geometry:** inset framed card with subtle chrome border and gold-leaf-style materiality (per the visuals spec). Sits flush below the panel header, separated from the transport below by a thin chrome divider. The card *is* a broadcast graphic insert — explicitly framed, not bleeding into the surrounding panel.
+
+**Content layout (default C-template):** the card uses a single flexible template that handles 95% of event types:
+
+- **Chyron banner (top):** event-type icon + category label + location + timestamp. Banner edge accent color follows the event's palette role (heraldic red for combat/death, chrome gold for weather/Capitol, emotion category color for emotion shifts, etc.). The banner is the stable broadcast frame — when announcer prose is missing, the banner alone communicates the event clearly.
+- **Body:** announcer prose (LLM-generated commentary) in the body face, with inline mentions of tributes rendered as **district-colored chips** (color + sigil + number per the accessibility triad).
+- **Footer (optional):** structured fields for severity / consequence when relevant, in the body face.
+
+**Named exceptions** to the C-template (each gets a bespoke variant):
+
+- **Combat "vs" card.** Two-tribute combat events render as a head-to-head broadcast graphic. Symmetric layout — left tribute / VS / right tribute — each side showing district color stripe + sigil + number + name + avatar. Outcome strip below shows what happened (damage, injury, kill). Combats involving more than two tributes (brawls) fall back to the C-template; vs is reserved for head-to-head.
+- **End-of-day cannon card.** At the end of each day's phase sequence, after the last regular event, a special card lists all that day's deaths, mimicking the cannons. Vertical list; one row per death; each row shows the dying tribute's full triad (color + sigil + number + name + avatar) with a cannon-shot icon (substrate icon, heraldic red, medallion frame) at the leading edge. Banner reads "Day N · Cannons." If no deaths occurred that day, the cannon card is **suppressed entirely** (no empty card). Cannon card is a **dwell anchor** — gets its own minimum dwell duration regardless of length-based rules, so the user always has time to read the daily death roll. (Add to per-card-type minimums table.)
+- **End-of-Games card.** When the game concludes, the now-playing card transitions to a final card and stays there indefinitely. Two variants:
+  - **Victor variant:** banner reading "End of Games — Day N"; the surviving tribute's full triad + avatar at large size in a Capitol-broadcast winner-graphic treatment. Optional final stats below (kills, days survived).
+  - **No-survivors variant:** sober chyron reading "No survivors. The Games are over." No tribute featured. Heraldic red accents.
+  Transport disables play (nothing to play forward to); scrubber still allows navigation through the full game's history. Live indicator goes dark — there is no live edge anymore.
+
+Other event types (alliance changes, weather, sponsor gifts, gamemaker events, emotion shifts, environmental hazards) all use the C-template. Additional special cards may be added per future bead, not pre-designed.
+
+**Card behavior in playback states:**
+
+- **Live (current) / Live (catching-up):** card holds each event for its dwell duration (per the existing length-based-with-floor pacing model), then transitions out as the next event takes over. Brief 200–400ms slide/fade transition.
+- **Paused:** card displays the user's selected event (from ticker click or scrubber position) without auto-advance. No dwell timer is running.
+
+`prefers-reduced-motion: reduce` collapses card transitions to instant swaps.
+
+**Card live indicator:** when the displayed event is the live current one (Live (current) state), a "● Live" badge appears in the chyron. Purely indicative; navigation lives on the scrubber.
+
+### Region 2: Transport region
+
+The transport sits between the now-playing card and the history ticker. **Two-row layout:**
+
+**Top row (full panel width):** scrubber + phase chips overlaid.
+
+- **Scrubber:** density-fill horizontal slider. The scrubber's track carries a low-saturation fill keyed to events-per-phase, so the user can see at a glance where the action was concentrated (e.g. "Day 3 Night was insanely busy"). Click-to-seek; drag-to-scrub. Keyboard: arrow keys for fine-grained step.
+- **Phase chips overlaid on the scrubber:**
+  - Day boundaries — heavier markers, day number labeled.
+  - Phase boundaries — lighter markers, phase named (Dawn / Morning / Day / Dusk / Night).
+  - Current phase — highlighted in chrome gold (the "now" marker).
+  - **Cannon markers** — heraldic-red cannon-shot icons at end-of-day positions where deaths occurred. Lets the user spot "deaths happened that day" at a glance and jump there.
+  - Phase chips are **clickable jump targets**: clicking a chip seeks the scrubber to that phase's start and pauses (so the user can play forward from there).
+
+**Bottom row:** transport buttons + speed selector + Jump-to-Live indicator.
+
+- **Prev / Play–Pause / Next.** Single play-pause toggle button reflects current state (playing → pause icon; paused → play icon). Keyboard: spacebar. Prev/next jump to adjacent events while paused; auto-pause if currently playing.
+- **Speed multiplier.** Selector for 0.5× / 1× / 2× / 4× playback speed. Persists per-device.
+- **Live indicator (right edge):**
+  - When in **Live (current)**: shows "● Live" badge in chrome gold (or heraldic red — implementing instance picks).
+  - When in **Live (catching-up)** or **Paused**: shows a "Jump to Live" button. Clicking it instantly seeks to the present and switches to Live (current).
+
+### Region 3: History ticker
+
+Chronological condensed log, growing downward. **Newest event at the bottom (closest to transport); oldest at the top (scrolls out via overflow as ticker grows).** Reading order is "old → new" top to bottom, like a transcript.
+
+**Line density: single-line condensed.** Each event is one line:
+
+- Leading category dot (left edge, color per the event's palette role — emotion category, weather/environmental, combat/heraldic-red, gamemaker/chrome-gold, etc.).
+- Substrate icon for the event type, immediately after the leading dot.
+- Body text in the body face: condensed event description with inline district chips (color + sigil + number) for any tributes mentioned, per the accessibility triad.
+
+**No prose in the ticker line by default.** The now-playing card is the prose-and-detail surface; the ticker is the scan-and-jump surface. Clicking any ticker line loads that event into the now-playing card and pauses playback there — that is where the user gets full content.
+
+**Optional expand chevron** at the right edge of each line: inline-expand to reveal the prose snippet without disrupting playback. Same chevron collapses. Low-priority feature; ship without if implementation is tight.
+
+**District sequential grouping:** consecutive lines for the same district collapse under a single district banner (color + sigil + number) with the individual lines underneath unstyled with respect to district color (per the visuals spec rule).
+
+**Line state variants:**
+
+- **Default:** as above.
+- **Currently-selected (paused on this event):** line is highlighted in chrome gold with a subtle raised material treatment (per the materiality guardrails — chrome only, not panel body).
+- **Currently-playing (Live mode dwelling on this event):** line is highlighted *and* receives a subtle progress indicator — a chrome-gold edge fill that completes over the event's dwell duration. Visual link between the now-playing card and the ticker; user can see where they are in history while watching the card, and the dwell pacing is legible (the bar filling intuitively shows when the next event will play). When dwell completes, the fill completes, the highlight fades, and the next event in the ticker becomes the currently-playing line.
+
+**Auto-scroll behavior:** auto-scroll only when the user is at the bottom (within ~100px). If the user has scrolled up to read history, the ticker stays put; a "↓ N new events" badge appears at the bottom indicating new content. Clicking the badge or scrolling back to bottom resumes auto-scroll. Standard chat-app pattern.
+
+**Empty state (no events yet):** ticker shows **"The Hangry Games will start shortly!"** in the body face, muted-foreground, optionally with a subtle Panem seal watermark behind it (polish detail). No empty void.
+
+**WebSocket disconnect / reconnect:** the live indicator surfaces connection state — "● Live" → "● Reconnecting…" (heraldic red, briefly) → "● Live" on success, or "○ Offline" with reconnect button on failure. Ticker continues to allow scrubbing through accumulated history while disconnected. Specifics depend on `use_game_websocket` connection-state surfacing — filed as an open implementation question.
+
+### Cross-region coordination
+
+- **Now-playing card ↔ ticker line:** the currently-playing or currently-selected ticker line and the now-playing card always show the same event. State changes (dwell complete, user click, scrubber seek) update both surfaces atomically.
+- **Scrubber ↔ ticker:** the scrubber's playhead position corresponds to the currently-playing ticker line. Scrubbing moves both the playhead and the ticker highlight.
+- **Live indicators:** card chyron badge and scrubber-edge indicator are independent renderings of the same state (Live (current) vs not). They never disagree.
+
+### Reciprocal highlighting with other panels
+
+Per the cross-panel coordination established in the weather UI section: events involving specific tributes participate in the Map ↔ Roster reciprocal highlighting. Hovering a tribute chip in the now-playing card or in a ticker line highlights that tribute in both Map (avatar ring) and Roster (card highlight). The Action panel is a participant in the broader "control room" cross-panel linking, not isolated.
+
+### Accessibility
+
+Per the visuals spec rules:
+
+- All event surfaces (card, ticker lines) carry color + icon + text; color is never the sole signal.
+- District chips always include sigil + number alongside color.
+- Cannon icons are paired with text ("Day N · Cannons" banner).
+- Live ● badge is paired with the word "Live."
+- "Jump to Live" button has a clear text label.
+- All transport controls have keyboard equivalents (spacebar for play/pause, arrow keys for prev/next/scrub).
+- Reduced-motion collapses card transitions, ticker progress bars, and any subtle animations to instant.
+- Screen-reader announcements for new events arriving in Live mode are surfaced via ARIA live regions on the ticker (configurable; filed as open implementation question — too-chatty announcements can be fatiguing).
+
+### Open implementation questions
+
+- Exact dwell anchor minimum duration for cannon cards.
+- Exact dwell anchor handling for End-of-Games cards (probably "infinite" — never times out).
+- Color choice for "● Live" badge (chrome gold vs heraldic red).
+- Whether the inline expand chevron on ticker lines ships in v1.
+- Exact density of the scrubber fill (linear events-per-phase, logarithmic, or something more sophisticated).
+- WebSocket disconnect/reconnect visual details, depending on `use_game_websocket` API.
+- ARIA live region behavior for screen reader announcements (configurable verbosity).
+- Whether the scrubber phase chips show all phases at all viewport widths or condense at narrow widths.
+- Whether the speed selector is a button group or a dropdown.
+
+### Out of scope (filed or to be filed as beads)
+
+- Per-event-type bespoke cards beyond combat-vs, cannon, and end-of-Games.
+- Save/share replay state (already filed: `hangrier_games-t4v`).
+- Per-card-type entrance animations (already filed: `hangrier_games-sk3`).
+- Audio cues for reveal pacing (already filed: `hangrier_games-1dd`).
+- Picture-in-picture / pop-out Action panel (covered by general pop-out bead: `hangrier_games-r6lu`).
+
 ## Integration Points
 
 - **Existing websocket plumbing.** `use_game_websocket` already streams `GameEvent`s into a `Signal<Vec<GameEvent>>`. Live mode subscribes to this signal directly; reveal-mode dwelling sits on top.

--- a/docs/superpowers/specs/2026-05-02-spectator-skin-layout-design.md
+++ b/docs/superpowers/specs/2026-05-02-spectator-skin-layout-design.md
@@ -1,0 +1,260 @@
+# Spectator Skin — Layout, Behavior, and Chrome
+
+**Status:** Draft
+**Date:** 2026-05-02
+**Scope:** The structural and behavioral foundation of the default "spectator" view of Hangrier Games — grid layout, HUD, panel system, resize/collapse interactions, and chrome treatment. Visual identity (palette, typography, texture, iconography) is deferred to a companion spec.
+
+## Goals
+
+- Establish a coherent **broadcast composition** for the default view: HUD strip + Action + Map + Roster panels.
+- Define a **panel system** that supports a shared substrate of role-agnostic infographic clarity, wrapped by a role-specific skin (initial role: spectator/sponsor; future roles: tribute, gamemaker).
+- Provide **early-2000s-portal-style affordances** (resize, collapse) at the panel level without taking on the full complexity of a movable/closable portal.
+- Keep the design **viewport-aware**: mobile, desktop, and widescreen all get an intentional layout, not a degraded one.
+- Provide a **per-panel inspect drilldown** as the contextual debug surface, instead of a separate global debug route.
+- Lay groundwork that future role skins (tribute, gamemaker) can extend or invert, not replace.
+
+## Non-goals
+
+- Visual identity: palette, typography, texture, iconography, motion language. Covered in a follow-up spec.
+- Tribute-player and gamemaker role skins. Designed later as deltas from this baseline.
+- Full portal-style movable/closable panels. Explicitly deferred to a possible future enhancement.
+- Per-account synced layout persistence. Per-device (localStorage) only for v1.
+- Multi-monitor "pop-out panel" support. Reserved as a future menu item but not implemented.
+- Redesigning existing routes outside the game view (`/account`, `/credits`, `/icons`, auth pages).
+
+## Conceptual frame
+
+The interface is built in two layers:
+
+- **Substrate (always-on, role-agnostic).** Board-game / infographic clarity. Iconography, status pills, legible at-a-glance state. The visual *language* the game speaks regardless of who is watching. Shared across all current and future roles.
+- **Skin (role-dependent).** Wraps the substrate. Provides the framing, chrome, and tonal register appropriate to the viewer's role.
+  - **Spectator/sponsor skin (this spec).** Capitol broadcast register: chunky control-panel chrome, ornate framing, "watching the show" energy.
+  - **Tribute skin (future).** District grit register: scarce, weathered, first-person tension, minimal chrome.
+  - **Gamemaker skin (future).** Possibly a clinical control-room variant of the spectator skin, or its own register entirely.
+
+When roles intersect on screen (e.g., a sponsor sending a gift to a tribute), the two registers are intended to *visibly collide*. The seam is a feature.
+
+This spec covers **only the spectator skin's structural layer.**
+
+## Layout system
+
+### Three breakpoints, three compositions
+
+The view is composed of four logical regions: **HUD**, **Action**, **Map**, **Roster**. The HUD is always a top strip; the other three reflow.
+
+- **Mobile (< ~768px):** HUD strip (sticky top), then a 1×3 vertical stack of Action / Map / Roster. A sticky **quick-jump nav** (3 icons) lets the user punch directly to a panel without scrolling.
+- **Desktop (~768–1536px):** HUD strip across the full top. Below, a **2×2 grid where Action takes the full left column (tall)**, Map occupies top-right, Roster occupies bottom-right. Action gets the most pixels in the most-scanned position.
+- **Widescreen (> ~1536px):** HUD strip on top, then **Action | Map | Roster** as three full-height columns left-to-right. Action remains leftmost (first-read).
+
+Reading order is preserved across breakpoints: **HUD → Action → Map → Roster.**
+
+### Panel sizing
+
+Every panel has min/max constraints expressed in the grid. **No panel ever shrinks small enough to become non-useful** (excepting the explicit collapsed state below). Resize gestures (see "Behavior") cannot violate min/max.
+
+Concrete min/max values are an implementation detail (the implementing instance can pick reasonable defaults), but the spec requires:
+
+- A panel's minimum size must keep its primary content legible without horizontal scrolling.
+- A panel's maximum size should not let it crowd siblings below their minimums.
+- The HUD strip's height is governed by its summary/expanded state (see HUD section), not by user resize.
+
+## HUD strip
+
+The HUD is the **persistent top-of-page broadcast bar**. It is the most explicitly "Capitol spectacle" surface in the spectator skin — the equivalent of a sports broadcast's bottom-line scorebug or top-of-screen graphic.
+
+It has **two states, user-toggleable**: *summary* and *expanded*.
+
+### Summary state (default for first-time viewers)
+
+A thin scoreboard strip (~48–56px desktop, similar on mobile). Contents:
+
+- **Day + phase chip** (e.g. `Day 3 · Dusk`).
+- **Living count** (e.g. `14 / 24`).
+- **Recent-death ticker.** Surfaces the last 1–2 deaths briefly (~10s) and fades. Suppressed when no fresh deaths.
+- **Gamemaker event indicator.** A small icon that animates/pulses when an event is active. Clickable: opens the expanded HUD (or jumps to detail).
+- **Expand toggle** on the right edge.
+
+The summary state intentionally **does not show weather** — weather is per-area and any single icon would lie. Weather lives in the expanded mini-map.
+
+### Expanded state
+
+Roughly 3× the summary's height on desktop/widescreen. **On mobile the expanded state takes most/all of the vertical viewport** (it's a takeover; user must collapse it back to see the panels below).
+
+Contents:
+
+- Everything from summary, but the **day/phase becomes a labeled phase progress indicator** showing the full phase cycle (Dawn → Morning → Day → Dusk → Night) with the current phase highlighted.
+- A **single mini-map** of the arena, with an **overlay toggle** between:
+  - **Weather** — areas colored/iconned by current weather state.
+  - **Events** — areas marked with recent-event density (heatmap) or last-event icon.
+  - **Both** — combined overlay.
+  Hover/tap an area to see the full state in a tooltip/popover.
+- **Gamemaker event detail card** if one is active: what it is, how long, affected areas.
+- *(Optional)* **Alliance summary chips** (e.g. `Careers (4) · Lone wolves (8) · Pairs (3)`).
+
+The mini-map is intentionally a **condensed echo** of the main Map panel, not a competitor. The Map panel is the canonical spatial view.
+
+### HUD persistence
+
+- Default state for a first-time visitor is **collapsed (summary)**.
+- The user's expand/collapse choice is **persisted in localStorage** and remembered across page navigations and reloads.
+- Persistence is **global, not per-game** — once a user expands the HUD, they keep it expanded everywhere until they collapse it. (Per-game scoping is reserved for future enhancement if user feedback warrants it.)
+
+## Panel system
+
+### Shared `<PanelFrame>` component
+
+All three content panels (Action, Map, Roster) are wrapped by a single shared component (provisional name `PanelFrame`). Slots:
+
+- `title` — short label and optional icon.
+- `context` — optional center strip in the header for live state (e.g. timeline mode for Action, current overlay for Map, sort/filter state for Roster).
+- `menu_items` — populated by each panel; rendered by the frame as a popover.
+- `body` — the panel's main content.
+
+Why a shared component (not per-panel implementations):
+
+- Enforces visual consistency — all menus, headers, dividers, and affordances look identical.
+- Centralizes resize/collapse behavior (see below) so each panel author doesn't reimplement it.
+- Centralizes the inspect drilldown affordance.
+- Makes adding a new panel in the future trivial.
+- Centralizes the future "pop out" affordance when/if it lands.
+
+### Panel header anatomy
+
+Reading left-to-right:
+
+- **Left:** panel title + small icon.
+- **Center:** optional live context strip (panel-defined).
+- **Right:** the **panel menu**, opened from a kebab/gear control. Contents:
+  - **Inspect** — opens the per-panel debug drilldown (see "Inspect drilldown" below). Always present.
+  - **Panel-specific actions:**
+    - *Action:* timeline mode (Static/Reveal/Live), playback speed, pause, jump-to-end. (See `2026-05-02-progressive-display-design.md`.)
+    - *Map:* overlay (Weather / Events / Tributes / All), zoom level.
+    - *Roster:* sort (alliance / status / name / district), filter (alive only / all).
+  - **Pop out** *(future, reserved)* — open this panel in a new window for second-screen / multi-monitor use.
+
+The menu pattern keeps the panel body clean. Inline controls in the panel body are reserved for **transport-style fast actions** (e.g. timeline play/pause), not configuration.
+
+### Panel chrome
+
+Per the "Hybrid C" decision: panels use **subtle gutters and dividers, with prominent panel headers**. They are not fully framed boxes, nor are they fully bleed-to-edge regions. The panel header is the visually anchored element; the body bleeds to the panel's allocated grid cell.
+
+The visual *treatment* of headers, gutters, dividers, and the resize/collapse handles is intentionally **chunky and early-2000s-portal-coded** (see "Chrome treatment" below). This spec defines structure; the visual identity spec defines exact materials.
+
+## Behavior
+
+### Resize
+
+- Both **column gutters and row gutters** are resizable, on viewports where the layout has more than one panel per axis (i.e. desktop and widescreen). Mobile (1×3 stack) does not expose resize handles.
+- Dragging a gutter changes the proportional sizes of the panels it separates.
+- Resize is constrained by the panels' min/max sizes; the gutter cannot be dragged past a sibling's minimum.
+- Resize state is **persisted per-device per-breakpoint** in localStorage. Different breakpoints get independent layouts (a desktop layout is not applied at widescreen, and vice versa).
+
+### Collapse
+
+- Each panel's header includes a **collapse control** (in addition to or as part of the menu). Clicking it collapses the panel to **just its header strip** (window-shade behavior).
+- A collapsed panel is still on screen and still has its menu. Clicking the same control restores it.
+- **Adjacent panels grow proportionally** to fill the freed space, respecting their max constraints.
+- Collapse state is persisted per-device per-breakpoint alongside resize state.
+- The HUD is **not collapsible to nothing** — the closest equivalent is the summary state. The HUD always occupies its top strip.
+
+### Inspect drilldown (contextual debug)
+
+There is **no separate global debug route**. Instead, every panel's menu includes an **Inspect** action that opens a dense data view scoped to that panel's subsystem.
+
+- **Action's Inspect** → full event log table: timestamp, source, severity, payload, affected entities. Sortable, filterable.
+- **Map's Inspect** → full area/terrain table: every area, current weather, active hazards, tribute occupancy, event density.
+- **Roster's Inspect** → full tribute table: every internal field exposed, sortable/filterable. SurrealDB-query-tool flavor.
+
+The inspect view opens as either a modal/dialog over the broadcast composition, or as a side-panel takeover (implementing instance can choose; modal is simpler). Closing the inspect view returns the user to the broadcast composition unchanged.
+
+This pattern means we do not maintain two parallel UIs (broadcast and debug). Broadcast is the identity; debug is contextual drilldown.
+
+### Reset layout affordance
+
+A **"Reset layout"** action exists in the global settings popover (see below). It clears the persisted resize/collapse state for the current breakpoint and restores the spec's default layout.
+
+### Settings popover
+
+The same global menu hosts:
+
+- **Theme switcher** (existing).
+- **Reset layout** (new, this spec).
+- Future toggles (HUD persistence scope, sound, accessibility prefs, etc.) live here as well.
+
+The popover replaces the current ad-hoc theme dropdown. Implementation may keep CSS-only behavior or switch to a Dioxus-managed popover; behavior, not implementation, is specified.
+
+## Chrome treatment
+
+The spectator skin **leans into early-2000s portal aesthetics** for its panel chrome and affordances. Concretely:
+
+- **Beveled / raised panel borders.**
+- **Visible drag-grip textures** on resize handles (e.g. `:::` dot patterns or equivalent).
+- **Thick header bars** with raised/inset shading.
+- **Gutter "rails"** between panels are visible, not invisible whitespace.
+- **Chunky controls** (kebab/gear, collapse, transport buttons) — substantial click targets, not minimal flat icons.
+
+This is on-theme: it sells the "Capitol gamemaker control panel" register, and it provides a strong differentiator from the eventual tribute skin (which is intended to feel sparse and chrome-free).
+
+**Fallback path:** if the chunky aesthetic ages poorly in practice, fall back to a **Hybrid C** treatment — flat at rest, chunky on interaction (handles light up with grip textures on hover/drag, gutters thicken). This is captured as an open question for visual identity, not committed here.
+
+The visual identity spec defines exact materials (colors, gradients, textures, type for header labels).
+
+## Persistence summary
+
+All persisted UI state for the spectator skin lives in **localStorage, per-device**, matching the existing theme/JWT pattern. No per-account sync in v1.
+
+Persisted keys (suggested, implementing instance can pick exact names):
+
+- HUD expanded/collapsed state (global).
+- Panel resize state (per breakpoint).
+- Panel collapsed state (per breakpoint).
+- Panel menu selections that should persist (e.g. Map overlay, Roster sort) — implementing instance decides which are session-only vs persisted.
+
+Per-account sync is reserved as a future bead.
+
+## Integration points
+
+- **Existing Dioxus app structure.** The spectator skin replaces the current `/games/:id`, `/games/:id/day/:day/:phase` page bodies with the broadcast composition. The route structure may stay the same; the rendered content changes.
+- **Theme system.** The existing `theme1/2/3` Tailwind theme variants are *not* assumed to survive — the visual identity spec will decide whether they remain, get refined, or get replaced. The spectator skin is one *role*, not one *theme*; theming within the role is an open question.
+- **WebSocket event stream (`use_game_websocket`).** The Action panel consumes this. Wiring is per the progressive display spec (`2026-05-02-progressive-display-design.md`).
+- **Weather and emotion systems.** Their UI surfaces (per their respective specs) live inside the appropriate panels — emotion pills on tribute cards in Roster; weather indicators on the Map panel and HUD mini-map.
+- **dioxus-query.** Continues to be the data layer; no changes implied.
+
+## Testing strategy
+
+- **Layout integration tests** at each breakpoint: HUD + 3 panels render, occupy expected grid cells, respect min/max.
+- **Resize behavior:** dragging a gutter changes sizes, respects min/max, persists to localStorage, restores on reload.
+- **Collapse behavior:** collapsing a panel reduces it to header height, adjacent panels grow proportionally, restoring inverts cleanly.
+- **HUD toggle:** summary ↔ expanded transitions, persistence across reload, mobile takeover behavior.
+- **Inspect drilldown:** opens scoped data view per panel, closes cleanly, does not corrupt panel state.
+- **Quick-jump nav (mobile):** tapping a target scrolls to the corresponding panel.
+- **Reset layout:** clears persisted state, restores spec defaults at current breakpoint, does not affect other breakpoints' state.
+
+## Migration
+
+This is largely greenfield UI work — there is no existing broadcast composition to migrate from. The migration is from the **current card-stack page layouts** to the new composed view.
+
+- Existing routes can stay; only their rendered bodies change.
+- The current `theme1/2/3` system continues to function until the visual identity spec replaces or refines it.
+- Existing components (tribute cards, etc.) are absorbed into panels — most likely Roster reuses tribute card concepts but in a denser layout suited to a panel.
+- No data model or API changes are required by this spec.
+
+## Open questions for implementation
+
+- Exact min/max sizes per panel, per breakpoint.
+- Exact pixel heights for HUD summary vs expanded states at each breakpoint.
+- Resize handle hit-area dimensions (chunky implies generous; needs to feel right under a mouse).
+- Whether the inspect view is a modal or a side-panel takeover.
+- Whether the settings popover reuses the existing CSS-only dropdown pattern or moves to a Dioxus-managed popover (likely the latter, for the additional content it'll host).
+- Whether collapse and resize handles should animate transitions, and how aggressively.
+- Whether mobile resize should expose any axis (e.g. drag a panel's bottom edge to grow its max-height) or be entirely fixed.
+
+## Out of scope (filed or to be filed as beads)
+
+- Tribute and gamemaker role skins.
+- Per-account synced layout persistence.
+- Pop-out / multi-monitor panel support.
+- Drag-to-rearrange / closable panels (full portal mode, the path from B → C).
+- The visual identity (palette, typography, texture, iconography, motion).
+- Sound design / audio cues for layout interactions.
+- Accessibility audit and remediation pass for the new chrome (separate bead recommended).

--- a/docs/superpowers/specs/2026-05-02-spectator-skin-visuals-design.md
+++ b/docs/superpowers/specs/2026-05-02-spectator-skin-visuals-design.md
@@ -1,0 +1,342 @@
+# Spectator Skin — Visual Identity
+
+**Status:** Draft
+**Date:** 2026-05-02
+**Scope:** The visual identity layer of the spectator skin — palette, typography, materiality, motion, and iconography. Companion to `2026-05-02-spectator-skin-layout-design.md`, which defines structure and behavior. Together the two specs fully define the spectator skin for v1.
+
+## Goals
+
+- Establish a coherent **Capitol broadcast** visual register: imperial baroque ground, broadcast-graphic energy, Art Deco geometric authority.
+- Define a **palette system with four distinct roles** (ground, chrome, heraldic accent, content electrics) and a **12-district electric color system** for tribute-identity surfaces.
+- Pick **typography** with three families serving three roles (display, numeric, body), each justified by the broadcast register.
+- Commit to **subtle materiality** — physical-feeling chrome without slipping into skeuomorphism — with explicit guardrails.
+- Keep **motion minimal** and purposeful, reserving ambient motion as a future enhancement for the HUD only.
+- Define **iconography as a substrate + identity** split: a normalized treatment of the existing icon library plus a small bespoke set of Capitol identity marks.
+- Bake **accessibility** in at the system level: every semantic signal carries at least two encodings, color is never the sole carrier of meaning.
+
+## Non-goals
+
+- Layout, behavior, panel system, HUD structure. Covered in the layout spec.
+- Tribute and gamemaker role skins. Designed later as deltas.
+- Existing routes outside the game view (`/account`, `/credits`, `/icons`, auth pages) — these get incidental updates as the design system rolls in but are not redesigned by this spec.
+- A bespoke hand-drawn Art Deco substrate icon set. Recognized as a desirable future state; out of scope for v1.
+- D13 colors / sigil / branding.
+- Concrete font selection (specific font names) — this spec specifies the *flavor* and constraints; the implementing instance auditions specific faces from the shortlist.
+- Concrete hex values for the 12-district palette — specified as design constraints, audited and pinned by the implementing instance.
+
+## Conceptual frame
+
+The spectator skin operates in the **Capitol broadcast** register: imperial baroque ground (deep blacks, oxblood, antique gold) overlaid with broadcast-graphic energy (saturated district electrics used as semantic content signals). The visual identity is *baroque-imperial-with-electricity* — explicitly not neon, not cyberpunk, not "futuristic," not generic-fantasy.
+
+The skin sits on top of a **role-agnostic substrate** of board-game / infographic clarity: iconography, status pills, legible at-a-glance state. The substrate is the visual language all current and future role skins share.
+
+This spec defines:
+
+- The **shared substrate** — the typography body face, the iconography normalization rules, accessibility constraints — which carries forward to all future role skins.
+- The **spectator skin proper** — palette, display and numeric typography, materiality, motion, identity icons — which is replaced or inverted by future role skins.
+
+## Palette system
+
+The palette has **four roles**, each with a clear job. Roles do not overlap.
+
+### Role 1 — Ground
+
+Very dark warm neutrals. Espresso black, deep oxblood near-black, charcoal with warm undertone. Used for:
+
+- Page background.
+- Panel bodies (the surface content sits on).
+- Modal/dialog overlays.
+
+Ground is intentionally *not pure black* — it carries a warm undertone that ties it to the chrome role and prevents the UI reading as a generic "dark mode" web app.
+
+### Role 2 — Chrome
+
+Antique gold and brass tones. Used for:
+
+- Panel borders, gutters, dividers, header strips.
+- Active controls (kebab/gear, transport buttons, resize handles).
+- The HUD frame and structural elements.
+- "Capitol speaking" affordances — system messages, gamemaker announcements (covered further in role 4 below; chrome and Capitol-voice share gold).
+
+Chrome is the carrier of the *baroque/Deco* register. Its treatment (subtle gradients, sheen, bevels) is defined under Materiality below.
+
+### Role 3 — Heraldic accent
+
+Deep imperial red (oxblood-leaning rather than fire-engine). Used for:
+
+- Danger, death, and urgent system signals.
+- Critical gamemaker events.
+- Error states (panel-level errors, failed loads).
+- "Everyone is dead" / game-over end states.
+- The recent-death ticker's accent edge.
+
+Heraldic red is **scarce by design**. It must read as serious when it appears, which means it cannot appear casually. Hover states, tooltips, ordinary information signals all use other roles.
+
+### Role 4 — Content electrics (district palette)
+
+The 12-district color system. Used **only on tribute-identity surfaces**:
+
+- Tribute cards in the Roster panel.
+- Event log lines naming a tribute (Action panel).
+- Map markers and tribute occupancy indicators.
+- HUD recent-death ticker.
+- Alliance summary chips (multi-color treatments for multi-district alliances; lone-wolves stay neutral).
+
+District electrics are **never** used in chrome, panel headers, gutters, settings, or any non-tribute-specific surface. The Capitol baroque ground is preserved as the unifier.
+
+#### District color sourcing (hybrid)
+
+The 12 colors are derived from each district's industry, with the constraint that the resulting palette is **distributed evenly enough around the hue wheel** to remain individually distinguishable at a glance. Industry resonance is the *target*; visual distinguishability is the *constraint*.
+
+Suggested industry → hue mapping (the implementing instance pins exact values):
+
+- D1 (luxury) — pink/rose-gold or champagne pink (luxury, rose-gold accent against the Capitol's brass)
+- D2 (masonry / weapons) — cool steel blue
+- D3 (electronics) — electric cyan
+- D4 (fishing) — deep ocean teal
+- D5 (power) — chartreuse / electric yellow-green
+- D6 (transportation) — burnt orange
+- D7 (lumber) — forest amber / sap-green
+- D8 (textiles) — magenta / rich violet
+- D9 (grain) — wheat-gold (must differentiate from chrome gold — possibly a paler or greener variant)
+- D10 (livestock) — terracotta / clay red
+- D11 (agriculture) — olive / earthen green
+- D12 (coal) — ember orange
+
+Constraints on the final palette:
+
+- Every color must reach **WCAG AA contrast (4.5:1)** against the ground role.
+- Every color must remain visually distinct from chrome gold and from heraldic red, which are reserved for other meanings.
+- Colors should be ordered in a defined sequence so that adjacent districts don't have hostile color interactions when shown together (e.g. D1 next to D2 in a roster).
+- D9 (wheat-gold) is the highest collision risk with the chrome role; the implementing instance must shift it sufficiently warm-green or muted to read as "wheat" not "more chrome."
+
+#### Sequential grouping rule
+
+When multiple consecutive items would carry the same district color (e.g. five Action-log lines in a row mentioning D2 tributes), the items **collapse under a single shared district banner/header**. The banner carries the color and (per accessibility) the sigil + number; the items underneath are unstyled with respect to district color, or at most subtly indented.
+
+This applies anywhere repeated district color would otherwise produce visual noise — Action panel event log primarily, and the HUD death ticker if multiple deaths from one district arrive close together.
+
+#### Capitol's voice
+
+The Capitol does not get a 13th electric. **Chrome gold does double duty** as both decorative chrome and "the show speaking" — Capitol announcements, gamemaker notices, system-voice content. This keeps the system to two channels (gold = the show; district color = a tribute) and avoids inventing a color whose only job is being not-a-district.
+
+D13 is not in scope.
+
+#### Palette reference table
+
+| Role | Hue character | Where used |
+| --- | --- | --- |
+| Ground | Deep warm neutral (espresso, oxblood-near-black) | Page bg, panel bodies, modal overlays |
+| Chrome | Antique gold / brass | Borders, headers, active controls, Capitol-voice content |
+| Heraldic accent | Deep oxblood imperial red | Danger, death, urgent system signals — scarce |
+| Content electric (12) | District palette per above | Tribute-identity surfaces only |
+
+## Typography
+
+Three families, three roles. Specific fonts are auditioned during implementation; this spec specifies flavor and role.
+
+### Display family — Art Deco
+
+Headers, panel titles, page chrome, ceremonial type. Carries the Capitol register at the largest sizes.
+
+- **Flavor:** Art Deco / Streamline Moderne. Geometric construction, stylized authority. Examples in this register: Limelight, Poiret One, Della Respira, Forum.
+- **Justification:** the Capitol's screen design language in canon is overtly Art Deco. Choosing Deco is *more on-canon* than the imperial-Roman-serif default and avoids the Trajan cliché of every fantasy game. It also justifies the chunky Deco-bevel chrome we already committed to in the layout spec.
+- **Open implementation detail:** many display Deco faces don't hold up at small panel-header sizes. The implementing instance is permitted to introduce a **secondary display face** for small-header use, ideally from the same era / geometric family as the primary (a "deck" version, or a paired geometric like a quieter Forum companion). This is treated as an implementation detail, not a separate decision.
+
+### Numeric family — Deco-coherent broadcast numerals
+
+HUD scoreboard, day counter, living count, future timers, future sponsor-currency display.
+
+- **Primary flavor:** numerals that match the Deco display register. Faces designed in the same era / geometry, or pairings explicitly designed to harmonize with the display family. The numeric face must feel like it came from the *same broadcast graphics package* as the display face.
+- **Fallback flavor:** broadcast-style display numerals (DIN, United Sans Display, modern broadcast tabular numerics). Acceptable if a Deco-coherent option doesn't exist.
+- **Ultimate fallback:** clean tabular monospace (JetBrains Mono, IBM Plex Mono). Acceptable if neither Deco-coherent nor broadcast-style options work — sacrifices "feels like a broadcast" for "data is unambiguous."
+- **Required:** tabular figures (`font-variant-numeric: tabular-nums`) on every numeric surface. Day counters and tallies must align across renders.
+
+### Body family — neutral humanist sans, accessibility-leaning
+
+Event log prose, tooltips, settings, panel body content, tribute-card metadata. The substrate's text voice.
+
+- **Flavor:** neutral, highly-readable, screen-optimized humanist sans. Examples: Inter, IBM Plex Sans, Atkinson Hyperlegible, Source Sans, Söhne.
+- **Justification:** body face is the wrong place to spend identity budget. Display and numeric carry voice; body must disappear into legibility. Atkinson Hyperlegible specifically aids the accessibility goals already baked into the palette and iconography systems.
+- **Permission to warm:** the implementing instance may audition slightly warmer alternatives (Public Sans, Source Serif at smaller sizes, etc.) if the result feels too neutral. Default starts from boring-and-legible.
+
+## Materiality
+
+The chrome is **subtly material** — physical-feeling without slipping into skeuomorphism. The chunky early-2000s portal aesthetic from the layout spec is executed through restrained materiality: light gradients, soft inner shadows, gold-leaf-style sheen on chrome elements, muted noise/grain on dark grounds.
+
+Panels feel slightly *fabricated* — like printed cards or engraved metal plates — without literally rendering as such.
+
+### Guardrails
+
+These are spec-level constraints, not implementation suggestions:
+
+1. **Materiality is reserved for chrome.** Panel borders, headers, gutters, controls, HUD frame. **Panel bodies and content surfaces stay flat.** Material treatment never appears under text content.
+2. **One material per surface role.**
+   - Chrome → gold-sheen.
+   - Ground → subtle warm-noise (optional, very low intensity).
+   - Heraldic accent → flat.
+   - District electrics → flat.
+   - Numerals on the HUD → flat.
+   Materials do not layer.
+3. **No drop shadows on type. Ever.** Subtle inner shadows on bevels and chrome surfaces are acceptable; type stays clean.
+4. **All material treatments must be honest at 1× and 2×.** No hairline gradients that disappear on low-DPI; no textures that moiré on high-DPI; no sheen effects that become noise at retina scale.
+
+### Why subtle, not heavy
+
+- Pure flat under-delivers on what the layout spec promised — chunky Deco chrome, gilded affordances. Flat treatment leaves the chrome looking underspecified.
+- Heavy materiality (real textures — gold leaf images, brushed brass, leather grounds) ages poorly, fights accessibility, costs performance, and risks iOS-6-skeuomorphism.
+- Subtle materiality is the **broadcast-graphic register itself** — real broadcast graphics imply physicality without rendering it.
+- Selectively dialing materiality up later is easy; reversing direction (paring back heavy textures) once asset pipelines exist is hard.
+
+### Fallback path
+
+If subtle materiality ages poorly in practice, the fallback is **flat-at-rest, chunky-on-interaction**: panels look modern when idle, chunky materiality emerges only when handles are hovered, gutters are dragged, or controls are activated. This is captured as an open implementation question, not a committed direction.
+
+## Motion
+
+**Minimal and purposeful only.** No idle animation, no ambient effects.
+
+Permitted motion:
+
+- Timeline reveal pacing (per `2026-05-02-progressive-display-design.md`).
+- HUD ticker fades (recent-death ticker fades after ~10s).
+- Panel collapse/expand transitions (window-shade behavior).
+- Hover and active states on controls.
+- Resize gutter drag tracking.
+
+### Future ambient motion (HUD only)
+
+Reserved as a future enhancement for the **HUD only** — never content panels (would interfere with reading the event log) or the Map (would compete with actual gameplay state):
+
+- Slow gold-sheen drift across HUD chrome.
+- Gentle pulsing on the "live ●" badge (already specified in the progressive display spec).
+- Subtle parallax on HUD when expanded.
+
+This is filed as a possible v1.x addition, not committed for v1.
+
+### Reduced motion
+
+`prefers-reduced-motion` must collapse all transitions to instant. Timeline reveal pacing reverts to Static mode under reduced-motion (already implied by the progressive display spec). HUD fades become instant swaps.
+
+## Iconography
+
+A **substrate + identity** split.
+
+### Substrate icons (B+ treatment)
+
+The existing game-icons.net library plus future additions form the **substrate icon vocabulary** — the role-agnostic infographic clarity layer. They are processed through a normalization pipeline so that the *finish* speaks Deco even though the underlying *forms* are generic.
+
+#### Normalization pipeline
+
+A scripted, repeatable process applied to every substrate SVG:
+
+- **Single stroke weight** across the set (or two: regular and a bold for emphasis). All icons re-exported to the chosen weight.
+- **Single grid size** with a defined safe area (24×24 or 32×32; pinned by the implementing instance).
+- **Palette tokens, not hardcoded colors.** Icons render in `currentColor`. The token applied determines the rendered color: chrome-gold by default, district color when contextual, heraldic red for danger, muted-foreground for inactive states. **Never arbitrary colors.**
+- **Metadata stripped** on export. Snap to grid.
+- **Naming convention by semantic role**, not by source. `icon-tribute-injured`, not `icon-broken-arm-game-icons`. This lets implementations be swapped (B+ → future C) without touching consumer code.
+
+#### Deco frame system
+
+To make substrate icons feel curated rather than generic, they are presented inside one of a small number of **Deco frame variants** appropriate to context:
+
+- **Medallion frame** — circular or octagonal Deco border, used on tribute-card status icons and other "this is a state" surfaces.
+- **Stepped-border frame** — angular Deco border, used on HUD chrome icons.
+- **Plain (no frame)** — used inline in event-log lines and other tight spaces where a frame would compete with prose.
+
+The frames are rendered as Deco SVG/CSS composition, not as raster assets. They are the carrier of the Deco register; the icon inside is the glyph.
+
+#### Future bespoke Deco substrate
+
+A fully hand-drawn Art Deco substrate icon set is the desirable north star but **not in scope for v1**. It is filed as a future bead. The B+ treatment is foundational — its pipeline, palette tokens, naming, and frame system carry forward unchanged; future bespoke icons drop into the same system.
+
+### Identity icons (bespoke)
+
+A small set of high-identity-weight icons drawn bespoke from geometric primitives. These are *not* substrate; they appear in defined Capitol-skin chrome contexts only.
+
+- **Panem seal.** Full-bleed page chrome, login screen, "broadcast off-air" empty states.
+- **District sigils (12).** One per district. Used in tribute cards as the **secondary encoding pair** to district color (see Accessibility below).
+- **Capitol / Gamemaker mark.** Used wherever Capitol-voice content appears.
+- **Mockingjay (existing custom set).** Reserved for the future tribute-skin chrome; remains in place for the existing theme switcher in the interim.
+
+Identity icons are designed as **composed SVG primitives** (circles, polygons, stepped borders, radial symmetry) — Art Deco identity marks are exactly the sort of thing this technique handles well. They do not go through the substrate normalization pipeline because they are not substrate.
+
+## Accessibility
+
+Color is never the sole carrier of semantic meaning. Every meaningful state must be encoded by **at least two channels**.
+
+### District identity — standard triad
+
+Every place district color appears, the standard triad is:
+
+- **Color** (district electric, per palette).
+- **Sigil** (district sigil from the bespoke identity icon set).
+- **Number** (textual `D7`-style label).
+
+Where space permits, all three appear. Where space is tight (event-log lines, narrow HUD ticker), the **textual label is mandatory**, the sigil is preferred, and color may serve as enhancement only.
+
+### Status indicators — icon + label
+
+Tribute status pills (injured, dehydrated, hungry, exposed, etc., per the emotion spec) are **always icon + text label paired**. Never icon-only.
+
+### Other semantic signals
+
+- Heraldic-red surfaces (danger, death) are paired with text and/or iconography.
+- The "live ●" badge from the progressive display spec is paired with the word "Live" or equivalent.
+- Gamemaker event indicators are paired with descriptive text on hover/expand.
+
+### Reduced motion
+
+See Motion section. `prefers-reduced-motion` is fully respected; no purely-decorative motion is ever uncancellable.
+
+### Contrast
+
+All foreground text on ground roles must meet **WCAG AA (4.5:1 for body, 3:1 for large)**. District electrics on ground must meet AA. Chrome gold against ground must meet at minimum the AA large-text threshold for use as control labels; ornamental chrome (borders, dividers) is exempt.
+
+## Integration with prior specs
+
+- **Layout spec (`2026-05-02-spectator-skin-layout-design.md`)** — this spec provides the visual treatment for panel chrome, HUD frame, headers, controls, dividers, and gutters specified there. The "chunky early-2000s portal" call is realized via Deco display type + subtle materiality + Deco frames + chrome gold.
+- **Emotion spec (`2026-05-02-tribute-emotions-design.md`)** — tribute status pills use the substrate iconography (B+ treatment + medallion frame) plus body-face text labels per accessibility.
+- **Weather spec (`2026-05-02-weather-system-design.md`)** — weather icons in the HUD mini-map and Map panel use the substrate iconography. Per-area weather is rendered with district-agnostic palette tokens (chrome gold or muted-foreground), since weather is environmental, not tribute-specific.
+- **Progressive display spec (`2026-05-02-progressive-display-design.md`)** — the "live ●" badge uses the heraldic accent (oxblood imperial red) or chrome gold (implementing instance picks); the timeline reveal pacing is the primary motion in the Action panel.
+
+## Testing strategy
+
+- **Palette accessibility audit:** every district color, chrome gold, and heraldic red tested against ground for WCAG AA contrast. Automated test against the palette tokens.
+- **Sequential-grouping correctness:** Action log and HUD ticker correctly collapse adjacent same-district items under a single banner.
+- **Triad presence:** automated test that every tribute-identity surface in the rendered DOM includes color + sigil-or-label + number.
+- **Status indicator pairing:** automated test that every status pill renders both icon and text label.
+- **Reduced-motion compliance:** all animations cancelled or instant under `prefers-reduced-motion: reduce`.
+- **Tabular-num correctness:** HUD numerics align across renders with different digit widths.
+- **Icon pipeline:** snapshot tests on the normalized SVG output of the substrate pipeline; visual regression against the Deco frame variants.
+- **Visual regression on identity icons:** snapshot tests for Panem seal, district sigils, Capitol mark.
+
+## Migration
+
+- The current `theme1/2/3` Tailwind theme variants (Ember/Forest/Gilded) are **superseded** by this spec. The spectator skin replaces all three. Future role skins (tribute, gamemaker) become the equivalent of "themes" in a more meaningful sense.
+- The current Mockingjay custom icons remain in the theme switcher slot for now and migrate to tribute-skin chrome later.
+- Existing game-icons.net SVGs go through the normalization pipeline as part of rollout; consumer code is updated to use the role-based naming convention.
+- District color tokens, sigil set, identity icon set are introduced as new design system artifacts (`district_palette`, `district_sigils`, `capitol_marks`).
+- Palette tokens, type tokens, materiality tokens, and motion tokens become part of the Tailwind config (or successor design-token system).
+
+## Open questions for implementation
+
+- Exact font selections for display, numeric, and body families (audition from shortlist).
+- Whether a secondary smaller-size display face is needed and which face it should be.
+- Pinned hex values for the 12-district palette satisfying the constraints listed.
+- Concrete materiality treatments — gradient angles, shadow radii, sheen intensity, noise texture choice.
+- Whether to ship subtle ambient motion on the HUD in v1 or defer.
+- Implementing the icon normalization pipeline — chosen toolchain (svgo, custom Python, Figma plugin export, etc.).
+- Whether the "live ●" badge uses chrome gold or heraldic red.
+- Whether to introduce a design-token system (Style Dictionary, native CSS custom properties, Tailwind tokens) or extend the existing Tailwind theme.
+
+## Out of scope (filed or to be filed as beads)
+
+- Bespoke hand-drawn Art Deco substrate icon set (future bead).
+- Tribute and gamemaker role skins.
+- D13 colors / sigil / branding.
+- Per-account synced visual preferences (theme variants within a role, if introduced).
+- Sound design / audio identity.
+- Sponsor-side UI surfaces and brand marks (future epic).
+- Marketing site / landing page visual identity outside the game view.
+- Print/export visual treatment (PDF replays, share images, etc.).

--- a/docs/superpowers/specs/2026-05-02-tribute-emotions-design.md
+++ b/docs/superpowers/specs/2026-05-02-tribute-emotions-design.md
@@ -247,17 +247,88 @@ impl Trait {
 }
 ```
 
-## Frontend Presentation (v1, Minimal)
+## Frontend Presentation
 
-The web frontend renders the derived label as a small status pill:
+The emotion UI is designed against the spectator skin (see `2026-05-02-spectator-skin-layout-design.md` and `2026-05-02-spectator-skin-visuals-design.md`). It surfaces in three places: the tribute card (Roster panel), the event log line (Action panel), and the inspect drilldown.
 
-- **Pill placement:** next to the tribute's name on both `TributeCard` and the tribute detail header.
-- **Visible only when label != Steady.** Unlabeled tributes show no pill (intentional — the labeled few stand out).
-- **Color convention:** label color follows its dominant axis (e.g., red for Enraged, gray for Broken, yellow for Hopeful, green for Resolute). Final palette decided during implementation.
-- **No axis bars in v1.** The four numeric axes are not surfaced in the UI; only the derived label. Axis bars / debug view filed as future work.
-- **Live updates** flow via the existing query refetch / websocket plumbing — no special handling beyond rendering the new label value.
+### Tribute card — bottom state strip
 
-Tooltip on hover (showing underlying axis values for debugging or curiosity) is optional for v1 — decide during implementation.
+Each tribute card has two zones:
+
+- **Top (identity zone)** — district color stripe + sigil + number + tribute name + alive/dead state + alliance membership.
+- **Bottom (state strip)** — the emotion surface.
+
+The state strip uses a **strict four-element vocabulary**, reading left-to-right:
+
+1. **Leading dot** *(always present)* — small colored dot encoding the **derived label's category** (calm / wary / hostile / despairing / enraged or final taxonomy). Categorical color lives only in this dot, contained so it does not compete with the district color in the identity zone.
+2. **Label pill** *(always present)* — the derived label as text inside a chrome-neutral pill. The pill carries no background color of its own; the leading dot is the only color carrier for emotion category.
+3. **Override icon** *(conditional)* — when an override state is active, a single icon appears: medallion-framed substrate icon (per the visuals spec's iconography system), rendered in **heraldic red** (oxblood) regardless of override type. The icon glyph carries the *kind* of override; the color carries "override active." If multiple overrides are simultaneously active, **only the highest-priority override is shown**, using the same threshold-priority list that derives the label.
+4. **Extreme-axis marker** *(conditional)* — when any axis is at a defined extreme (e.g. morale < 10, aggression > 90, trust < 10, composure < 10), a small **directional glyph** (↓ or ↑) labeled with the axis appears. Only **one marker is shown** — the most-extreme axis if multiple qualify.
+
+Calm tribute = dot + word. Escalating tribute = dot + word + icon + glyph. Maximum visual density per card is bounded; the strip never exceeds these four elements.
+
+### Event log line (Action panel)
+
+Emotion-changing events surface in the event log via a **leading category dot** at the left edge of the line, mirroring the card's leading dot color. The dot encodes the emotion category that the event resulted in (or the dominant category change).
+
+The prose itself is unmodified — no inline icons in the body of the line. This keeps the event log readable as prose and avoids icon clutter when many emotion changes happen in sequence.
+
+This composes cleanly with the **district sequential-grouping rule** from the visuals spec: when emotion-event lines for the same district group under one banner, the banner carries the district color and individual lines carry their per-line emotion-category dots. Two color systems, two roles, no conflict.
+
+If the leading dot proves too subtle in practice, the fallback is to add an inline override icon next to the state name within the prose. Filed as an open implementation question.
+
+### Alliance bond (not on the card)
+
+The per-alliance bond value is **not surfaced on individual tribute cards**. It is treated as an alliance-level concept rather than a tribute-level state, on the grounds that:
+
+- Card real estate is already at maximum density with the four-element state strip.
+- Bond is a slow-moving relational value, less moment-to-moment-actionable than the label/override/axis signals.
+- Bond is genuinely a property of *who is allied with whom how strongly* — an alliance attribute, not a per-tribute attribute.
+
+Alliance bond appears instead on:
+
+- **Alliance summary chips** — aggregate bond strength (average across members) shown as a small bar or dot pattern.
+- **Alliance inspect view** — full per-pair bond detail (which members feel how strongly bonded with which others).
+
+Per-pair bond detail is reserved for the inspect surface; the at-a-glance broadcast view shows aggregate.
+
+### Inspect drilldown (Roster panel menu → Inspect)
+
+The Roster's per-panel inspect view (per the layout spec) opens a dense data view scoped to tributes. For emotion this includes:
+
+- All four axis values per tribute, with current numeric values and recent trajectory.
+- All active overrides (not just the highest-priority one), with remaining duration / decay rate.
+- Per-alliance bond values for every alliance the tribute is in.
+- Recent emotion-changing events that drove the current state.
+
+The inspect view is the place all "I want the full picture" questions get answered. The card and event-log surfaces stay calm by design.
+
+### Live updates
+
+Live updates flow via the existing query refetch / websocket plumbing. Emotion changes appear:
+
+- On cards as state-strip element transitions (override icon appears/disappears, axis marker appears/disappears, label pill text changes).
+- On event-log lines as new entries with their leading category dot.
+- On alliance chips as aggregate bond shifts.
+- In the inspect view in real time when open.
+
+No special handling beyond rendering the new state.
+
+### Accessibility
+
+Per the visuals spec accessibility rules:
+
+- Color is never the sole signal. The leading dot is paired with the label pill text; the override icon is paired with hoverable / inspectable text describing the override; the axis marker is paired with the axis name (e.g. ↓Morale, not just ↓).
+- Override icons follow the substrate icon normalization: stroke weight, palette token, medallion frame are consistent.
+- Reduced-motion mode collapses any state-strip transition animations to instant swaps.
+
+### Open implementation questions
+
+- Final taxonomy of label categories and their dot colors (calm/wary/hostile/despairing/enraged or other groupings).
+- Exact axis-extreme thresholds per axis.
+- Exact form of the directional axis glyph (single arrow, arrow + axis name letter, etc.).
+- Whether the leading dot in event-log lines proves sufficient or whether to escalate to inline override icons.
+- Whether alliance-chip bond aggregate shows as a bar, dot pattern, or numeric value.
 
 ## Integration Points
 

--- a/docs/superpowers/specs/2026-05-02-tribute-emotions-design.md
+++ b/docs/superpowers/specs/2026-05-02-tribute-emotions-design.md
@@ -1,0 +1,291 @@
+# Tribute Emotions & Outlook — Design
+
+**Status:** Draft
+**Date:** 2026-05-02
+**Crate(s) primarily affected:** `game/`
+**Related specs:** `2026-04-25-tribute-alliances-design.md`, `2026-04-26-game-event-enum.md`
+
+## Goals
+
+Add a load-bearing emotional state layer to tributes that:
+
+1. **Mechanically influences combat and decision-making** (primary goal). Emotions modify the existing Brain decision tree and add new override states.
+2. **Increases behavioral diversity** between tributes. Two tributes with similar health/sanity can act differently because their emotional state differs.
+3. **Provides narrative color** for the announcer LLM, event log, and UI ("Cato is enraged after Glimmer's death").
+
+Non-goals:
+
+- Replace the existing `sanity` mechanic. Sanity is the long-term breakdown clock; emotions are short-term regulation and outlook.
+- Replace traits. Traits are who-you-are at reaping; emotions are who-you-become in the arena.
+
+## Model: Continuous Axes with Derived Label
+
+Tributes carry four continuous emotional axes (the truth of their state) and one derived dominant-emotion label (the display/narrative surface). All decisions are made on the axes; the label is a pure function of them.
+
+This is a hybrid by intent: continuous axes give nuance and clean numeric gating; the label gives the UI and announcer a single concept to render. The label can be flattened back into a simple enum later if the axis layer proves over-engineered.
+
+### The Four Axes
+
+All axes are `u8` in `0..=100`, neutral around `50`, clamped on every update.
+
+| Axis | Low end | High end | Primary mechanical role |
+|---|---|---|---|
+| **Morale** | despair, suicidal | hope, resolve | Rest/give-up thresholds; willingness to push forward |
+| **Aggression** | passive, fleeing | rage, bloodlust | Attack-vs-evade decisions; engaging when outnumbered |
+| **Trust** | paranoid, betrayer | loyal, cooperative | Alliance formation, betrayal odds, defensive aid (replaces `loyalty`) |
+| **Composure** | panicked, shaky | calm, focused | Combat accuracy gates; ability to use items under pressure |
+
+### Distinction from Existing Stats
+
+- **Sanity** (existing): long-term breakdown counter. Drains over the whole game; reaching 0 causes self-harm. Persistent damage.
+- **Composure** (new): short-term emotional regulation. Recovers via rest, drops on shocks. Recovers fully day-to-day if the tribute is safe.
+- **Trust** (new) **replaces** the per-tribute `loyalty: f32` scalar entirely. The old "loyalty to whom?" question is now answered by per-pair bond strength (below); Trust is the global disposition toward people in general.
+
+## Alliance Bond
+
+Per-alliance edge gets a `bond: u8` in `0..=100`. **Symmetric** — one number per alliance pair.
+
+Bond starts at `25` for newly-formed alliances, or `40` if both tributes are from the same district. Drifts upward through cooperative behavior, downward through neglect or conflict (see trigger table below).
+
+### What Bond Gates
+
+- **Betrayal probability.** Existing `loyalty < 0.25` check becomes `betrayal_probability` scaled inversely with bond. Higher bond, lower odds.
+- **Defensive aid (new mechanic).** Tributes with high bond to a nearby ally under attack may intervene on the ally's behalf.
+- **Grief impact.** When a bond-partner dies, the surviving tribute's Morale drop scales with bond. The grief table differentiates `bond ≥ 50` from `bond < 50`.
+- **Last-two-standing behavior.** High bond = hesitation; low bond = clean betrayal.
+
+### One-Sided Betrayals
+
+Bond is symmetric, but **decisions are per-tribute**. Even with shared `bond = 80`, A may roll betrayal this turn while B does not. The asymmetry lives in the decision, not the storage. The genuinely one-sided cases (gift-giving, healing) are handled as a small bond bonus to the recipient, retaining symmetry by convention.
+
+## Starting Values
+
+Tributes do **not** start identical. Traits provide a starting offset for each axis.
+
+Each `Trait` gains an `emotion_bias() -> (i8, i8, i8, i8)` method returning per-axis deltas (Morale, Aggression, Trust, Composure). At tribute creation:
+
+1. Start each axis at `50`.
+2. For each trait the tribute owns, sum its `emotion_bias` into the axes.
+3. Clamp final per-axis values to `20..=80` so no tribute starts in override-state territory.
+
+Example bias intuitions (final values to be tuned during implementation):
+
+- *Bloodthirsty:* `(0, +20, 0, 0)`
+- *Cowardly:* `(-5, -20, 0, -15)`
+- *Loyal:* `(0, 0, +20, 0)`
+- *Paranoid:* `(0, 0, -25, -5)`
+
+The trait→axes table is part of implementation, not this spec.
+
+## Triggers and Axis Updates
+
+Triggers fire during the existing `process_turn_phase` and combat-resolution paths. All deltas are signed and applied with saturating arithmetic, then clamped to `0..=100`.
+
+### Combat Triggers
+
+| Event | Morale | Aggression | Trust | Composure |
+|---|---|---|---|---|
+| Won fight (decisive) | +8 | +5 | — | +3 |
+| Won fight (normal) | +3 | +2 | — | +1 |
+| Lost fight (survived) | −5 | +3 | — | −8 |
+| Killed someone | +5 | +10 | −3 | −5 |
+| Took a wound | −3 | — | — | −5 |
+| Witnessed kill nearby | −2 | +1 | −2 | −3 |
+
+### Social Triggers
+
+| Event | Morale | Aggression | Trust | Composure | Bond |
+|---|---|---|---|---|---|
+| Formed alliance | +5 | — | +5 | +2 | (init 25/40) |
+| Ally died (bond ≥ 50) | −15 | +8 | −5 | −10 | n/a |
+| Ally died (bond < 50) | −5 | +2 | −2 | −3 | n/a |
+| Betrayed by ally | −10 | +12 | −20 | −8 | n/a (alliance breaks) |
+| Betrayed an ally | −3 | — | −5 | −3 | n/a (alliance breaks) |
+| District-mate died (non-ally) | −8 | +5 | — | −5 | — |
+| Received sponsor gift | +10 | — | +3 | +5 | — |
+| Survived turn together (same area) | — | — | — | — | +1 |
+| Fought side-by-side (both attacked enemies) | — | — | — | — | +3 |
+| Healed/gifted ally | +1 | — | — | — | +3 (recipient bond +5) |
+| Witnessed ally take damage, did not help | — | — | — | — | −1 |
+| Refused to share an item | — | — | −2 | — | −3 |
+| Competed for same kill/item | — | +1 | −1 | — | −1 |
+
+### Environmental / Passive Triggers
+
+"Alone" below means the tribute ended the turn with no living ally in the same `Area`. "Hit by area event" fires when `apply_area_effects` applies any `AreaEvent` to the tribute (currently: Wildfire, Flood, Earthquake, Avalanche, Blizzard, Landslide, Heatwave). The "Hungry / low on supplies" trigger is contingent on a hunger/supplies system existing — if no such system is present at implementation time, omit this row and revisit when supplies tracking lands.
+
+| Event | Morale | Aggression | Trust | Composure |
+|---|---|---|---|---|
+| Survived a day (alone) | −1 | — | −1 | +1 |
+| Survived a day (with ally in same area) | +1 | — | +1 | +1 |
+| Hungry / low on supplies *(if supported)* | −2 | +1 | — | −2 |
+| Hit by area event (flood, wildfire, etc.) | −3 | — | — | −5 |
+| Long rest in safe area | +2 | −1 | — | +5 |
+| Night falls (alone) | −2 | — | — | −2 |
+| Hidden successfully | +1 | −1 | — | +2 |
+
+### Passive Drift
+
+After all triggers resolve at end of turn, every axis moves toward `50` by `1`. If the axis is exactly at `50`, no change. If a `+1` step would cross `50` (e.g., from `49` to `50` or from `51` to `50`), it stops at `50` rather than overshooting. This provides a "reset" so emotional state doesn't ratchet permanently in one direction across long games. Triggers always dominate drift because trigger magnitudes are larger.
+
+Drift is **silent** — no `TributeEmotionalEvent` is emitted unless the drift causes a label change.
+
+## Brain Feedback (Mechanical Payoff)
+
+The existing `Brain::act()` decision tree is modified in two places. Pure additions; the existing health/sanity/intelligence logic stays.
+
+### Override States (Checked First)
+
+Before any normal decision logic:
+
+```text
+if outlook.morale     < 15  → Broken    (Rest or self-harm)
+if outlook.aggression > 85  → Enraged   (Attack)
+if outlook.composure  < 20  → Panicked  (Hide or random Move)
+if outlook.trust      < 20  → Paranoid  (refuse alliance, attack ally if cornered)
+```
+
+Multiple overrides hitting at once resolve by priority order above (Broken wins, then Enraged, etc.). The same priority order drives the derived label (next section).
+
+### Threshold Shifting (Otherwise)
+
+The existing decision-tree thresholds become functions of the axes rather than constants. Indicative formulas (final coefficients tuned during implementation; results clamped to sane bounds so a single axis can't make a threshold negative or exceed 100):
+
+```text
+attack_threshold = clamp(40 - (outlook.aggression - 50) * 0.4, 0, 100)
+rest_threshold   = clamp(20 + (50 - outlook.morale)    * 0.3, 0, 100)
+hide_threshold   = clamp(base_hide_threshold + (50 - outlook.composure) * 0.2, 0, 100)
+```
+
+A high-Aggression tribute attacks at lower health than baseline; a low-Morale tribute rests sooner; a low-Composure tribute hides more readily. Tributes near 50 on every axis behave identically to today's Brain.
+
+## Derived Label
+
+A pure function of the axes, evaluated whenever the axes change. Threshold-priority list, first match wins:
+
+```text
+Morale     <  15                              → Broken
+Aggression >  85                              → Enraged
+Composure  <  20                              → Panicked
+Trust      <  20                              → Paranoid
+Morale     <  30 AND Aggression > 65          → Vengeful
+Morale     >  75 AND Composure  > 65          → Resolute
+Morale     >  70 AND Trust      > 65          → Hopeful
+Aggression >  65 AND Composure  > 65          → Focused
+                                              → Steady (no special label)
+```
+
+The first four entries are the same thresholds as the override states — single source of truth.
+
+`Steady` tributes display no special label. This is intentional: labeled tributes stand out narratively because the unlabeled majority provides contrast.
+
+A label change is the storytelling moment. The announcer narrates it; the UI highlights it; the player notices it.
+
+## Events
+
+One event type covers all emotional updates. Defined in `game/src/tributes/events.rs`:
+
+```rust
+pub struct TributeEmotionalEvent {
+    pub tribute: Uuid,
+    pub trigger: EmotionTrigger,        // discriminant: Killed, Betrayed, AllyDied, etc.
+    pub axis_changes: AxisDeltas,       // {morale: i16, aggression: i16, trust: i16, composure: i16}
+    pub label_change: Option<(EmotionLabel, EmotionLabel)>,
+}
+```
+
+One event per *causing moment* — not one per axis. A kill emits a single event with all four axis deltas plus the optional label transition. This gives:
+
+- Announcer / event log: a clean unit to render per dramatic beat.
+- Progressive display: enough data to show subtle motion if it wants.
+- Replay / debugging: full causal chain.
+
+Passive drift does **not** emit an event unless it crosses a label boundary. When drift causes a label transition, emit with `trigger: EmotionTrigger::Drift` and the relevant axis deltas.
+
+## Data Model Changes
+
+### `Tribute` struct (`game/src/tributes/mod.rs`)
+
+```rust
+pub struct Tribute {
+    // ...existing fields...
+    pub outlook: Outlook,            // NEW
+    // pub loyalty: f32,             // REMOVED
+}
+```
+
+### New `Outlook` struct (`game/src/tributes/emotions.rs`)
+
+```rust
+pub struct Outlook {
+    pub morale: u8,
+    pub aggression: u8,
+    pub trust: u8,
+    pub composure: u8,
+}
+
+impl Outlook {
+    pub fn neutral() -> Self;
+    pub fn from_traits(traits: &[Trait]) -> Self;
+    pub fn apply(&mut self, deltas: AxisDeltas);
+    pub fn drift_toward_neutral(&mut self);
+    pub fn label(&self) -> EmotionLabel;
+}
+```
+
+### Alliance edge
+
+Wherever alliances are stored (per `2026-04-25-tribute-alliances-design.md`), the edge representation gains `bond: u8`. The exact storage shape is left to the alliance phase that introduces edges; this spec only specifies the field, default values, and update rules.
+
+If the current alliances representation is `allies: Vec<Uuid>`, this becomes `allies: Vec<Ally { id: Uuid, bond: u8 }>` or an equivalent parallel map keyed by Uuid.
+
+### `Trait` extension (`game/src/tributes/traits.rs`)
+
+```rust
+impl Trait {
+    pub fn emotion_bias(&self) -> (i8, i8, i8, i8);  // (morale, aggression, trust, composure)
+}
+```
+
+## Integration Points
+
+- **`Brain::act()`** — add override-state checks at the top; replace constant thresholds with axis-derived expressions in existing branches.
+- **`process_turn_phase()`** — invoke `outlook.drift_toward_neutral()` after triggers resolve; emit drift-driven label-change events.
+- **Combat (`attacks`, `apply_combat_results`)** — fire combat triggers on winners/losers/witnesses; bond updates for allies fighting side-by-side.
+- **Alliance code (`try_form_alliance`, betrayal paths)** — fire social triggers; replace existing `loyalty` reads with bond/Trust reads; initialize bond on formation.
+- **Area-effect application (`apply_area_effects`)** — fire environmental triggers when a tribute is hit by a flood/wildfire/etc.
+- **Sponsor-gift path (`receive_patron_gift`)** — fire sponsor-gift trigger.
+- **Event consumers (announcer, API, web)** — handle the new `TributeEmotionalEvent` variant in whatever event-rendering plumbing exists.
+
+## Testing Strategy
+
+Following the project's existing rstest pattern in `game/`:
+
+- **Unit tests for `Outlook`** — clamping, drift saturation at 50, trait-bias clamping to 20..=80, label derivation for every priority rung and the unlabeled fallback.
+- **Trigger application tests** — each trigger row in the tables produces the documented deltas; combined triggers in one turn sum correctly.
+- **Brain override tests** — each override state forces the documented action; threshold-shifting moves the existing decision boundaries by the predicted amount.
+- **Bond tests** — bond initialization values, symmetric update through cooperative-action triggers, betrayal-probability scales inversely with bond, grief delta differs across the 50-bond cutoff.
+- **Event emission tests** — one `TributeEmotionalEvent` per causing moment; passive drift silent unless label changes.
+- **Loyalty removal regression** — existing tests that touch `loyalty` either are converted to read Trust/bond or are deleted with rationale in the commit message.
+
+## Migration / Backward Compatibility
+
+- The `loyalty` field is removed from `Tribute`. SurrealDB persisted games need migration: drop the `loyalty` field, add `outlook` with neutral values (all axes at `50`), add `bond` to alliance edges with a default of `25` (or `40` if same district). Migration lives as a new entry under `migrations/definitions/` plus accompanying `schemas/*.surql` updates, following the existing `surrealdb-migrations` pattern.
+- API DTOs in `shared/` that surface tribute state need a paired field for outlook + label so the frontend can render it. Existing API consumers ignore unknown fields, so addition is non-breaking; removal of `loyalty` from any DTO is breaking and must be coordinated with the web frontend.
+- In-flight games re-hydrate with neutral outlooks rather than reconstructing emotional history from event logs (out of scope for v1).
+
+## Open Questions for Implementation
+
+These don't need to be answered before writing the implementation plan, but the implementer will need to make calls:
+
+- Exact `emotion_bias()` values per trait — needs a pass over the trait list with a tuning eye.
+- Final coefficients in threshold-shifting formulas (the `* 0.4`, `* 0.3` placeholders).
+- Drift magnitude — `±1` per turn is the starting value; may need to be `±2` if testing shows axes get stuck.
+- Whether `EmotionTrigger` is one large enum or a struct-of-cause-data.
+
+## Out of Scope
+
+- Visual presentation of emotions in the web frontend (covered by the upcoming progressive-display spec).
+- Announcer prompt changes to use the new event payload (covered separately when announcer integration lands).
+- Any new traits introduced by the emotion system.
+- Multi-emotion display (always exactly one label or none).

--- a/docs/superpowers/specs/2026-05-02-tribute-emotions-design.md
+++ b/docs/superpowers/specs/2026-05-02-tribute-emotions-design.md
@@ -247,6 +247,18 @@ impl Trait {
 }
 ```
 
+## Frontend Presentation (v1, Minimal)
+
+The web frontend renders the derived label as a small status pill:
+
+- **Pill placement:** next to the tribute's name on both `TributeCard` and the tribute detail header.
+- **Visible only when label != Steady.** Unlabeled tributes show no pill (intentional — the labeled few stand out).
+- **Color convention:** label color follows its dominant axis (e.g., red for Enraged, gray for Broken, yellow for Hopeful, green for Resolute). Final palette decided during implementation.
+- **No axis bars in v1.** The four numeric axes are not surfaced in the UI; only the derived label. Axis bars / debug view filed as future work.
+- **Live updates** flow via the existing query refetch / websocket plumbing — no special handling beyond rendering the new label value.
+
+Tooltip on hover (showing underlying axis values for debugging or curiosity) is optional for v1 — decide during implementation.
+
 ## Integration Points
 
 - **`Brain::act()`** — add override-state checks at the top; replace constant thresholds with axis-derived expressions in existing branches.

--- a/docs/superpowers/specs/2026-05-02-weather-system-design.md
+++ b/docs/superpowers/specs/2026-05-02-weather-system-design.md
@@ -280,16 +280,174 @@ The `compute_hazard_weights` function and its underlying table.
 
 Add a `weather` field to whatever `DisplayArea` (or equivalent area DTO) the frontend consumes. New addition is non-breaking; existing API consumers ignore unknown fields.
 
-## Frontend Presentation (v1, Minimal)
+## Frontend Presentation
 
-The web frontend renders current weather per area as an icon with a tooltip:
+The weather UI lives at two scales: the **Map panel proper** (primary spatial reference) and the **HUD mini-map** (compressed echo). Both are designed against the spectator skin (see `2026-05-02-spectator-skin-layout-design.md` and `2026-05-02-spectator-skin-visuals-design.md`).
 
-- **Icon placement:** in the area card / area detail header, next to terrain or area name.
-- **Icon set:** one glyph per `Weather` variant (☀ Clear, ☁ Overcast, 🌫 Fog, 🌦 LightRain, 🌧 HeavyRain, ⛈ Storm, 🌨 LightSnow, ❄ HeavySnow, 🌪 Sandstorm). Final glyphs (emoji vs. inline SVG) decided during implementation; consistency with the existing icon system in `web/src/components/` takes priority.
-- **Tooltip on hover** shows the weather name, a one-line description, and the visible per-tribute consequences ("Heavy rain — exposed tributes lose 1 health/phase, visibility −3").
-- **No animated icons in v1.** Static glyph only; animated weather icons filed as future work.
-- **No forecast.** Per the design, only current weather is visible (re-confirmed here for the frontend).
-- **`WeatherChanged` events** render as event cards in the Timeline (handled by the progressive-display spec); the area icon updates via the standard query refetch / websocket plumbing.
+### Map panel substrate
+
+The Map panel renders the arena as a **schematic node graph of hexagons**. Each hex is one area; edges between hexes represent area adjacency. No imposed grid, no pseudo-geographic illustration — the substrate honors the underlying area-graph data model and reads as a Gamemaker's situation board.
+
+Why hexagons:
+- Geometric kinship with the medallion frame system from the visuals spec's iconography.
+- Clean Art Deco geometric construction.
+- Six neighbors per node maps cleanly to the area adjacency graph.
+
+The implementing instance picks the auto-layout strategy (force-directed, hand-tuned per arena, or hybrid) and the hex sizing rules.
+
+### Tribute avatars on hexes
+
+Each hex hosts a **honeycomb cluster** of tribute avatars representing the tributes currently in that area.
+
+**Avatar definition (v1):** geometric token. A small hexagonal token containing:
+- Tribute initials in chrome gold (numeric/display face).
+- District color as the token background or border.
+- District sigil tucked in a corner (per the accessibility triad).
+
+**Avatar slot is swappable.** The avatar component is designed as a slot that can be replaced later by:
+- Procedural / AI-generated portraits.
+- User-uploaded illustrative avatars.
+
+When portraits land, the surrounding cluster, hex, and overlay code is unchanged. Filed as future beads.
+
+**Cluster behavior:**
+- Honeycomb arrangement inside the hex, up to **6 visible avatars**.
+- 7th-or-greater tributes collapse the last slot into a **"+N"** chrome-gold neutral token (no district color, since composition is mixed) showing "+N" in the numeric face.
+- Click "+N" to expand into a popover or jump to the area's inspect view.
+
+**Tribute marker mode** (the "Tributes" overlay): avatars dominate; weather/event signals are de-emphasized to corner glyphs only, no interior tint.
+
+### Reciprocal Map ↔ Roster highlighting
+
+Hovering or focusing a Map avatar puts a chrome-gold ring around it AND scrolls/highlights the corresponding card in the Roster panel. The reverse also holds: hovering a Roster card highlights the avatar on the Map. The HUD ticker death entries get the same treatment when applicable.
+
+Each avatar carries an HTML `title` attribute with the tribute's name as an accessibility/fallback tooltip.
+
+### Three-layer hex rendering (weather, hazard, gamemaker event)
+
+A hex can simultaneously render up to three signals from the weather spec's three-layer architecture. Each layer uses a distinct palette role and frame variant from the visuals spec, making them unambiguous at a glance:
+
+| Layer | Color (palette role) | Frame variant | Position |
+| --- | --- | --- | --- |
+| **Weather (current variant)** | Chrome gold or muted-foreground (environmental, never district color) | Medallion | One corner |
+| **Natural hazard (active)** | Heraldic red (oxblood, dangerous-by-definition) | Medallion with emphasis (thicker border, optional subtle pulse) | Opposite corner |
+| **Gamemaker event (active)** | Chrome gold (Capitol-authored, "the show speaking") | Stepped border (distinct from weather's medallion) | Third corner or stacking rule |
+
+The frame distinction (medallion vs stepped) carries the *Capitol-authored vs environmental* semantic, reinforcing the visuals spec's iconography system.
+
+### Weather rendering on a hex
+
+Weather has two visual encodings on a hex:
+
+1. **Always-present corner glyph.** A substrate icon (per the B+ pipeline in the visuals spec) for the current weather variant, medallion-framed, in chrome gold or muted-foreground. Glyph carries unambiguous variant identity. Hoverable / focusable for the variant name + temperature + active hazards.
+
+2. **Conditional interior tint.** When the **"Weather" overlay is the active Map overlay**, the hex interior carries a low-saturation wash keyed to the variant (muted blue for rain variants, white-grey for snow, ochre for sandstorm, neutral for clear/overcast, semi-transparent grey for fog). The tint is suppressed in other overlay modes so it doesn't drown avatars.
+
+This composite respects the visuals spec's accessibility rule (color is never the sole signal — glyph + label always present) and resolves the substrate-vs-overlay tension cleanly via overlay-mode conditioning.
+
+### Weather variant glyph mapping
+
+The substrate icon system carries one glyph per variant:
+
+- Clear, Overcast, Fog, LightRain, HeavyRain, Storm, LightSnow, HeavySnow, Sandstorm.
+
+Glyphs are normalized through the substrate icon pipeline (single stroke weight, palette tokens, snapped to grid, named by role — `icon-weather-clear`, `icon-weather-storm`, etc.). They are never hardcoded as emoji.
+
+### Transition motion on weather change
+
+When weather changes (LightRain → HeavyRain, HeavySnow → Storm, etc.), the affected hex animates a brief **1–2s transition**:
+- Corner glyph swaps (cross-fade or slide).
+- Interior tint shifts to the new variant's tint (if weather overlay is active).
+
+This fits the visuals spec's "minimal and purposeful" motion budget — weather changes are events worth noticing. `prefers-reduced-motion: reduce` collapses the transition to an instant swap.
+
+### Hazard glyphs
+
+Active hazards (flood, wildfire, etc., per the hazard system section above) render as a heraldic-red medallion-with-emphasis glyph in the opposite corner from weather. The medallion's emphasis treatment (thicker border, optional subtle pulse) signals "this is dangerous, not just informational."
+
+Hazards are per-area, transition-aware, and may have multiple simultaneous instances. Multi-hazard rendering rule:
+
+- **Single hazard:** glyph in the dedicated hazard corner.
+- **Multiple hazards:** highest-priority hazard takes the corner; secondary hazards are surfaced via the hex's hover/inspect (no on-hex visual stacking — would compete with avatars).
+
+### Gamemaker event glyphs
+
+Active gamemaker events render as a chrome-gold stepped-frame glyph in a third hex corner (or, if a fourth corner is unavailable due to layout, replacing weather's corner — gamemaker-event presence implies "the show is talking about this area," which trumps ambient weather attention). The stepped frame distinguishes the layer at a glance from medallion-framed weather/hazards.
+
+Multi-event rule mirrors hazards: highest-priority event takes the slot; full list in hover/inspect.
+
+### Map panel header — overlay toggle
+
+The Map panel's header context strip carries an inline segmented control / tab group:
+
+- **Tributes** *(default on first load)*
+- **Weather**
+- **Events**
+- **All**
+
+The active overlay is highlighted; switching is one click. Overlay mode is persisted per-device per-panel alongside other panel state (per the layout spec). The panel menu hosts everything else (zoom, inspect drilldown).
+
+Overlay behavior summary:
+
+| Overlay | Avatars | Weather glyph | Weather tint | Hazard glyph | GM event glyph | Event density |
+| --- | --- | --- | --- | --- | --- | --- |
+| Tributes | Honeycomb | Corner glyph only | Suppressed | Corner glyph | Corner glyph | None |
+| Weather | De-emphasized | Corner glyph | Visible | Corner glyph | Corner glyph | None |
+| Events | De-emphasized | Corner glyph | Suppressed | Corner glyph | Corner glyph | Heatmap on hex fill |
+| All | Honeycomb | Corner glyph | Visible | Corner glyph | Corner glyph | Heatmap accent |
+
+"De-emphasized" avatars become small district-color dots in the cluster region rather than full tokens — area population is still visible but doesn't compete with the active overlay.
+
+### HUD mini-map
+
+The HUD's expanded info bar carries a mini-map (per the layout spec). At mini-map scale, hexes are too small for honeycomb avatars or per-hex glyphs. Compressed rules:
+
+- **Hexes are tiny** — single color fill only.
+- **Weather overlay:** hexes filled with the variant tint. Hover/tap a hex shows a tooltip with variant name + temperature + active hazards.
+- **Events overlay:** hex fill intensity encodes recent-event density (heatmap), with last-event icon on the highest-density hex if space permits.
+- **Both:** events as fill intensity, weather as a thin border tint per hex.
+- **Tribute count badge:** small numeric badge (count only, per the mini-map count-only decision) in hex center if any tributes present. Always visible regardless of overlay.
+
+The mini-map is intentionally lossy. Its job is "is anything *interesting* happening anywhere I should look at the main Map?" If yes, the user expands the panel or jumps to the main Map.
+
+### `WeatherChanged` events in the Action panel
+
+`WeatherChanged` and hazard-onset / hazard-end events render as event log lines in the Action panel (per `2026-05-02-progressive-display-design.md`). They use:
+
+- **Leading category dot:** chrome gold (environmental) or heraldic red (hazardous), matching the layer.
+- **Substrate weather/hazard icon** inline if the event is the dominant content (e.g. "A storm rolled into the Forest"). Otherwise plain prose.
+
+Sequential grouping per the visuals spec: multiple weather events for the same area within a short window can collapse under a single area-banner.
+
+### Accessibility
+
+Per the visuals spec rules:
+
+- Weather glyphs are paired with hoverable / focusable text labels (variant name, temperature, hazards). Color and tint are never sole signals.
+- Hazard glyphs are paired with the hazard name; heraldic red signals danger but never alone.
+- Gamemaker event glyphs are paired with descriptive text.
+- Avatar tokens carry initials + sigil + district number per the standard triad.
+- All hex hover/focus states have keyboard-navigable equivalents (tab order across hexes; arrow-key navigation between adjacent hexes is desirable).
+- Reduced-motion collapses weather transitions to instant.
+
+### Open implementation questions
+
+- Auto-layout strategy for the hex node graph (force-directed vs hand-tuned per arena vs hybrid).
+- Hex size at each breakpoint and the avatar honeycomb sizes inside.
+- Exact tint colors per weather variant (must satisfy WCAG contrast against avatars overlaid on top).
+- Whether to render the avatar slot as SVG inline or as a Dioxus component with conditional content.
+- Heatmap intensity scale for the Events overlay (linear vs logarithmic).
+- Whether Map ↔ Roster reciprocal highlighting uses scroll-into-view, a flash effect, or both.
+- Whether keyboard navigation between hexes follows the graph (next-neighbor) or a flat reading order.
+
+### Out of scope (filed or to be filed as beads)
+
+- Stylized pseudo-geographic substrate (replaces hex node graph as the visual base when arena-specific illustrations exist).
+- Tribute portrait avatars (procedural, AI-generated).
+- User-uploaded tribute avatars (auth, storage, moderation implications).
+- Animated weather glyphs (beyond transition swaps).
+- Forecasting UI.
+- Multi-arena map navigation (if multiple arenas per game ever lands).
 
 ## Integration Points
 

--- a/docs/superpowers/specs/2026-05-02-weather-system-design.md
+++ b/docs/superpowers/specs/2026-05-02-weather-system-design.md
@@ -280,6 +280,17 @@ The `compute_hazard_weights` function and its underlying table.
 
 Add a `weather` field to whatever `DisplayArea` (or equivalent area DTO) the frontend consumes. New addition is non-breaking; existing API consumers ignore unknown fields.
 
+## Frontend Presentation (v1, Minimal)
+
+The web frontend renders current weather per area as an icon with a tooltip:
+
+- **Icon placement:** in the area card / area detail header, next to terrain or area name.
+- **Icon set:** one glyph per `Weather` variant (☀ Clear, ☁ Overcast, 🌫 Fog, 🌦 LightRain, 🌧 HeavyRain, ⛈ Storm, 🌨 LightSnow, ❄ HeavySnow, 🌪 Sandstorm). Final glyphs (emoji vs. inline SVG) decided during implementation; consistency with the existing icon system in `web/src/components/` takes priority.
+- **Tooltip on hover** shows the weather name, a one-line description, and the visible per-tribute consequences ("Heavy rain — exposed tributes lose 1 health/phase, visibility −3").
+- **No animated icons in v1.** Static glyph only; animated weather icons filed as future work.
+- **No forecast.** Per the design, only current weather is visible (re-confirmed here for the frontend).
+- **`WeatherChanged` events** render as event cards in the Timeline (handled by the progressive-display spec); the area icon updates via the standard query refetch / websocket plumbing.
+
 ## Integration Points
 
 - **Game loop (`process_turn_phase` and surrounding cycle code)** — at each phase boundary, for each area: roll weather transition → roll hazard → apply modifiers / emit events.

--- a/docs/superpowers/specs/2026-05-02-weather-system-design.md
+++ b/docs/superpowers/specs/2026-05-02-weather-system-design.md
@@ -1,0 +1,330 @@
+# Weather System — Design
+
+**Status:** Draft
+**Date:** 2026-05-02
+**Crate(s) primarily affected:** `game/`, `shared/`
+**Related specs:** `2026-04-17-terrain-biome-system-design.md`, `2026-04-17-event-severity-integration.md`, `2026-04-26-game-event-enum.md`, `2026-05-02-tribute-emotions-design.md`
+**Related future spec:** Gamemaker Event System (to be filed separately)
+
+## Goals
+
+Add a persistent atmospheric layer to each area that:
+
+1. **Influences combat and movement** through derived per-state modifiers (primary mechanical role).
+2. **Drives natural hazards** (formerly `AreaEvent`) by combining with terrain so disasters feel earned, not arbitrary.
+3. **Provides ambient narrative texture** the announcer can lean on ("a storm rolls into the Forest as night falls").
+4. **Separates natural causation from gamemaker intervention** — the existing `AreaEvent` enum currently mixes "wildfire spreads in dry forest" with "fireballs from the sky." This spec untangles them.
+
+Non-goals:
+
+- Implementing the gamemaker-event side of the split. That gets its own spec; this one only carves the boundary.
+- Modeling forecasts, atmospheric fronts, pressure systems, or any meteorological realism beyond per-area Markov transitions.
+- Sponsoring weather-aware items, shelter-class items, or gamemaker weather control. Future work.
+
+## Three-Layer Architecture
+
+The current `AreaEvent` enum does two unrelated jobs: natural consequences of conditions (wildfire, flood) and gamemaker interventions (which are not yet implemented but are the obvious next step — fireballs, mutts). This spec splits them and adds the missing weather layer underneath.
+
+| Layer | What it is | Lifecycle | Examples |
+|---|---|---|---|
+| **Weather** *(new)* | Persistent atmospheric state per area | Evolves slowly per-day-phase | Clear, LightRain, HeavyRain, Storm, Snow, Fog |
+| **NaturalHazard** *(refactor of `AreaEvent`)* | Acute event caused by terrain + weather | One-shot, probabilistic | Wildfire, Flood, Avalanche, Landslide, Heatwave, Earthquake |
+| **GamemakerEvent** *(new, separate spec)* | Imposed Capitol intervention | One-shot, narratively-driven, weather-independent | Fireballs, Mutts, ForceFieldShift, AreaClosure |
+
+This spec covers Weather and NaturalHazard. GamemakerEvent is filed as a separate brainstorm.
+
+### Carving the Existing `AreaEvent`
+
+Current `AreaEvent` variants and where they go:
+
+- **Stay as NaturalHazard:** Wildfire, Flood, Earthquake, Avalanche, Blizzard, Landslide, Heatwave, Rockslide.
+- **Removed (folded into Weather):** Sandstorm — the weather state's modifiers do the damage; no separate hazard variant. Drought — dropped entirely; long-term aridity is a terrain property already.
+- **Future GamemakerEvent variants:** none migrate from `AreaEvent` directly. The gamemaker spec defines its own enum.
+
+`Heatwave` is acute, not a sustained weather state — gamemakers cranking the temperature in an already-hot area. It stays a NaturalHazard, weighted toward hot terrain (Desert, Badlands).
+
+## Weather State Space
+
+Discrete enum with derived modifier methods (model C — same pattern as `EmotionLabel` derived from axes in the emotions spec). The variant set is curated and small; consumers read modifier methods, never the variant name directly, so adding a state means adding modifier methods rather than patching match arms across the codebase.
+
+```rust
+pub enum Weather {
+    Clear,
+    Overcast,
+    Fog,
+    LightRain,
+    HeavyRain,
+    Storm,
+    LightSnow,
+    HeavySnow,
+    Sandstorm,
+}
+```
+
+### Derived Modifier Surface
+
+Every variant implements:
+
+```rust
+impl Weather {
+    pub fn visibility_modifier(&self) -> i8;       // applied to combat/detection rolls
+    pub fn movement_modifier(&self) -> i8;         // applied to effective speed
+    pub fn temperature_band(&self) -> TemperatureBand;  // Cold/Cool/Mild/Warm/Hot/Scorching
+    pub fn hide_modifier(&self) -> i8;             // bonus or penalty to hide rolls
+    pub fn exposure_health_tick(&self) -> u8;      // damage per phase if exposed (0 = no tick)
+    pub fn exposure_sanity_tick(&self) -> u8;      // sanity damage per phase if exposed
+    pub fn hazard_weight_multiplier(&self, hazard: NaturalHazard) -> f32;
+    pub fn is_extreme(&self) -> bool;              // Storm, HeavySnow, Sandstorm
+    pub fn is_precipitating(&self) -> bool;
+}
+```
+
+### Starter Modifier Table (per-phase tribute effects)
+
+Final values to be tuned during implementation; these are the design targets.
+
+| Weather | Visibility | Movement | Hide | Health tick (exposed) | Sanity tick (exposed) |
+|---|---|---|---|---|---|
+| Clear | 0 | 0 | 0 | 0 | 0 |
+| Overcast | 0 | 0 | 0 | 0 | 0 |
+| Fog | −6 | 0 | **+3** | 0 | 0 |
+| LightRain | −1 | −1 | 0 | 0 | 0 |
+| HeavyRain | −3 | −2 | 0 | 1 | 0 |
+| Storm | −5 | −3 | 0 | 2 | 0 |
+| LightSnow | −1 | −2 | **−2** | 0 | 0 |
+| HeavySnow | −3 | −4 | **−3** | 2 | 0 |
+| Sandstorm | −7 | −4 | 0 | 2 | 1 |
+
+Principles baked in:
+
+- **Visibility hits combat/detection** — added to both `attack_contest` rolls (attacker and defender). Heavy fog and sandstorms make every attack feel like fumbling.
+- **Movement modifier reduces effective speed** in `travels`, same path as the existing `BROKEN_BONE_LEG_SPEED_REDUCTION`.
+- **Hide modifier** — fog *helps* hiding (low visibility everywhere); snow *hurts* hiding (visible tracks).
+- **Exposure ticks fire only if exposed** — i.e., the tribute is not Hidden *and* the tribute is not in a shelter-providing area. For v1, "shelter" is defined as: `TributeStatus::Hidden` is set, OR the tribute's current `Area` has `BaseTerrain::UrbanRuins`. Shelter-class items are out of scope.
+- **Sanity tick on Sandstorm only** — most weather is irritating, sandstorms are *psychologically* grinding (per Q5 discussion).
+
+## Per-Area, Per-Phase Lifecycle
+
+Each `Area` (or `AreaDetails`) carries:
+
+```rust
+pub struct AreaWeather {
+    pub current: Weather,
+    pub phases_in_state: u8,    // turns since last transition; capped to avoid overflow
+}
+```
+
+Each game day has two phases (day, night) per the existing day/night cycle in `process_turn_phase`. At each phase boundary:
+
+1. **Weather transition roll** — Markov chain on current weather, conditioned on terrain.
+2. **Hazard roll** — using the (possibly-new) weather + terrain, with a transition bonus if the weather just escalated.
+3. **Apply modifiers** — visibility, movement, exposure ticks applied to tributes in the area for the duration of the phase.
+4. **Emit `WeatherChanged` event** if the state changed; otherwise silent.
+
+This is twice per game day. Within a phase, weather is constant.
+
+### Starting Weather
+
+At game creation, for each area:
+
+- **Cornucopia** always starts `Clear`. Mirrors the bloodbath staging — gamemakers want maximum visibility for the opening spectacle.
+- **All other areas:** sampled from the stationary distribution of the area's terrain transition matrix, biased toward neutral states. Implementation: down-weight `is_extreme()` variants by an additional factor (e.g., ×0.25) when sampling Day 1 weather. This gives Day 1 atmospheric variety without immediate disaster.
+
+## Markov Chain Evolution
+
+Each `BaseTerrain` has its own transition matrix governing what weather is plausible in that terrain. Most cells are `0`; the matrix is sparse.
+
+```rust
+fn transition_weights(terrain: BaseTerrain, current: Weather) -> &'static [(Weather, u32)];
+```
+
+Returned weights feed a weighted random sample. Sample illustrates the shape (final tables tuned during implementation):
+
+**Forest, current = Clear:** `[(Clear, 60), (Overcast, 25), (Fog, 8), (LightRain, 7)]`
+**Forest, current = HeavyRain:** `[(HeavyRain, 30), (Storm, 20), (LightRain, 35), (Overcast, 15)]`
+**Desert, current = Clear:** `[(Clear, 70), (Overcast, 15), (Sandstorm, 10), (HeavyRain, 5)]`
+**Desert, current = HeavyRain:** `[(HeavyRain, 20), (Storm, 10), (LightRain, 30), (Clear, 40)]` *(rain doesn't last in desert)*
+**Tundra, current = Clear:** `[(Clear, 55), (Overcast, 20), (LightSnow, 15), (Fog, 10)]`
+**Tundra, current = HeavySnow:** `[(HeavySnow, 40), (LightSnow, 35), (Storm, 10), (Overcast, 15)]`
+
+Transitions to states with `0` weight are impossible (no `Sandstorm` in Tundra, no `HeavySnow` in Desert). Each terrain's table embeds its climate.
+
+The full per-terrain matrix is part of implementation, not this spec.
+
+## Hazard System (Transition-Aware)
+
+Hazard rolls happen *after* the weather transition each phase. Weights are computed from `(weather, terrain, hazard)`, with a bonus if the weather just escalated.
+
+### `NaturalHazard` Enum
+
+```rust
+pub enum NaturalHazard {
+    Wildfire,
+    Flood,
+    Earthquake,
+    Avalanche,
+    Blizzard,
+    Landslide,
+    Heatwave,
+    Rockslide,
+}
+```
+
+Same set as today's `AreaEvent` minus Sandstorm and Drought. Severity, survival rolls, status-effect application, and emotion triggers (existing "hit by area event" trigger) all carry over from the current `AreaEvent` machinery — this is a rename + scope-narrowing, not a behavioral rewrite of hazards themselves.
+
+### Weight Computation
+
+```rust
+fn compute_hazard_weights(
+    weather: Weather,
+    terrain: BaseTerrain,
+    just_escalated: bool,
+) -> Vec<(NaturalHazard, u32)>;
+```
+
+`just_escalated` is `true` when the weather changed *and* the new state has a strictly higher severity rank than the previous one. Severity ranks (low → high):
+
+```
+Clear / Overcast / Fog        = 0  (calm)
+LightRain / LightSnow         = 1  (mild)
+HeavyRain / HeavySnow         = 2  (heavy)
+Storm / Sandstorm             = 3  (extreme)
+```
+
+A `Clear → HeavyRain` transition escalates by 2 ranks → `just_escalated = true`. A `HeavyRain → LightRain` transition de-escalates → `just_escalated = false`. A `Clear → Overcast` transition is same-rank → `just_escalated = false`.
+
+For each plausible `(weather, terrain)` combination, a small table maps to hazards:
+
+| Weather | Terrain | Hazard | Base weight | Transition bonus (if escalated) |
+|---|---|---|---|---|
+| HeavyRain | **Desert / Badlands** | **Flood** | **30** | **+50** |
+| HeavyRain | Wetlands | Flood | 12 | +20 |
+| HeavyRain | Forest / Grasslands | Flood | 6 | +15 |
+| HeavyRain | Mountains / Highlands | Landslide | 15 | +25 |
+| Storm | Desert / Badlands | Flood | 35 | +60 |
+| Storm | any lowland | Flood | 18 | +30 |
+| Storm | Mountains | Landslide | 20 | +30 |
+| HeavySnow | Mountains | Avalanche | 20 | +25 |
+| HeavySnow | Highlands | Avalanche | 12 | +20 |
+| Clear | Desert / Badlands | Heatwave | 4 | n/a |
+| (any) | (any) | Earthquake | 1 | n/a *(weather-independent baseline)* |
+
+After weights are summed, roll: pick one hazard from the weighted distribution, or roll `None` (no hazard this phase) using a baseline `no-hazard` weight (e.g., 50). The full table is implementation work.
+
+**Two independent terrain effects are now in play:**
+
+1. **Terrain shapes which weather is common** (the Markov transition table — deserts trend Clear and Sandstorm, tundras trend Snow).
+2. **Terrain shapes which hazards a given weather triggers** (the weight table — HeavyRain in a Desert is much more likely to flash-flood than HeavyRain in Wetlands).
+
+Earthquakes and Rockslides remain weather-independent (small constant baseline weight regardless of weather) — they're geological, not atmospheric. They still fit under NaturalHazard because they're caused by the world, not the gamemakers.
+
+### The "Clear → HeavyRain in Desert" Worked Example
+
+1. Phase boundary. Area = Desert, current weather = Clear.
+2. Markov roll on Desert/Clear table → `HeavyRain` (5% chance).
+3. `just_escalated = true` (Clear=0 → HeavyRain=2, two-rank jump).
+4. `compute_hazard_weights(HeavyRain, Desert, true)` → `[(Flood, 30 + 50 = 80), (None, 50)]`.
+5. Roll: Flood fires (≈61% probability).
+6. Existing `AreaEvent::Flood` survival/damage logic runs. `WeatherChanged { area, Clear → HeavyRain, Day }` event is emitted, plus the existing flood event.
+
+In contrast: same transition in Wetlands would produce `Flood` weight `12 + 20 = 32` against `None` `50`, ≈39% — a coin flip.
+
+## Emotion Integration
+
+Per the emotions spec, exposure to harsh weather produces a new dedicated trigger weaker than the punctual area-event trigger:
+
+```rust
+EmotionTrigger::ExposedToHarshWeather  // axis_changes: morale -1, composure -2
+```
+
+Fired once per phase per exposed tribute on weather states with `exposure_health_tick() > 0` or `exposure_sanity_tick() > 0`. A tribute caught in a Storm during the day phase, in `Cornucopia` (no shelter) and not Hidden, accrues one trigger that phase.
+
+The existing `EmotionTrigger::HitByAreaEvent` (from emotions spec) continues to fire when a NaturalHazard hits the tribute, separately and additively.
+
+## Events
+
+New event:
+
+```rust
+pub struct WeatherChanged {
+    pub area: Area,
+    pub from: Weather,
+    pub to: Weather,
+    pub phase: DayPhase,  // Day or Night
+}
+```
+
+Emitted only when the Markov roll changes the state. Silent on no-op transitions (e.g., `Clear → Clear`). The announcer can lean on these for atmospheric beats ("as night falls, a storm rolls into the Forest").
+
+NaturalHazard events continue to fire from the existing `AreaEvent` plumbing (renamed). No change to event volume from hazards.
+
+## Data Model Changes
+
+### `Area` / `AreaDetails` (`game/src/areas/mod.rs`)
+
+Add a `weather: AreaWeather` field. Migration sets initial values per the starting-weather rules.
+
+### `Weather` enum (new `game/src/areas/weather.rs`)
+
+The enum, its modifier methods, and the Markov transition function live here. Per-terrain transition tables and stationary distributions in a sibling `transition_tables.rs`.
+
+### `NaturalHazard` (refactor of existing `AreaEvent`)
+
+Rename `AreaEvent` → `NaturalHazard` in `game/src/areas/events.rs`. Remove `Sandstorm` and `Drought` variants. All `FromStr` / `Display` / `random_for_terrain` impls update accordingly. Existing `EventSeverity` and `SurvivalResult` types stay as-is.
+
+### Hazard weight table (new `game/src/areas/hazards.rs` or extension of `events.rs`)
+
+The `compute_hazard_weights` function and its underlying table.
+
+### `shared/` DTOs
+
+Add a `weather` field to whatever `DisplayArea` (or equivalent area DTO) the frontend consumes. New addition is non-breaking; existing API consumers ignore unknown fields.
+
+## Integration Points
+
+- **Game loop (`process_turn_phase` and surrounding cycle code)** — at each phase boundary, for each area: roll weather transition → roll hazard → apply modifiers / emit events.
+- **Combat (`attack_contest` in `tributes/mod.rs`)** — read current area weather, add `visibility_modifier()` to both attacker and defender rolls.
+- **Movement (`travels` in `tributes/mod.rs`)** — apply `movement_modifier()` to effective speed.
+- **Hiding (`hides` and related)** — apply `hide_modifier()` to hide success rolls.
+- **Status processing (`process_status`)** — if the tribute is exposed, apply `exposure_health_tick()` and `exposure_sanity_tick()`; fire `ExposedToHarshWeather` emotion trigger.
+- **Hazard application** — existing `apply_area_effects` keeps its shape; the input is now selected by `compute_hazard_weights` instead of `AreaEvent::random_for_terrain`.
+- **Frontend rendering** — current weather per area is surfaced via the area DTO; UI displays it (covered by progressive-display spec).
+
+## Testing Strategy
+
+Following the project's existing rstest pattern:
+
+- **Modifier methods** — every weather variant returns the documented modifiers; `is_extreme()` flags the right variants.
+- **Markov transitions** — given a fixed RNG seed, transitions follow the terrain table; impossible transitions (zero-weight cells) never occur; stationary distribution sampling produces plausible Day 1 weather.
+- **Hazard weighting** — `(HeavyRain, Desert)` produces near-guaranteed Flood on transition; `(HeavyRain, Wetlands)` produces ≈coin-flip Flood on transition; weather-independent hazards (Earthquake) fire under any weather at low rate.
+- **Exposure logic** — Hidden tributes don't take exposure ticks; tributes in `UrbanRuins` don't take exposure ticks; tributes in any other area in extreme weather do.
+- **Cornucopia start** — game creation across many seeds always produces `Clear` for Cornucopia.
+- **Per-area independence** — different areas in the same phase can have different weather and different hazard outcomes.
+- **Emotion trigger emission** — `ExposedToHarshWeather` fires once per phase per exposed tribute on qualifying weather states.
+- **Event emission** — `WeatherChanged` fires only on actual state changes; no event on `Clear → Clear`.
+- **Refactor regression** — every existing `AreaEvent` test that referenced `Sandstorm` or `Drought` is converted, deleted with rationale, or moved to the weather state's modifier tests.
+
+## Migration / Backward Compatibility
+
+- **`AreaEvent` rename to `NaturalHazard`** — all internal references updated. SurrealDB schema field that stored `AreaEvent` strings continues to work for the kept variants; persisted games that recorded `Sandstorm` or `Drought` need a one-time migration to either drop those records or convert `Sandstorm` records to a `Weather::Sandstorm` state on the affected area at hydration time. Trivial migration entry under `migrations/definitions/`.
+- **`Area` schema** — new `weather` field added, defaulted to `Clear` for in-flight games (or rolled fresh per the starting-weather rules on first hydration; implementation choice).
+- **API DTOs** — additive only. Removing `Sandstorm`/`Drought` from any `AreaEvent`-shaped DTO is breaking and must be coordinated with the frontend.
+
+## Open Questions for Implementation
+
+These don't block writing the implementation plan but the implementer will resolve them:
+
+- Final modifier values in the per-state table (the `−6`, `−7`, etc. are starting points; Q5 confirmed the shape, not the exact numbers).
+- Final per-terrain transition matrices (one matrix per `BaseTerrain` × current weather).
+- Final hazard weight table including cells the design didn't enumerate (e.g., HeavySnow in Forest? LightSnow in Desert if it can even occur?).
+- Whether `phases_in_state` is read anywhere or is debug-only telemetry. (Could later drive things like "weather has been bad for 5 phases → morale tick.")
+- Whether `WeatherChanged` events are emitted before or after `NaturalHazard` events from the same phase. (Design intent: Weather first, then Hazard, so the announcer has the cause before the effect.)
+- Whether the per-phase Day 1 starting roll uses a dedicated "neutral-biased" sampler or just calls the standard sampler with a flag.
+
+## Out of Scope
+
+- The GamemakerEvent system. Filed as a separate brainstorm. This spec carves the boundary; gamemaker design is its own conversation.
+- Forecasts, weather control items, weather-aware sponsor gifts, or weather-aware tribute traits.
+- Cross-area weather coupling (no fronts moving from West → East over time). Each area is independent.
+- Visual frontend representation of weather. Covered by the progressive-display spec.
+- Announcer prompt updates to use `WeatherChanged` events. Handled when the announcer integration lands.

--- a/docs/superpowers/specs/2026-05-03-gamemaker-event-system-design.md
+++ b/docs/superpowers/specs/2026-05-03-gamemaker-event-system-design.md
@@ -1,0 +1,554 @@
+# Gamemaker Event System — Design
+
+**Status:** Draft
+**Date:** 2026-05-03
+**Crate(s) primarily affected:** `game/`, `shared/`, `web/`
+**Related specs:** `2026-05-02-weather-system-design.md` (carved this out), `2026-04-17-event-severity-integration.md`, `2026-04-26-game-event-enum.md`, `2026-05-02-tribute-emotions-design.md`, `2026-05-03-shelter-hunger-thirst-design.md`
+**Related issue:** `hangrier_games-5q9`
+
+## Goals
+
+Add a Capitol-intervention layer to the simulation that:
+
+1. **Imposes authored drama on the arena** — the gamemaker decides *when* and *where* something happens, separate from natural causation (weather, hazards, combat).
+2. **Bypasses natural-cover rules at will** — gamemaker interventions are explicitly *force majeure*; shelter and hide get partial respect at best, never full immunity. They're the answer to "the tribute did everything right, why did they still die?"
+3. **Models the gamemaker as an actor with internal state** — RimWorld-storyteller style: gauges drive decisions, profiles tune personality. Single source of truth for "what does the Capitol want right now?"
+4. **Slots cleanly under the timeline + announcer** — every intervention emits typed `MessagePayload` variants the existing UI and announcer LLM can consume.
+
+Non-goals (deferred — see "Out of Scope" section):
+
+- Multiple storyteller profiles in v1 (one default ships).
+- Tribute-targeted interventions ("Capitol decides X dies").
+- Human-controlled gamemaker mode.
+- Scripted day-N set-pieces (cornucopia rerun, etc.) — generalized via `ConvergencePoint::Lure` instead.
+- Bespoke timeline card layouts per intervention (generic rendering in v1).
+- Capitol Feed panel exposing gauges to spectators.
+- Sponsor-pressure feedback into gauges.
+
+## Architectural Position
+
+Per the weather spec's three-layer split:
+
+| Layer | What it is | Lifecycle | This spec? |
+|---|---|---|---|
+| **Weather** | Persistent atmospheric state per area | Evolves slowly per-day-phase | No (weather spec) |
+| **NaturalHazard** | Acute event caused by terrain + weather | One-shot, probabilistic | No (weather spec) |
+| **GamemakerEvent** | Imposed Capitol intervention | One-shot or persistent active-effect | **Yes** |
+
+The three layers are orthogonal; gamemaker decisions never *cause* weather transitions or natural hazards (with one explicit exception: `Fireball` may bias the next phase's wildfire roll in its target area — see Q7 / "Interactions" below).
+
+### Coexistence with current `AreaEvent` (independent migration)
+
+Current code reality:
+- `AreaEvent` enum (10 variants in `game/src/areas/events.rs`) is implemented and live, mixed-purpose.
+- `Weather` enum doesn't exist (shelter PR1 wedges a stub: `Clear, HeavyRain, Heatwave, Blizzard`).
+- `NaturalHazard` enum doesn't exist.
+- `Gamemaker*` doesn't exist.
+
+This spec ships **independently** of the weather/hazard refactor. Gamemaker code lives at `game/src/gamemaker/`, defines its own enums, and does **not** carve `AreaEvent`. When the weather spec lands later it carves `AreaEvent` → `NaturalHazard`; this gamemaker work is unaffected.
+
+**Weather stub coordination:** if shelter PR1 has shipped, gamemaker re-uses its `Weather` enum (single source of truth). If shelter hasn't shipped, gamemaker introduces the same minimal stub (`Weather::{Clear, HeavyRain, Heatwave, Blizzard}` plus `current_weather() -> Weather` returning `Clear`). Whichever ships first owns the wedge; the other re-imports.
+
+## The Gamemaker Actor
+
+A new `Gamemaker` struct on `Game` carries all gamemaker state:
+
+```rust
+pub struct Gamemaker {
+    pub profile: GamemakerProfile,
+    pub gauges: Gauges,
+    pub recent_interventions: VecDeque<RecentIntervention>,  // capped at 6 entries
+    pub interventions_today: u8,                              // resets each day
+    pub active_effects: Vec<ActiveIntervention>,              // ongoing things on the map
+}
+
+pub struct Game {
+    // ... existing fields
+    pub gamemaker: Gamemaker,
+}
+```
+
+Cost: ~50 bytes plus active_effects vec. Persists via existing serialization.
+
+### Gauges
+
+Six `u8`s, each 0–100, recomputed at each phase boundary:
+
+| Gauge | Rises when | Decays when | Drives |
+|---|---|---|---|
+| `drama_pressure` | Quiet phases (no kills, no hazards, no major moves) | Combat / hazards / deaths happen, intervention fires | Whether to intervene at all |
+| `audience_attention` | Spectacle moments, named-tribute deaths, alliance breaks | Slowly each phase regardless | Magnitude — low attention biases toward flashier picks |
+| `bloodthirst` | Phases without a tribute death | Each tribute death (proportional to "fame") | Bias toward lethal vs. nuisance interventions |
+| `chaos` | Predictable patterns (same tribute winning, sectors quiet) | Already-chaotic states (active combat, multiple hazards live) | Bias toward disruptive picks |
+| `patience` | Each phase since last intervention (cooldown timer) | Fires intervention → resets to 0 | Hard gate — no intervention until `patience >= profile.patience_threshold` |
+| `body_count_debt` | Daily expected_deaths > actual_deaths (clamped 0..=100) | Deaths happen | Late-game escalation; low priority early |
+
+```rust
+pub struct Gauges {
+    pub drama_pressure: u8,
+    pub audience_attention: u8,
+    pub bloodthirst: u8,
+    pub chaos: u8,
+    pub patience: u8,
+    pub body_count_debt: u8,
+}
+
+impl Gauges {
+    pub const STARTING: Self = Self {
+        drama_pressure: 0,
+        audience_attention: 80,
+        bloodthirst: 20,
+        chaos: 10,
+        patience: 0,
+        body_count_debt: 0,
+    };
+}
+```
+
+### Profile (storyteller personality)
+
+```rust
+pub struct GamemakerProfile {
+    pub name: &'static str,
+    pub pressure_decay_rate: u8,        // pressure rises this much per quiet phase
+    pub attention_decay_rate: u8,       // attention drains this much per phase
+    pub bloodthirst_weight: u8,         // multiplier into variant scoring (100 = baseline)
+    pub chaos_weight: u8,               // multiplier into variant scoring
+    pub patience_threshold: u8,         // gauge minimum to be eligible to intervene
+    pub max_per_day: u8,                // hard cap on interventions per game-day
+    pub max_concurrent_events: u8,      // cap on simultaneously-active effects
+    pub late_game_multiplier: f32,      // pressure scaling once ≤ 8 tributes alive
+    pub recent_penalty: u32,            // each occurrence in window subtracts this from variant score
+}
+```
+
+V1 ships **one profile**, `Cassandra` (rising tension, paced escalation):
+
+```rust
+pub const CASSANDRA: GamemakerProfile = GamemakerProfile {
+    name: "Cassandra",
+    pressure_decay_rate: 8,
+    attention_decay_rate: 3,
+    bloodthirst_weight: 100,
+    chaos_weight: 100,
+    patience_threshold: 30,
+    max_per_day: 2,
+    max_concurrent_events: 2,
+    late_game_multiplier: 1.5,
+    recent_penalty: 25,
+};
+```
+
+Numbers are starting points; tune during implementation playtest.
+
+Additional profiles (Phoebe, Randy, custom) are filed as a follow-up bead.
+
+### Trigger thresholds
+
+Gauges drive a `should_intervene(profile, gauges, game_state) -> bool` decision. After patience gates pass, fire if **any** of:
+
+- `drama_pressure >= 60`
+- `bloodthirst >= 70`
+- `chaos >= 70`
+- `body_count_debt >= 10`
+
+If `interventions_today >= profile.max_per_day` → no-op regardless of gauges. If `active_effects.len() >= profile.max_concurrent_events` → no-op (let the field clear first).
+
+## The Catalog (6 variants)
+
+```rust
+pub enum InterventionKind {
+    Fireball,
+    MuttPack,
+    ForceFieldShift,
+    AreaClosure,
+    ConvergencePoint,
+    WeatherOverride,
+}
+```
+
+Grouped by flavor:
+
+### Lethal
+
+**`Fireball { area, severity }`**
+Area-targeted instant damage. Tributes in the area roll a survival check (`d20 + dodge_mod` vs. severity DC). Bypasses shelter completely. Bypasses hide completely. May bias next phase's wildfire roll in target area (see Interactions).
+
+**`MuttPack { area, kind: Animal, members: u8, hp: u32, decay_phases: u8 }`**
+Spawns a `MuttSwarm` — single aggregate entity with HP pool + member count, **not** individual NPCs. Reuses existing `threats::animals::Animal` enum for the kind (Wolf, Bear, Cougar, Hyena, etc.). Pursues nearest tribute; combat reduces swarm HP; killing each chunk reduces `members`. Sheltered tributes get **+5 evade roll**, hidden tributes get **+2 evade roll** (additive, max +7 if both apply). Despawns conditionally — at next morning OR after N consecutive phases with no tributes in adjacent areas.
+
+### Disruptive
+
+**`ForceFieldShift { close: Vec<Area>, open: Vec<Area>, warning_phases: u8 }`**
+Closes some sectors, opens others. Tributes inside closing sectors get a one-phase warning (announced via `ForceFieldShifted` event with `warning_phases`); after warning expires, attempting to remain takes damage equivalent to `AreaClosure` entry damage. Topology-only intervention; no direct damage on resolution.
+
+**`AreaClosure { area, duration_phases: u8 }`**
+Temporary lockdown. Entering or remaining in the area takes damage per phase. Pressures tributes toward each other. No bypass via shelter/hide (the seal damage is "Capitol force field"; sheltering inside doesn't help).
+
+### Convergence
+
+**`ConvergencePoint { area, lure: Lure, duration_phases: u8, payload: Vec<Item> }`**
+Drops a marked area on the map. Brain logic gets a "go to convergence point" pull — adds to `choose_destination` scoring proportional to lure strength. Items in payload are claimable by whoever reaches the area before duration expires. Generic — feast is one lure flavor, future cousins (water cache, sponsor airdrop carnival, capitol summons) plug in as additional `Lure` variants without new top-level intervention.
+
+```rust
+pub enum Lure {
+    Feast,
+    // Future: WaterCache, AirdropCluster, CapitolSummons, ...
+}
+```
+
+### Atmospheric
+
+**`WeatherOverride { area, weather: Weather, duration_phases: u8 }`**
+Forces a weather state in the target area regardless of natural transition. Replaces (does not stack with) current weather for the duration; reverts to natural transition rolls afterward. Cheapest intervention — the gamemaker's "I need to do *something* but the field's not ready for spectacle" valve.
+
+## Decision Flow (per phase)
+
+At each phase boundary in `process_turn_phase`:
+
+1. **Tick gauges** — apply per-phase rises and decays (see "Gauge tick rules" below). Apply `late_game_multiplier` to `drama_pressure` rise if `alive_tributes <= 8`.
+2. **Tick active_effects** — decrement remaining phases on `MuttSwarm`/`AreaClosure`/`ConvergencePoint`; emit despawn/expire/unseal events; remove expired entries.
+3. **Resolve pending damage from active_effects** — `AreaClosure` entry damage to anyone inside, `MuttSwarm` attacks against tributes in pack's area, etc. Emits `AreaSealEntryDamage`, `MuttSwarmAttack` events.
+4. **Eligibility gate** — `should_intervene(profile, gauges, game_state)`:
+   - If `interventions_today >= profile.max_per_day` → skip
+   - If `active_effects.len() >= profile.max_concurrent_events` → skip
+   - If `patience < profile.patience_threshold` → skip
+   - If no trigger threshold met → skip
+5. **Pick variant** — for each `InterventionKind`, compute `score(profile, gauges, game_state)`. Subtract `profile.recent_penalty * occurrences_in_recent_interventions` per variant. Highest score wins; ties → rng.
+6. **Pick target** — call selected variant's `target_pref(game_state) -> Option<TargetSpec>`. If `None`, drop this variant from the candidate set and re-pick (loop max 3 attempts; if all fail, no intervention this phase).
+7. **Resolve immediately or register active effect:**
+   - `Fireball` / `ForceFieldShift` / `WeatherOverride` → resolve now, emit events, no `active_effects` entry.
+   - `MuttPack` / `AreaClosure` / `ConvergencePoint` → push `ActiveIntervention` entry, emit announcement event, resolution happens in step 3 of subsequent phases.
+8. **Update bookkeeping** — push to `recent_interventions` (cap at 6), increment `interventions_today`, reset `patience` to 0, decay gauges per intervention rules.
+9. **Day rollover** — at the day-night-day transition, reset `interventions_today` to 0.
+
+### Gauge tick rules (per phase)
+
+Per-phase background tick (before any intervention):
+
+```text
+drama_pressure   += profile.pressure_decay_rate (clamped 0..=100)
+                    × (alive_tributes <= 8 ? profile.late_game_multiplier : 1.0)
+audience_attention -= profile.attention_decay_rate (clamped 0..=100)
+patience         += 1 (clamped 0..=255)
+```
+
+Per-event reactions (subtract these *after* each event):
+
+| Trigger | drama_pressure | audience_attention | bloodthirst | chaos | body_count_debt |
+|---|---|---|---|---|---|
+| Tribute killed (any cause) | −15 | +12 | −20 | −5 | −10 |
+| Hazard fires (no kills) | −8 | +5 | −2 | −10 | 0 |
+| Hazard fires (with kill) | −15 | +12 | −20 | −15 | −10 |
+| Combat round (no kill) | −3 | +2 | +2 | −2 | 0 |
+| Day boundary, expected_deaths_today > actual | 0 | 0 | +10 | 0 | +(expected − actual) × 5 |
+| Day boundary, no deaths all day | +20 | 0 | +25 | 0 | +5 |
+
+Per-intervention reactions (subtract *after* this gamemaker's own intervention):
+
+| Intervention | drama_pressure | audience_attention | bloodthirst | chaos | patience |
+|---|---|---|---|---|---|
+| Fireball / MuttPack with kills | −30 | +20 | −30 | −10 | reset to 0 |
+| Fireball / MuttPack with no kills | −15 | +5 | −10 | −5 | reset to 0 |
+| ForceFieldShift / AreaClosure | −10 | +5 | 0 | −20 | reset to 0 |
+| ConvergencePoint announce | −5 | +3 | 0 | 0 | reset to 0 |
+| ConvergencePoint resolve (combat fires there) | use combat reactions | — | — | — | — |
+| WeatherOverride | −5 | 0 | 0 | −5 | reset to 0 |
+
+Numbers are starting points; tune during implementation.
+
+## Variant Scoring & Targeting (sketch)
+
+Each variant exposes two pure functions:
+
+```rust
+trait InterventionLogic {
+    fn score(&self, profile: &GamemakerProfile, gauges: &Gauges, state: &GameState) -> u32;
+    fn target_pref(&self, state: &GameState) -> Option<TargetSpec>;
+}
+```
+
+Sketches (final tuning during implementation):
+
+- **Fireball**: `score = bloodthirst·2 + drama_pressure − patience_penalty`. Target = area with highest `tribute_count + alliance_co_location_bonus`.
+- **MuttPack**: `score = bloodthirst + body_count_debt·2 + chaos`. Target = area with `tribute_count > 0` and at least one adjacent occupied area.
+- **ForceFieldShift**: `score = chaos·3 + drama_pressure − (alive_tributes_below_threshold ? 50 : 0)`. Target = pick 1–3 low-tribute areas to close, opening previously-closed adjacent areas; refuses if doing so would leave < 3 areas open.
+- **AreaClosure**: `score = chaos·2 + drama_pressure`. Target = empty-or-low area positioned between two clusters (forces movement around it).
+- **ConvergencePoint**: `score = drama_pressure·2 + (audience_attention < 40 ? 30 : 0) + (alive_tributes >= 6 ? 15 : 0)`. Target = central area (high adjacency count), low current tribute count.
+- **WeatherOverride**: `score = drama_pressure + chaos − bloodthirst`. Target = any area; slight preference for area with tributes present.
+
+Each `score` then has `profile.recent_penalty * occurrences_in_recent_interventions` subtracted before comparison.
+
+`TargetSpec` is variant-specific:
+```rust
+pub enum TargetSpec {
+    SingleArea(Area),
+    AreaSet { close: Vec<Area>, open: Vec<Area> },  // ForceFieldShift
+}
+```
+
+## Active Effects
+
+```rust
+pub enum ActiveIntervention {
+    MuttSwarm {
+        area: Area,
+        kind: Animal,
+        members: u8,
+        hp: u32,
+        max_hp_per_member: u32,
+        phases_since_combat: u8,
+        despawn_at_morning: bool,
+    },
+    AreaClosure {
+        area: Area,
+        expires_at_phase: u32,
+        damage_per_phase: u32,
+    },
+    ConvergencePoint {
+        area: Area,
+        lure: Lure,
+        expires_at_phase: u32,
+        payload: Vec<Item>,
+    },
+}
+```
+
+Variants not listed (`Fireball`, `ForceFieldShift`, `WeatherOverride`) resolve immediately and don't appear in `active_effects`. (`WeatherOverride`'s persistence lives in `AreaWeather` once the weather spec lands; for the v1 wedge, it's a single phase override applied at resolution time.)
+
+## Interactions With Other Systems
+
+| Intervention | Respects shelter? | Respects hide? | Respects weather modifiers? | Triggers natural hazard? |
+|---|---|---|---|---|
+| Fireball | **No** (bypass) | No | No | Yes — sets +20% wildfire roll bonus in target area for the next phase |
+| MuttPack | Partial — sheltered tributes get +5 evade roll; not immune | Partial — hidden tributes get +2 evade roll (stacks with shelter, max +7) | No | No |
+| ForceFieldShift | N/A (topology) | N/A | No | No |
+| AreaClosure | N/A (entry damage only) | N/A | No | No |
+| ConvergencePoint (Feast) | N/A (lure) | N/A | N/A | No |
+| WeatherOverride | N/A — *is* weather | N/A | Replaces current weather for area | Per weather spec — yes |
+
+**Brain integration:**
+
+Each tribute's `Brain::act` gets one new override pass before existing logic:
+
+1. **Convergence pull (only when not in combat / not starving / not dehydrated):**
+   add `convergence_pull(area)` term to `choose_destination` scoring for each active `ConvergencePoint`.
+2. **Mutt avoidance (always when not in combat):**
+   any active `MuttSwarm` in the tribute's current area triggers `Travel(adjacent_area)` if any adjacent area lacks one. Higher priority than Forage/SeekShelter.
+3. **Sealed-area avoidance:**
+   active `AreaClosure` areas filtered out of `choose_destination` candidate set entirely.
+
+Combat preempts all of the above (existing rule).
+
+## Events / Messages
+
+11 new `MessagePayload` variants in `shared/src/messages.rs`. `MuttSwarmDespawned` covers all swarm endings (members exhausted, morning rollover, no nearby targets) via `DespawnReason`; `ConvergencePointActive` is omitted since active state is queryable from `gamemaker.active_effects`.
+
+```rust
+pub enum DespawnReason {
+    Morning,
+    NoTargetsNearby,
+    NoMembersLeft,
+}
+
+// Lethal
+MessagePayload::FireballStrike {
+    area: AreaRef,
+    severity: EventSeverity,
+    victims: Vec<TributeRef>,
+    survivors: Vec<TributeRef>,
+}
+MessagePayload::MuttSwarmSpawned {
+    area: AreaRef,
+    kind: Animal,
+    members: u8,
+}
+MessagePayload::MuttSwarmAttack {
+    area: AreaRef,
+    kind: Animal,
+    victim: TributeRef,
+    damage: u32,
+    killed: bool,
+}
+MessagePayload::MuttSwarmDespawned {
+    area: AreaRef,
+    kind: Animal,
+    reason: DespawnReason,
+}
+
+// Disruptive
+MessagePayload::ForceFieldShifted {
+    closed: Vec<AreaRef>,
+    opened: Vec<AreaRef>,
+    warning_phases: u8,
+}
+MessagePayload::AreaSealed {
+    area: AreaRef,
+    expires_at_phase: u32,
+}
+MessagePayload::AreaUnsealed {
+    area: AreaRef,
+}
+MessagePayload::AreaSealEntryDamage {
+    area: AreaRef,
+    tribute: TributeRef,
+    damage: u32,
+}
+
+// Convergence
+MessagePayload::ConvergencePointAnnounced {
+    area: AreaRef,
+    lure: Lure,
+    starts_at_phase: u32,
+}
+MessagePayload::ConvergencePointExpired {
+    area: AreaRef,
+    lure: Lure,
+    claimed_by: Vec<TributeRef>,
+}
+
+// Atmospheric
+MessagePayload::WeatherOverridden {
+    area: AreaRef,
+    weather: Weather,
+    duration_phases: u8,
+}
+```
+
+Final v1 emission set (11):
+
+1. `FireballStrike`
+2. `MuttSwarmSpawned`
+3. `MuttSwarmAttack`
+4. `MuttSwarmDespawned`
+5. `ForceFieldShifted`
+6. `AreaSealed`
+7. `AreaUnsealed`
+8. `AreaSealEntryDamage`
+9. `ConvergencePointAnnounced`
+10. `ConvergencePointExpired`
+11. `WeatherOverridden`
+
+**Death cause constants** (added to existing `MessagePayload::TributeKilled.cause: String`):
+
+```rust
+pub const CAUSE_FIREBALL: &str = "fireball";
+pub const CAUSE_MUTT_PACK: &str = "mutt_pack";
+pub const CAUSE_AREA_SEAL: &str = "area_seal";
+```
+
+Mutt-killed tributes emit `TributeKilled { cause: CAUSE_MUTT_PACK, ... }` — the specific animal kind is recoverable from the preceding `MuttSwarmAttack` event with the same victim.
+
+## Frontend (PR2 scope)
+
+**Hex map** (`web/src/components/map.rs`) gains three new marker types:
+
+| Marker | Visual | Source data |
+|---|---|---|
+| Mutt swarm pin | Red claw glyph + member count badge | `gamemaker.active_effects` filtered to `MuttSwarm` |
+| Sealed-area shading | Red translucent overlay on hex tile | `gamemaker.active_effects` filtered to `AreaClosure` |
+| Convergence point pin | Gold star + lure-specific micro-icon | `gamemaker.active_effects` filtered to `ConvergencePoint` |
+
+**Timeline cards:** generic rendering for all 11 new `MessagePayload` variants. Pattern matches the existing fallback used by `xamw` (typed AreaEvent fallback). Each variant gets:
+- A category icon (lethal = flame, disruptive = forcefield-shimmer, convergence = star, atmospheric = cloud)
+- Stringified payload fields
+- The standard timeline-card chrome (timestamp, source, severity badge if applicable)
+
+Bespoke per-variant card layouts are filed as a follow-up bead.
+
+**No** Capitol Feed panel — gauges are not exposed to spectators in v1.
+
+## File / Module Layout
+
+New module: `game/src/gamemaker/`
+
+```
+game/src/gamemaker/
+  mod.rs               // pub use; Gamemaker struct
+  gauges.rs            // Gauges struct + tick + reaction tables
+  profile.rs           // GamemakerProfile struct + CASSANDRA const
+  interventions/
+    mod.rs             // InterventionKind + InterventionLogic trait
+    fireball.rs
+    mutt_pack.rs
+    force_field.rs
+    area_closure.rs
+    convergence.rs
+    weather_override.rs
+  active.rs            // ActiveIntervention enum + per-phase tick/resolve
+  decision.rs          // should_intervene + variant selection + targeting fallback loop
+  weather_stub.rs      // (only if shelter PR1's Weather isn't merged yet)
+```
+
+`shared/src/messages.rs` gains the 11 new `MessagePayload` variants + `DespawnReason` enum + `Lure` enum + 3 cause constants.
+
+`game/src/games.rs` `process_turn_phase` integrates the per-phase decision flow described above.
+
+## PR Split
+
+Mirrors the shelter spec's PR1/PR2 split:
+
+**PR1 — Backend** (~15 TDD tasks, ~equivalent to shelter PR1 footprint):
+- `Gauges`, `GamemakerProfile`, `Gamemaker` structs
+- `Cassandra` profile constant
+- 6 intervention variants with `score()` + `target_pref()` + resolution logic
+- `ActiveIntervention` lifecycle (tick, resolve, despawn)
+- 11 new `MessagePayload` variants + `DespawnReason` + `Lure` + cause constants
+- `should_intervene` + variant selection + targeting fallback loop
+- Brain integration (convergence pull, mutt avoidance, sealed-area avoidance)
+- `process_turn_phase` integration
+- Per-event gauge reaction wiring
+- Day-rollover bookkeeping (`interventions_today` reset)
+- Weather stub coordination (or import from shelter PR1)
+- All unit tests + integration tests
+
+**PR2 — Frontend** (~7 TDD tasks):
+- Mutt swarm pin marker on hex map
+- Sealed-area overlay on hex map
+- Convergence point pin on hex map
+- Generic timeline card for each of 11 new payloads
+- WCAG check on new map overlay colors
+- Visual integration tests
+- Self-review
+
+## Out of Scope (filed as follow-up beads after spec lands)
+
+1. **Multiple storyteller profiles** (Phoebe, Randy, others) — single Cassandra in v1
+2. **Gamemaker selection at game creation** — UI affordance for choosing storyteller
+3. **Capitol Feed panel** — gauge visibility for spectators (toggleable dev view)
+4. **Bespoke timeline cards** for gamemaker variants (per-payload card layouts)
+5. **Tribute-targeted interventions** ("Capitol decides X dies tonight")
+6. **Human-controlled gamemaker mode** (spectator-as-director)
+7. **Scripted set-pieces** (fixed-day-N events) — generalized via `Lure` instead, but no scripted-day machinery
+8. **Sponsor-pressure feedback into gauges** (sponsor activity affecting `audience_attention`)
+9. **Announcer prompt updates for gamemaker events** — extends scope of `hangrier_games-xfi`
+10. **Fireball→wildfire chain** — flagged as droppable during PR1 implementation if it complicates testing
+11. **Per-game custom profile tuning** (knobs in game-creation UI)
+12. **Replay/spectator-mode integration** — existing replay system (`hangrier_games-5wt`) wraps gamemaker state regardless
+
+## Open Questions (defer to implementation)
+
+- Exact damage formulas for `Fireball.severity` per `EventSeverity` band (use existing `survival_check` infrastructure as a model).
+- Mutt swarm `members → hp` mapping — does each member's death proportionally reduce HP, or is HP a single pool drained until threshold per-member?
+- Recent-interventions window size — spec says 6, but window in *phases* vs. *count* may matter once tuned.
+- Whether `WeatherOverride` should require shelter PR1's `Weather` enum to be merged first, or always carry its own stub. (Cleanest is "whichever spec lands first owns the Weather wedge.")
+
+## Risks
+
+- **Cadence feels off in playtest** — the 6-gauge model has many knobs; tuning is non-trivial. Mitigation: ship Cassandra with conservative numbers, expect a tuning pass.
+- **Active effect persistence across game-state mutations** — mutt swarms surviving SurrealDB round-trips need careful serialization. Mitigation: standard `serde` derives; covered by integration tests.
+- **Brain override interaction with hunger/thirst overrides** — gamemaker overrides land at the *front* of the brain decision pipeline; combat preempts both. Hunger/thirst overrides (per shelter spec) sit between gamemaker overrides and the standard brain logic. Order documented above.
+- **Independent migration with weather pending** — same wedge approach as shelter PR1 has been validated; low risk.
+
+## Acceptance Criteria
+
+- [ ] All 6 intervention variants implementable and emit correct events
+- [ ] Cassandra profile produces dramatically-paced interventions (≤ 2/day, patience-gated, recent-penalty-resistant)
+- [ ] Mutt swarm aggregate combat resolves correctly against tributes (hidden +2, sheltered +5, both stack max +7)
+- [ ] Sealed areas damage tributes inside per phase; brain avoids them
+- [ ] Convergence points pull tribute brain `choose_destination`; expire correctly with item claim list
+- [ ] Weather override replaces area weather for declared duration; reverts to natural rolls afterward
+- [ ] All 11 new `MessagePayload` variants serialize/deserialize round-trip
+- [ ] Gamemaker state persists across SurrealDB game save/load
+- [ ] Frontend renders 3 hex-map marker types correctly on integration test
+- [ ] Generic timeline cards render all 11 new payloads without crashing

--- a/docs/superpowers/specs/2026-05-03-shelter-hunger-thirst-design.md
+++ b/docs/superpowers/specs/2026-05-03-shelter-hunger-thirst-design.md
@@ -1,0 +1,527 @@
+# Shelter + Hunger/Thirst — Design
+
+**Status:** Draft
+**Date:** 2026-05-03
+**Crate(s) primarily affected:** `game/`, with shared/api/web echoes
+**Related specs:** `2026-05-02-weather-system-design.md`, `2026-05-02-tribute-emotions-design.md`, `2026-04-17-terrain-biome-system-design.md`, `2026-04-25-tribute-alliances-design.md`
+**Related beads:** `hangrier_games-0yz` (this spec), `hangrier_games-ex3f` (resource sharing follow-up)
+
+## Goals
+
+Add an interlocking shelter / hunger / thirst layer that:
+
+1. Makes geography (terrain biome) and weather mechanically *expensive* to ignore.
+2. Gives the Brain a survival decision branch that can override combat/movement when desperate.
+3. Wires the existing-but-unused `TributeStatus::Starving` and `TributeStatus::Dehydrated` into a real lifecycle.
+4. Closes the conditional "Hungry / low on supplies" trigger left open in the emotions spec.
+5. Replaces the placeholder shelter definition (`Hidden` OR `UrbanRuins`) used in the weather spec with a proper, distinct shelter system.
+
+Non-goals (v1):
+
+- Cooking, food preparation, contamination tracking. *Food poisoning chance* on consumption is in scope (cheap, generates drama). Anything beyond a single roll is not.
+- Constructed/persistent shelter, capacity rules, ally co-sheltering bonuses.
+- Inter-tribute resource sharing or taking (filed: `hangrier_games-ex3f`).
+- Cannibalism / corpse consumption.
+- Sponsor pool *content* and economic balance. Data-model affordance only.
+- Long-run balance tuning. v1 ships with provisional numbers; expect tuning passes.
+
+## Weight Class
+
+Mid-weight survival loop ("weight B" in the brainstorm). Survival meaningfully shapes play but does not dominate it. Roughly 1.5–2× the implementation footprint of the emotions spec.
+
+## Architecture Overview
+
+Three interlocking subsystems, each modeled as a small pure module wired into the existing tick:
+
+```
+                ┌──────────────────────────┐
+                │  Area shelter_quality()  │  pure: (terrain, weather) -> u8
+                └──────────────────────────┘
+                              │
+                              ▼
+   ┌──────────────────────┐  rolls   ┌──────────────────────────┐
+   │  Action: SeekShelter │ ───────► │ Tribute.sheltered_until  │
+   └──────────────────────┘          └──────────────────────────┘
+                                                │
+                                                ▼
+       ┌────────────────────────────┐    ┌─────────────────────────┐
+       │ Area forage_richness()     │    │ Survival tick()         │
+       │ Area water_source()        │    │   hunger += k_h         │
+       └────────────────────────────┘    │   thirst += k_t         │
+                  │                      │   weather/shelter mods  │
+       ┌──────────┴──────────┐           │   band crossings emit   │
+       ▼                     ▼           │   drain HP at thresholds│
+   Action: Forage      Action: Drink     └─────────────────────────┘
+       │                     │                       │
+       └─────────┬───────────┘                       │
+                 ▼                                   ▼
+           Tribute.hunger / Tribute.thirst    TributeKilled(Starvation/Dehydration)
+                 ▲
+                 │
+       Action: Eat / Drink (item)  ◄── ItemType::Food(u8) / Water(u8)
+```
+
+The three subsystems share two ground rules:
+
+- **Shelter is per-tribute, not per-area.** An area's `shelter_quality` is the *substrate* a tribute rolls against; the resulting `Sheltered` window lives on the tribute.
+- **Hunger and thirst are debt counters**, not 0–100 bars. They tick *up*; eating/drinking ticks them *down*. Bands map directly onto existing `TributeStatus` variants.
+
+## Shelter
+
+### Area shelter quality (derived)
+
+A pure function in a new `game/src/areas/shelter.rs`:
+
+```rust
+pub fn shelter_quality(terrain: BaseTerrain, weather: &Weather) -> u8 { ... }
+```
+
+Returns 0 (no shelter possible) through 4 (excellent shelter). Pure of any tribute state.
+
+Provisional table covering all current `BaseTerrain` variants (pre-weather):
+
+| Terrain     | Base quality | Notes                                |
+|-------------|--------------|--------------------------------------|
+| UrbanRuins  | 3            | shelters, structures, cover          |
+| Forest      | 2            | dense canopy                         |
+| Jungle      | 2            | dense canopy + foliage               |
+| Mountains   | 2            | caves, overhangs                     |
+| Geothermal  | 2            | warm rock, vents, scattered cover    |
+| Wetlands    | 1            | reeds, scattered trees               |
+| Highlands   | 1            | rocky outcrops, scattered cover      |
+| Clearing    | 1            | scattered trees, low brush           |
+| Grasslands  | 1            | rare hedges, low cover               |
+| Badlands    | 1            | crags and gullies, sparse            |
+| Tundra      | 0            | open frozen ground, no cover         |
+| Desert      | 0            | nothing to hide under                |
+
+Note: `Cornucopia` is an `Area`, not a `BaseTerrain`. Its shelter quality follows from whichever terrain the area is assigned (typically `Clearing` or `Grasslands` → 1).
+
+Weather modifiers on top (see Weather subsystem below for the v1 minimal enum):
+
+- `HeavyRain`, `Blizzard`: −1 to all (visibility/exposure penalty for the *roll*, but successful shelter still works — see action below).
+- `Heatwave`: UrbanRuins/Mountains/Geothermal keep their full value (stone is cool); Forest/Jungle stay; Tundra/Desert pinned at 0.
+- `Clear`: no modifier.
+
+### Action: `SeekShelter`
+
+A tribute spends one action to attempt to shelter. The roll:
+
+```
+roll = uniform(0, 4)
+modifier = trait_bonus  // see Traits, below
+if roll + modifier <= shelter_quality(area.terrain, weather):
+    tribute.sheltered_until = now + N_phases
+    emit ShelterSought { success: true }
+else:
+    emit ShelterSought { success: false }
+```
+
+`N_phases` (provisional): **3 phases** — long enough to weather a storm and forage; short enough that long-term hiding requires repeated effort.
+
+The action is *available* even at `shelter_quality == 0`, but always fails there (events still log it; useful for "Cato spent the night exposed in the desert" flavor).
+
+### `Sheltered` is its own thing
+
+`Sheltered` is **not** the same as `Hidden`.
+
+- `Hidden` is a stealth state from the existing system — it conceals the tribute from other tributes.
+- `Sheltered` is an environmental protection state — it shields from weather exposure ticks and modulates survival ticks.
+
+A tribute can be both, neither, or either independently. `Hidden` no longer participates in weather exposure logic; the weather spec's interim definition of "shelter" (`Hidden` OR `UrbanRuins`) is fully *replaced* by `sheltered_until.is_some()` checked in `tick_survival` and weather exposure pipelines.
+
+### Allies do not co-shelter (v1)
+
+Same-area allies each roll independently. No group bonus, no shared `sheltered_until`. Filed for future consideration if playthroughs show this is too punishing.
+
+## Hunger & Thirst
+
+### Counters and bands
+
+Two `u8` debt counters on the tribute, default 0:
+
+```rust
+pub hunger: u8,   // 0 = Sated; ticks up each phase
+pub thirst: u8,   // 0 = Sated; ticks up each phase
+```
+
+Band thresholds (provisional, tunable):
+
+| Hunger value | Band            | Public event? | Status set?            | Brain effect             |
+|--------------|-----------------|---------------|------------------------|--------------------------|
+| 0            | Sated           | —             | clear `Starving`       | none                     |
+| 1–2          | Peckish         | —             | —                      | flavor only              |
+| 3–4          | Hungry          | yes (on entry)| —                      | weighting + emotion trig |
+| 5+           | Starving        | yes (on entry)| set `Starving`         | override eligible        |
+
+| Thirst value | Band            | Public event? | Status set?            | Brain effect             |
+|--------------|-----------------|---------------|------------------------|--------------------------|
+| 0            | Sated           | —             | clear `Dehydrated`     | none                     |
+| 1            | Thirsty         | —             | —                      | flavor only              |
+| 2            | Parched         | yes (on entry)| —                      | weighting + emotion trig |
+| 3+           | Dehydrated      | yes (on entry)| set `Dehydrated`       | override eligible        |
+
+Thirst escalates faster than hunger by design — a body lasts about 3× longer without food than without water; the spec compresses that ratio into game phases.
+
+### Tick rate
+
+Each phase, for each living tribute:
+
+```
+hunger += hunger_tick_for(tribute, weather, sheltered)
+thirst += thirst_tick_for(tribute, weather, sheltered)
+```
+
+Where:
+
+```
+hunger_tick_for:
+    base = 1
+    if tribute.strength is high (≥ threshold):  base += 1   // bigger body, more calories
+    if tribute.strength is low (≤ threshold):   base may be 0 this phase (every other phase)
+    if not sheltered AND weather is cold (Blizzard/HeavyRain): base += 1
+    return base
+
+thirst_tick_for:
+    base = 1
+    if tribute.stamina is high:  base += 1
+    if tribute.stamina is low:   base may be 0 this phase
+    if not sheltered AND weather is hot (Heatwave/Clear+Desert): base += 1
+    return base
+```
+
+Net effect: a tribute with no food/water and no shelter typically reaches `Starving` ≈ day 3 morning, `Dehydrated` ≈ day 2 night. Tunable later.
+
+### Death curve: escalating drain
+
+Once a tribute enters `Starving` or `Dehydrated`, an HP drain begins each phase, *escalating*:
+
+```rust
+pub starvation_drain_step: u8,    // resets to 0 on partial recovery (eating)
+pub dehydration_drain_step: u8,
+```
+
+Each phase in status:
+
+```
+starvation_drain_step += 1
+hp -= starvation_drain_step       // -1, then -2, then -3, ...
+```
+
+(Identical for dehydration.) Both can stack on the same tribute; combined drain in late stages is brutal and intentional.
+
+Eating any food drops the tribute back to the `Hungry` band (or below) and resets `starvation_drain_step` to 0. Drinking does the same for thirst.
+
+If HP reaches 0 while either status is set, the death is routed through `TributeKilled` with the dominant cause (whichever drain landed the killing blow; ties resolved as Dehydration first since it ticks first within a phase).
+
+## Food & Water Items
+
+### `ItemType` extension
+
+Two new variants on `ItemType`:
+
+```rust
+pub enum ItemType {
+    Consumable,      // existing — "potion-like" non-food consumables
+    Weapon,          // existing
+    Food(u8),        // new — value = hunger debt removed on consumption
+    Water(u8),       // new — value = thirst debt removed on consumption
+}
+```
+
+Typical food values: `1` (snack), `3` (ration), `5` (feast).
+Typical water values: `1` (sip), `2` (canteen), `3` (full waterskin).
+
+### Actions
+
+- **`Eat(item)`** — consume a `Food(n)` item from inventory. `tribute.hunger = saturating_sub(n)`. Resets `starvation_drain_step`. Emits `Ate`. Item is destroyed.
+- **`Drink(item)`** — same shape for `Water(n)`. Emits `Drank { source: Item(...) }`.
+- **`Drink(area)`** — terrain action at a hex with `water_source(...) > 0`. No item needed. Resolves to `tribute.thirst -= 1` on success. Emits `Drank { source: Terrain(...) }`.
+- **`Forage`** — terrain action at a hex with non-zero forage richness. Roll vs. richness. On success, `tribute.hunger -= 1`. Emits `Foraged`.
+
+### Food poisoning
+
+Each `Eat` and each terrain `Drink`/`Forage` rolls for contamination:
+
+```
+poisoning_chance = base + weather_modifier - trait_modifier
+```
+
+Provisional defaults:
+
+- `base` = 5% for `Eat(item)`, 10% for `Forage`, 15% for terrain `Drink`.
+- Weather modifier: `Heatwave` +5%, `Flood`/`HeavyRain` +5% on terrain water.
+- Trait modifier: see `ResourcefulForager` in Traits.
+- On hit: tribute gains `TributeStatus::Poisoned` for a short window (existing status, existing handling).
+
+The roll is silent on failure (no event); success emits the existing poisoning flow.
+
+### Terrain affordances (forage and water)
+
+Two more pure functions in `game/src/areas/`:
+
+```rust
+pub fn forage_richness(terrain: BaseTerrain) -> u8 { ... }     // 0..=4
+pub fn water_source(terrain: BaseTerrain, weather: &Weather) -> u8 { ... }  // 0..=3
+```
+
+Provisional terrain table covering all current `BaseTerrain` variants:
+
+| Terrain     | forage_richness | base water_source | water in HeavyRain |
+|-------------|-----------------|--------------------|--------------------|
+| Wetlands    | 3               | 3                  | 3                  |
+| Forest      | 2               | 2                  | 3                  |
+| Jungle      | 3               | 2                  | 3                  |
+| Geothermal  | 1               | 2 (hot springs)   | 2                  |
+| Mountains   | 1               | 2 (springs)        | 2                  |
+| Highlands   | 1               | 1                  | 2                  |
+| Clearing    | 1               | 1                  | 2                  |
+| UrbanRuins  | 2 (scavenge)    | 1 (rare)           | 2                  |
+| Grasslands  | 1               | 0                  | 2                  |
+| Badlands    | 0               | 0                  | 1                  |
+| Tundra      | 0               | 1 (snowmelt)       | 1                  |
+| Desert      | 0               | 0                  | 1                  |
+
+Note: `Cornucopia` is an `Area`, not a terrain — its forage/water values follow from the terrain it is assigned.
+
+`Heatwave` halves base `water_source` (rounded down).
+
+## Looting on Death (Adjacent Fix, In Scope)
+
+The food/water economy assumes carried items can re-enter the loot pool when a tribute dies. Currently no code transfers `Tribute.items` to `Area.items` on death. This spec adds that step:
+
+- On the `RecentlyDead → Dead` lifecycle transition (or on the kill event, whichever the lifecycle code prefers — see implementation notes), drain `tribute.items` into the area's `items` vector at the tribute's last position.
+- The dead tribute's inventory is cleared.
+- A `TributeLooted` event (or extension of the existing death event payload) records that N items dropped, for timeline visibility. *(Open implementation question — see below.)*
+
+This change is in scope because:
+- It's small and self-contained.
+- Without it, food/water spawned via sponsor or item drops becomes a one-shot resource (sticks on the first body).
+- The same plumbing is what the future resource-sharing spec (`hangrier_games-ex3f`) will hook into.
+
+## Brain Integration
+
+Mirrors the emotion spec's "override-then-weight" pattern.
+
+### Override states (checked first, before normal Brain scoring)
+
+In order:
+
+1. **`Dehydrated` + at water-source terrain** → `Drink(area)`.
+2. **`Dehydrated` + Water item in inventory** → `Drink(item)`.
+3. **`Starving` + Food item in inventory** → `Eat(item)`.
+4. **`Starving` + at forageable terrain + not in active combat** → `Forage`.
+
+Combat preempts all overrides. A Starving tribute under attack still defends.
+
+### Soft weighting (when no override fires)
+
+Layered onto the existing Brain scoring:
+
+| State                | Weight nudges                                                             |
+|----------------------|---------------------------------------------------------------------------|
+| Peckish / Thirsty    | small bonus to picking up Food/Water items if encountered                 |
+| Hungry / Parched     | move-toward-food-or-water-terrain weight; pick up Food/Water always       |
+| Starving / Dehydrated (override miss) | strong move-toward-shelter/water bias; flee combat unless cornered |
+
+`Hungry`/`Parched` band entry also fires the emotion spec's "Hungry / low on supplies" trigger row (which was held conditional on this system existing).
+
+## Traits
+
+Two new traits (see `game/src/tributes/traits.rs`):
+
+| Trait              | Effect                                                                                          |
+|--------------------|-------------------------------------------------------------------------------------------------|
+| `Builder`          | +1 to `SeekShelter` roll modifier. Successful shelter lasts +1 phase.                            |
+| `ResourcefulForager` | +1 to `Forage` roll modifier; halves food poisoning chance on `Forage` and `Eat(item)`.        |
+
+Trait distribution is left to the existing trait roll/assignment system; no special weighting in v1.
+
+## Events
+
+Six new typed events. Public events flow through the existing timeline pipeline; private events are not surfaced in the Action panel by default, only in the per-tribute Inspect drilldown's recent-actions feed.
+
+| Event                  | When                                                              | Payload                                                              | Public? |
+|------------------------|-------------------------------------------------------------------|----------------------------------------------------------------------|---------|
+| `HungerBandChanged`    | tribute crosses Sated↔Peckish↔Hungry↔Starving                     | `tribute_ref`, `from_band`, `to_band`                                | only Hungry/Starving entries are public |
+| `ThirstBandChanged`    | tribute crosses Sated↔Thirsty↔Parched↔Dehydrated                  | `tribute_ref`, `from_band`, `to_band`                                | only Parched/Dehydrated entries are public |
+| `ShelterSought`        | `SeekShelter` action ran                                          | `tribute_ref`, `area_ref`, `success: bool`, `roll`                   | private |
+| `Foraged`              | `Forage` action ran                                               | `tribute_ref`, `area_ref`, `success: bool`, `debt_recovered: u8`     | private |
+| `Drank`                | any drink action                                                  | `tribute_ref`, `source: Terrain(area_ref) \| Item(item_ref)`, `debt_recovered: u8` | private |
+| `Ate`                  | `Eat(item)` action                                                | `tribute_ref`, `item_ref`, `debt_recovered: u8`                      | private |
+
+Hunger and thirst band events are kept *separate* (rather than collapsed into one `SurvivalBandChanged`) so the timeline UI can filter and color them independently.
+
+Two new `TributeKilled` causes (extension of the existing death event):
+
+- `Cause::Starvation`
+- `Cause::Dehydration`
+
+Provisional in-engine death-line copy (Action panel / timeline):
+
+- "{name} starved." (timeline)
+- "{name} died of thirst." (timeline)
+- "{name} collapsed from hunger in the {area_name}." (richer log line for Action panel)
+
+## Data Model Changes
+
+### `Tribute` (`game/src/tributes/mod.rs`)
+
+```rust
+#[serde(default)] pub hunger: u8,
+#[serde(default)] pub thirst: u8,
+#[serde(default)] pub sheltered_until: Option<u32>,        // phase index; None = exposed
+#[serde(default)] pub starvation_drain_step: u8,
+#[serde(default)] pub dehydration_drain_step: u8,
+```
+
+`sheltered_until` is stored on the tribute (parallel to the existing `is_hidden: bool`), *not* as a `TributeStatus` variant. Rationale: tributes can be Sheltered *and* Wounded/Sick/etc., which the mutually-exclusive `TributeStatus` enum doesn't model.
+
+`_drain_step` fields are stored (rather than recomputed) so save/load and websocket replay produce identical drain trajectories.
+
+### `TributeStatus`
+
+No new variants. `Starving` and `Dehydrated` already exist; this spec finally drives them.
+
+### `ItemType`
+
+Add `Food(u8)` and `Water(u8)` variants. **Migration risk** — see Open Implementation Questions.
+
+### `Area` / `AreaDetails`
+
+No new persisted fields. `shelter_quality`, `forage_richness`, `water_source` are pure functions of `(terrain, weather)`.
+
+### Traits
+
+Add `Builder` and `ResourcefulForager` to the `Trait` enum.
+
+## Migration / Backward Compatibility
+
+- **Tribute fields:** all new fields use `serde(default)`, so existing JSON game saves deserialize cleanly with all counters at 0 / `None`. SurrealDB schema needs `DEFINE FIELD … DEFAULT …` updates (`hunger: int = 0`, `thirst: int = 0`, `sheltered_until: option<int>`, drain steps `= 0`).
+- **In-flight games:** existing games on load become Sated, exposed, no drain. They begin accruing on the next phase. No retroactive penalties.
+- **`ItemType` enum bump:** the format used to persist `ItemType` (string tag, full enum, integer discriminant?) determines the migration cost. See open question below.
+- **Weather spec interop:** the weather exposure tick must switch from "Hidden OR UrbanRuins" to `tribute.sheltered_until.is_some_and(|p| p > now)` once this spec lands. Hard cutover; no flag.
+
+## Frontend Presentation
+
+### Tribute card — bottom state strip
+
+Extend the emotion-spec state strip with two pips:
+
+- 🍗 hunger band: 4-state (Sated=hidden, Peckish=dim, Hungry=amber, Starving=red pulse).
+- 💧 thirst band: 4-state same color logic.
+
+Pips render only when band > Sated. Hover/tap → tooltip with the raw counter and band, e.g. `"Hunger 3 — Hungry"`, and (when applicable) a drain line: `"Starving — losing 3 HP/phase"`.
+
+A house glyph (🏠) renders adjacent to the strip when `sheltered_until.is_some()` and active, with phases-remaining number.
+
+### Tribute Inspect drilldown — Survival panel
+
+Adds a new "Survival" panel to the Inspect view (the same drilldown introduced by the emotions spec).
+
+- Numeric counter and band: `Hunger 3 (Hungry band)` / `Thirst 2 (Parched band)`.
+- Optional bar visualization, color-keyed by band.
+- Drain step display when relevant: `"Starving — losing 3 HP/phase (next phase: 4)"`.
+- Shelter line: `"Sheltered for 2 more phases"` or `"Exposed"`.
+- Recent-actions feed (last 3 of: forage / drink / eat / shelter rolls). This is where private events surface.
+
+This panel SHOULD also be visible in any debug/dev tribute view.
+
+### Map panel — terrain affordance hints
+
+When a tribute is selected, surrounding hexes get small overlay glyphs (re-using the layering pattern from the weather spec):
+
+- 💧 droplet — current `water_source(...) > 0` hex.
+- 🌿 sprig — `forage_richness(...) > 0` hex.
+- 🏠 house — `shelter_quality(...) ≥ 2` hex.
+
+Glyphs respect the weather spec's accessibility convention: shape + glyph carry the meaning, color is decoration only.
+
+### Action panel — event lines
+
+- Public events get standard event-card treatment, color-keyed by severity:
+  - "Katniss is now **Hungry**." (amber)
+  - "Marvel is now **Starving**." (red, severity bump)
+  - "Cato died of thirst in the Desert." (death severity)
+- Private events (`ShelterSought`/`Foraged`/`Drank`/`Ate`) are not in the Action panel by default. A debug toggle in dev mode surfaces them. They always appear in the Inspect drilldown's recent-actions feed.
+
+### Sponsor UI affordance (forward-compat)
+
+The sponsor pool will eventually include Food/Water tiers. v1 does not build that UI; the data-model affordance (the new `ItemType` variants) is enough so the future sponsor work doesn't hit a wall.
+
+### Accessibility
+
+- Every band change line carries a text label, not just color.
+- Pip elements have `aria-label` (e.g. `"Hunger: Starving"`).
+- Map terrain affordance icons use shape + glyph, not color alone.
+
+### Open frontend questions (flagged, deferred)
+
+- Should successful `SeekShelter` get a per-hex transition glyph/animation similar to weather changes?
+- Should crossing into Hungry/Parched fire a passive toast notification, or only the Action-panel line?
+
+## Integration Points
+
+- **Weather spec.** Replaces the placeholder shelter check with `tribute.sheltered_until`. Weather exposure ticks gate on shelter, hunger/thirst weather mods gate on shelter. Hard cutover. **At the time this spec lands, the weather subsystem is not yet implemented;** Plan 1 introduces a *minimal* `Weather` enum (`Clear`, `HeavyRain`, `Heatwave`, `Blizzard`) with a stub producer that returns `Clear` everywhere, sufficient to wire the consumer side. The full weather spec implementation later swaps the producer side without touching consumers.
+- **Emotions spec.** Activates the "Hungry / low on supplies" trigger row. Brain override list interleaves with the emotion override list in a documented order: emotion overrides first (combat-driven rage etc.), survival overrides second, normal scoring last.
+- **Terrain biome spec.** This is the system that finally gives the terrain table teeth — Desert lethality, Wetlands desirability, etc.
+- **Alliance spec.** No direct interop in v1. The follow-up resource-sharing work (`hangrier_games-ex3f`) hooks here.
+- **Game timeline / Action panel.** Six new event types feed the existing typed-event pipeline.
+- **Combat spec / lifecycle.** Looting-on-death fix is a small adjacent change to the `RecentlyDead → Dead` transition.
+
+## Testing Strategy
+
+Convention: rstest inline in `game/`. Total v1 surface ≈ 30 unit + 5 integration cases.
+
+### Unit tests
+
+- `shelter::shelter_quality(terrain, weather)` — every `BaseTerrain` × representative weather. Anchors: Cornucopia in storm = 0; UrbanRuins ≥ 2 in any weather; Desert + Heatwave = 0.
+- `areas::forage_richness(terrain)` — full table coverage, bounded.
+- `areas::water_source(terrain, weather)` — full table; HeavyRain boosts Plains; Heatwave halves base; Wetlands always > 0.
+- `tribute::tick_survival(weather, sheltered)` — pure function:
+  - Sated, no weather, exposed → +1 hunger, +1 thirst.
+  - Exposed in Heatwave → +2 thirst.
+  - Exposed in Blizzard → +2 hunger.
+  - Sheltered in same → +1 each (weather modifier suppressed).
+  - High strength → hunger ticks every other phase.
+  - High stamina → thirst ticks every other phase.
+- `band(value)` boundaries — exact thresholds: Sated/Peckish/Hungry/Starving; Sated/Thirsty/Parched/Dehydrated. Off-by-one bait.
+- `apply_starvation_drain(tribute)` — escalating: -1, -2, -3 across phases; resets on `Eat`.
+- `apply_dehydration_drain(tribute)` — same, independently.
+- Brain override branch (stubbed tribute):
+  - Starving + Food in inventory → picks `Eat`.
+  - Dehydrated + at water-source area → picks `Drink(area)`.
+  - Starving + at forageable terrain + no inventory → picks `Forage`.
+  - Starving + in active combat → does NOT override.
+  - Hungry (not Starving) → no override; falls through to weighting.
+
+### Integration tests
+
+- 7-day deterministic run, 2 tributes, no items: both die of dehydration before day 4. (Confirms thirst-kills-first.)
+- Same fixture with one tribute given a `Water(3)` item at start: that tribute survives an extra ~3 phases.
+- Sheltered tribute in Heatwave does NOT accrue weather thirst tick (regression guard for shelter↔weather wire).
+- Death routing: tribute reaches 0 HP while `Starving` → `TributeKilled { cause: Starvation }` in the timeline event stream.
+- Band-crossing visibility: tribute crossing 3→4 hunger emits `HungerBandChanged { to: Hungry }` (public); 1→2 emits a private band change only.
+
+### Out of v1 test scope
+
+- Frontend rendering of pips, gauges, and map overlays. Manual smoke test, like other UI work.
+- Sponsor pool food/water spawn balance.
+- Long-run balance (this is what playthroughs are for).
+
+## Open Implementation Questions
+
+1. **`ItemType` migration.** What format does the persisted `Item.item_type` field use today — string tag, full enum JSON, integer discriminant? If string-tag with named variants, adding `Food(u8)`/`Water(u8)` requires either a custom serde shape (e.g. `"food:3"` or a struct form) or a tagged enum bump with a fallback for legacy `"Consumable"` rows. Audit before implementation begins.
+2. **Looting event shape.** Add a new `TributeLooted { dropped: Vec<ItemRef> }` event, OR extend the existing kill/death event payload with a `dropped` field, OR just rely on `Area`-state change and emit nothing? Pick during implementation; either is acceptable for v1.
+3. **Drain ordering within a phase.** "Dehydration ticks first" is asserted for tie-breaking the death cause; confirm this matches the implementation order chosen for `tick_survival`.
+4. **Trait roll integration.** `Builder` and `ResourcefulForager` are new entries on the `Trait` enum; whether they slot into the existing trait-assignment weighting unchanged or need explicit weights is an implementation choice.
+5. **Shelter on death/movement.** Does `sheltered_until` carry across area moves, or does any move clear it? Recommendation: any successful move clears it (you left the shelter), but the action that *moves into* a sheltering area does not auto-shelter. A fresh `SeekShelter` is required.
+
+## Out of Scope (filed, or to be filed, as beads)
+
+- `hangrier_games-ex3f` — Resource sharing/taking between allied tributes.
+- (file if desired) Sponsor pool food/water content + economic balance pass.
+- (file if desired) Cooking and food preparation system.
+- (file if desired) Constructed/persistent shelter, capacity rules, group sheltering bonuses.
+- (file if desired) Cannibalism / corpse consumption.
+- (file if desired) Long-run balance tuning for hunger/thirst tick rates and band thresholds.


### PR DESCRIPTION
## Summary

Adds two complete spec+plan sets so implementers have full context, instructions, and TDD task breakdowns:

**hangrier_games-0yz — Shelter + Hunger/Thirst**
- `docs/superpowers/specs/2026-05-03-shelter-hunger-thirst-design.md` (527 lines)
- `docs/superpowers/plans/2026-05-03-shelter-hunger-thirst-pr1-backend.md` (2082 lines)
- `docs/superpowers/plans/2026-05-03-shelter-hunger-thirst-pr2-frontend.md` (848 lines)

**hangrier_games-5q9 — Gamemaker Event System**
- `docs/superpowers/specs/2026-05-03-gamemaker-event-system-design.md` (554 lines)
- `docs/superpowers/plans/2026-05-03-gamemaker-event-system-pr1-backend.md` (2668 lines)
- `docs/superpowers/plans/2026-05-03-gamemaker-event-system-pr2-frontend.md` (957 lines)

Plans are bite-sized TDD tasks (failing test → run → implement → run → commit) with exact code, exact commands, and self-review checklists. Implementers should use the `superpowers:subagent-driven-development` or `superpowers:executing-plans` skill.

## Ship order
1. Shelter PR1 (backend) → Shelter PR2 (frontend)
2. Gamemaker PR1 (backend) → Gamemaker PR2 (frontend)

Gamemaker PR1 reuses shelter PR1's `Weather` enum if shipped, else wedges its own stub.

## Verification
- All six docs reviewed and approved during brainstorm
- No code changes; docs-only PR
- Beads issues remain open until implementation PRs land

## Follow-ups
Both specs include explicit Out-of-Scope and Open-Questions sections enumerating items deferred to future beads.