### PR TITLE
feat(shared,game,web): typed CycleStart/CycleEnd/GameEnded payloads (closes hangrier_games-xamw)

### DIFF
--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -270,14 +270,7 @@ impl Game {
                 kind: AreaEventKind::Other,
                 description: String::new(),
             },
-            MessageSource::Game(id) => MessagePayload::AreaEvent {
-                area: AreaRef {
-                    identifier: id.clone(),
-                    name: id.clone(),
-                },
-                kind: AreaEventKind::Other,
-                description: String::new(),
-            },
+            MessageSource::Game(_) => MessagePayload::GameEnded { winner: None },
         }
     }
 
@@ -394,17 +387,32 @@ impl Game {
 
     fn check_for_winner(&mut self) -> Result<(), GameError> {
         if let Some(winner) = self.winner() {
-            self.log(
-                crate::messages::MessageSource::Game(self.identifier.clone()),
-                format!("game:{}", self.identifier),
+            let game_id = self.identifier.clone();
+            let payload = crate::messages::MessagePayload::GameEnded {
+                winner: Some(crate::messages::TributeRef {
+                    identifier: winner.identifier.clone(),
+                    name: winner.name.clone(),
+                }),
+            };
+            let tick = self.tick_counter.boundary();
+            self.push_message(
+                crate::messages::MessageSource::Game(game_id.clone()),
+                format!("game:{}", game_id),
                 format!("{} has won the game!", winner.name),
+                payload,
+                tick,
             );
             self.end();
         } else if self.living_tributes_count() == 0 {
-            self.log(
-                crate::messages::MessageSource::Game(self.identifier.clone()),
-                format!("game:{}", self.identifier),
+            let game_id = self.identifier.clone();
+            let payload = crate::messages::MessagePayload::GameEnded { winner: None };
+            let tick = self.tick_counter.boundary();
+            self.push_message(
+                crate::messages::MessageSource::Game(game_id.clone()),
+                format!("game:{}", game_id),
                 "The game has ended with no survivors.".to_string(),
+                payload,
+                tick,
             );
             self.end();
         }
@@ -431,28 +439,37 @@ impl Game {
         let current_day = self.day.unwrap_or(1);
         let game_id = self.identifier.clone();
         let subject = format!("game:{}", game_id);
+        let phase = if day {
+            crate::messages::Phase::Day
+        } else {
+            crate::messages::Phase::Night
+        };
 
-        if day {
-            let content = match current_day {
+        let content = if day {
+            match current_day {
                 1 => format!("Day {}: The games have begun!", current_day),
                 3 => format!(
                     "Day {}: Sponsors take note of the remaining tributes.",
                     current_day
                 ),
                 _ => format!("Day {} dawns over the arena.", current_day),
-            };
-            self.log(
-                crate::messages::MessageSource::Game(game_id),
-                subject,
-                content,
-            );
+            }
         } else {
-            self.log(
-                crate::messages::MessageSource::Game(game_id),
-                subject,
-                format!("Night {} falls. The arena grows dark.", current_day),
-            );
-        }
+            format!("Night {} falls. The arena grows dark.", current_day)
+        };
+
+        let payload = crate::messages::MessagePayload::CycleStart {
+            day: current_day,
+            phase,
+        };
+        let tick = self.tick_counter.boundary();
+        self.push_message(
+            crate::messages::MessageSource::Game(game_id),
+            subject,
+            content,
+            payload,
+            tick,
+        );
 
         Ok(())
     }
@@ -468,11 +485,23 @@ impl Game {
         // duplicated those events with a `SanityBreak` fallback payload
         // which mis-classified them in the timeline.
 
-        let phase = if day { "day" } else { "night" };
-        self.log(
+        let phase_str = if day { "day" } else { "night" };
+        let phase = if day {
+            crate::messages::Phase::Day
+        } else {
+            crate::messages::Phase::Night
+        };
+        let payload = crate::messages::MessagePayload::CycleEnd {
+            day: current_day,
+            phase,
+        };
+        let tick = self.tick_counter.boundary();
+        self.push_message(
             crate::messages::MessageSource::Game(game_id.clone()),
             format!("game:{}", game_id),
-            format!("End of {} {}.", phase, current_day),
+            format!("End of {} {}.", phase_str, current_day),
+            payload,
+            tick,
         );
         Ok(())
     }

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -255,6 +255,25 @@ pub enum MessagePayload {
         item: ItemRef,
         debt_recovered: u8,
     },
+
+    // Lifecycle / cycle-boundary announcements (formerly an AreaEvent fallback
+    // synthesised by Game::log() for MessageSource::Game; see
+    // hangrier_games-xamw).
+    /// Emitted at the very start of a day or night phase.
+    CycleStart {
+        day: u32,
+        phase: Phase,
+    },
+    /// Emitted at the very end of a day or night phase.
+    CycleEnd {
+        day: u32,
+        phase: Phase,
+    },
+    /// Emitted when the game ends. `winner` is `Some` for the lone-survivor
+    /// case and `None` for "no survivors".
+    GameEnded {
+        winner: Option<TributeRef>,
+    },
 }
 
 impl MessagePayload {
@@ -275,6 +294,7 @@ impl MessagePayload {
             ItemFound { .. } | ItemUsed { .. } | ItemDropped { .. } | SponsorGift { .. } => {
                 MessageKind::Item
             }
+            CycleStart { .. } | CycleEnd { .. } | GameEnded { .. } => MessageKind::State,
             TributeWounded { .. }
             | TributeRested { .. }
             | TributeStarved { .. }
@@ -325,6 +345,8 @@ impl MessagePayload {
             | Ate { tribute, .. } => r(tribute),
             SponsorGift { recipient, .. } => r(recipient),
             AreaClosed { .. } | AreaEvent { .. } => false,
+            CycleStart { .. } | CycleEnd { .. } => false,
+            GameEnded { winner } => winner.as_ref().is_some_and(r),
         }
     }
 }

--- a/web/src/components/timeline/cards/cycle_card.rs
+++ b/web/src/components/timeline/cards/cycle_card.rs
@@ -1,0 +1,35 @@
+use dioxus::prelude::*;
+use shared::messages::{GameMessage, MessagePayload};
+
+#[derive(Props, PartialEq, Clone)]
+pub struct CycleCardProps {
+    pub message: GameMessage,
+}
+
+/// Renders cycle-boundary and game-lifecycle announcements
+/// (`CycleStart`, `CycleEnd`, `GameEnded`). Falls back to the
+/// pre-rendered `content` string for the human-readable text since
+/// the typed payload only carries structural data (day/phase/winner).
+#[component]
+pub fn CycleCard(props: CycleCardProps) -> Element {
+    let (icon, accent) = match &props.message.payload {
+        MessagePayload::CycleStart { .. } => {
+            ("🌅", "border-amber-500 bg-amber-50 theme2:bg-amber-950")
+        }
+        MessagePayload::CycleEnd { .. } => {
+            ("🌙", "border-indigo-500 bg-indigo-50 theme2:bg-indigo-950")
+        }
+        MessagePayload::GameEnded { .. } => (
+            "🏁",
+            "border-emerald-600 bg-emerald-50 theme2:bg-emerald-950",
+        ),
+        _ => ("📣", "border-sky-500 bg-sky-50 theme2:bg-sky-950"),
+    };
+    rsx! {
+        article { class: "rounded border-l-4 p-3 {accent}",
+            header { class: "font-semibold",
+                "{icon} {props.message.content}"
+            }
+        }
+    }
+}

--- a/web/src/components/timeline/cards/mod.rs
+++ b/web/src/components/timeline/cards/mod.rs
@@ -1,6 +1,7 @@
 pub mod alliance_card;
 pub mod combat_card;
 pub mod combat_swing_card;
+pub mod cycle_card;
 pub mod death_card;
 pub mod item_card;
 pub mod movement_card;

--- a/web/src/components/timeline/cards/movement_card.rs
+++ b/web/src/components/timeline/cards/movement_card.rs
@@ -1,6 +1,6 @@
 use crate::routes::Routes;
 use dioxus::prelude::*;
-use shared::messages::{AreaRef, GameMessage, MessagePayload, MessageSource};
+use shared::messages::{AreaRef, GameMessage, MessagePayload};
 
 #[derive(Props, PartialEq, Clone)]
 pub struct MovementCardProps {
@@ -24,12 +24,6 @@ fn AreaLink(game_identifier: String, area: AreaRef) -> Element {
 
 #[component]
 pub fn MovementCard(props: MovementCardProps) -> Element {
-    // Cycle announcements ("Night 4 falls...", "End of day 3.") flow
-    // through Game::log() which synthesises a fallback `AreaEvent`
-    // payload with `area.name = <game uuid>` and an empty
-    // `description`. Render the human-readable `content` (and drop the
-    // compass flair) for those instead of the raw uuid prefix.
-    let is_game_announcement = matches!(props.message.source, MessageSource::Game(_));
     let gid = props.game_identifier.clone();
     let body = match &props.message.payload {
         MessagePayload::TributeMoved { tribute, from, to } => rsx! {
@@ -49,7 +43,7 @@ pub fn MovementCard(props: MovementCardProps) -> Element {
         MessagePayload::AreaEvent {
             area, description, ..
         } => {
-            if is_game_announcement || description.trim().is_empty() {
+            if description.trim().is_empty() {
                 rsx! { "{props.message.content}" }
             } else {
                 rsx! {
@@ -60,11 +54,10 @@ pub fn MovementCard(props: MovementCardProps) -> Element {
         }
         _ => rsx! { "{props.message.content}" },
     };
-    let prefix = if is_game_announcement { "" } else { "🧭 " };
     rsx! {
         article { class: "rounded border-l-4 border-sky-500 bg-sky-50 theme2:bg-sky-950 p-3",
             header { class: "font-semibold",
-                "{prefix}"
+                "🧭 "
                 {body}
             }
         }

--- a/web/src/components/timeline/event_card.rs
+++ b/web/src/components/timeline/event_card.rs
@@ -1,7 +1,7 @@
 use crate::components::timeline::cards::{
     alliance_card::AllianceCard, combat_card::CombatCard, combat_swing_card::CombatSwingCard,
-    death_card::DeathCard, item_card::ItemCard, movement_card::MovementCard, state_card::StateCard,
-    survival_card::SurvivalCard,
+    cycle_card::CycleCard, death_card::DeathCard, item_card::ItemCard, movement_card::MovementCard,
+    state_card::StateCard, survival_card::SurvivalCard,
 };
 use dioxus::prelude::*;
 use shared::messages::{GameMessage, MessageKind, MessagePayload};
@@ -55,6 +55,9 @@ pub fn EventCard(props: EventCardProps) -> Element {
                 | MessagePayload::Foraged { .. }
                 | MessagePayload::Drank { .. }
                 | MessagePayload::Ate { .. } => rsx! { SurvivalCard { message: props.message.clone() } },
+                MessagePayload::CycleStart { .. }
+                | MessagePayload::CycleEnd { .. }
+                | MessagePayload::GameEnded { .. } => rsx! { CycleCard { message: props.message.clone() } },
                 _ => rsx! { StateCard { message: props.message.clone() } },
             },
             MessageKind::CombatSwing => {


### PR DESCRIPTION
## Summary

- Replaces the `MessagePayload::AreaEvent` fallback that `Game::log()` synthesised for `MessageSource::Game` cycle announcements with three dedicated typed variants: `CycleStart { day, phase }`, `CycleEnd { day, phase }`, and `GameEnded { winner: Option<TributeRef> }`.
- `announce_cycle_start`, `announce_cycle_end`, and `check_for_winner` now construct typed payloads and call `push_message` directly instead of going through `log()` + `fallback_payload()`.
- New `CycleCard` renders the three variants on the timeline; `event_card` routes them via `MessageKind::State`; `MovementCard` drops the `is_game_announcement` workaround that was only there because cycle announcements masqueraded as `AreaEvent` with `area.name = <game uuid>`.

## Changes

- `shared/src/messages.rs`: 3 new `MessagePayload` variants; `kind()` and `involves()` updated.
- `game/src/games.rs`: rewrite `announce_cycle_start`, `announce_cycle_end`, `check_for_winner` to emit typed payloads. `fallback_payload(MessageSource::Game)` now returns `GameEnded { winner: None }` (defensive; no remaining call sites use it for Game source).
- `web/src/components/timeline/cards/cycle_card.rs`: new card.
- `web/src/components/timeline/cards/{mod.rs,movement_card.rs}` + `event_card.rs`: wire the new card and remove the old workaround.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --tests -- -D warnings` — clean
- `cargo test -p game --lib test_announce` — 3 passed (cycle start, cycle end, area events)
- `cargo test -p game` — full game suite passes
- `cargo test -p shared` — 26 passed
- `cargo check -p web` — clean

## Follow-ups

- hangrier_games-g2v (next on the backlog) — typed `CombatBeat` payload for `GameEvent::Combat`.