### PR TITLE
test(game): expand combat parity-snapshot suite for to_log_lines

### DIFF
--- a/game/src/tributes/combat_beat.rs
+++ b/game/src/tributes/combat_beat.rs
@@ -433,5 +433,128 @@ mod tests {
             };
             b
         });
+
+        // --- Gap-coverage snapshots (hangrier_games-b84) ---
+
+        // `Pristine` wear must produce no extra lines (no-op branch).
+        snap!(wound_with_pristine_weapon_and_shield, {
+            let mut b = base_beat(SwingOutcome::Wound { damage: 5 });
+            b.wear.push(WearReport {
+                owner: t("Alice"),
+                item: sword(),
+                outcome: WearOutcomeReport::Pristine,
+                forfeited_effect: None,
+                mid_action_penalty: None,
+            });
+            b.wear.push(WearReport {
+                owner: t("Bob"),
+                item: shield(),
+                outcome: WearOutcomeReport::Pristine,
+                forfeited_effect: None,
+                mid_action_penalty: None,
+            });
+            b
+        });
+
+        // Both weapon and shield worn (not broken) in one beat.
+        snap!(wound_with_both_worn, {
+            let mut b = base_beat(SwingOutcome::Wound { damage: 6 });
+            b.wear.push(WearReport {
+                owner: t("Alice"),
+                item: sword(),
+                outcome: WearOutcomeReport::Worn,
+                forfeited_effect: None,
+                mid_action_penalty: None,
+            });
+            b.wear.push(WearReport {
+                owner: t("Bob"),
+                item: shield(),
+                outcome: WearOutcomeReport::Worn,
+                forfeited_effect: None,
+                mid_action_penalty: None,
+            });
+            b
+        });
+
+        // Stress with no `stressed` set falls back to the attacker name.
+        snap!(wound_with_stress_fallback_to_attacker, {
+            let mut b = base_beat(SwingOutcome::Wound { damage: 4 });
+            b.stress = StressReport {
+                stress_damage: 6,
+                stressed: None,
+            };
+            b
+        });
+
+        // Critical hit + weapon break with penalty + attacker stress.
+        snap!(critical_hit_with_weapon_break_and_stress, {
+            let mut b = base_beat(SwingOutcome::CriticalHitWound { damage: 18 });
+            b.wear.push(WearReport {
+                owner: t("Alice"),
+                item: sword(),
+                outcome: WearOutcomeReport::Broken,
+                forfeited_effect: Some(6),
+                mid_action_penalty: Some(3),
+            });
+            b.stress = StressReport {
+                stress_damage: 4,
+                stressed: Some(t("Alice")),
+            };
+            b
+        });
+
+        // BlockWound (counter) + shield break + penalty + defender stress.
+        snap!(block_wound_with_shield_break_and_stress, {
+            let mut b = base_beat(SwingOutcome::BlockWound { damage: 7 });
+            b.wear.push(WearReport {
+                owner: t("Bob"),
+                item: shield(),
+                outcome: WearOutcomeReport::Broken,
+                forfeited_effect: Some(4),
+                mid_action_penalty: Some(2),
+            });
+            b.stress = StressReport {
+                stress_damage: 5,
+                stressed: Some(t("Bob")),
+            };
+            b
+        });
+
+        // AttackerDied (PerfectBlock kill) with defender stress.
+        snap!(attacker_died_with_defender_stress, {
+            let mut b = base_beat(SwingOutcome::AttackerDied { damage: 10 });
+            b.stress = StressReport {
+                stress_damage: 9,
+                stressed: Some(t("Bob")),
+            };
+            b
+        });
+
+        // FumbleDeath + weapon break (rare but emittable: the swing breaks the
+        // weapon then the fumble kills the attacker).
+        snap!(fumble_death_with_weapon_break, {
+            let mut b = base_beat(SwingOutcome::FumbleDeath { self_damage: 8 });
+            b.wear.push(WearReport {
+                owner: t("Alice"),
+                item: sword(),
+                outcome: WearOutcomeReport::Broken,
+                forfeited_effect: Some(5),
+                mid_action_penalty: Some(2),
+            });
+            b
+        });
+
+        // SelfAttackWound with weapon worn (self-targeted swing still wears gear).
+        snap!(self_attack_wound_with_weapon_worn, {
+            let mut b = base_beat(SwingOutcome::SelfAttackWound { damage: 3 });
+            b.wear.push(WearReport {
+                owner: t("Alice"),
+                item: sword(),
+                outcome: WearOutcomeReport::Worn,
+                forfeited_effect: None,
+                mid_action_penalty: None,
+            });
+            b
+        });
     }
 }

--- a/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__attacker_died_with_defender_stress.snap
+++ b/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__attacker_died_with_defender_stress.snap
@@ -1,0 +1,7 @@
+---
+source: game/src/tributes/combat_beat.rs
+expression: lines
+---
+- "🤣 Bob attacks Alice, but loses!"
+- ☠️ Alice is killed by Bob
+- "😱 Bob is horrified by the violence, loses 9 sanity."

--- a/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__block_wound_with_shield_break_and_stress.snap
+++ b/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__block_wound_with_shield_break_and_stress.snap
@@ -1,0 +1,10 @@
+---
+source: game/src/tributes/combat_beat.rs
+expression: lines
+---
+- 🛡️ Bob breaks their Iron Buckler
+- "🛡️ Bob's Iron Buckler shatters mid-block! (-2 defense)"
+- "🛡️ Bob perfectly blocks Alice's attack and counters!"
+- "🤣 Bob attacks Alice, but loses!"
+- 🤕 Alice wounds Bob
+- "😱 Bob is horrified by the violence, loses 5 sanity."

--- a/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__critical_hit_with_weapon_break_and_stress.snap
+++ b/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__critical_hit_with_weapon_break_and_stress.snap
@@ -1,0 +1,10 @@
+---
+source: game/src/tributes/combat_beat.rs
+expression: lines
+---
+- 🗡️ Alice breaks their Iron Sword
+- "🗡️ Alice's Iron Sword shatters mid-swing! (-3 attack)"
+- 💥 Alice lands a CRITICAL HIT on Bob!
+- "🔪 Alice attacks Bob, and wins!"
+- 🤕 Alice wounds Bob
+- "😱 Alice is horrified by the violence, loses 4 sanity."

--- a/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__fumble_death_with_weapon_break.snap
+++ b/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__fumble_death_with_weapon_break.snap
@@ -1,0 +1,8 @@
+---
+source: game/src/tributes/combat_beat.rs
+expression: lines
+---
+- 🗡️ Alice breaks their Iron Sword
+- "🗡️ Alice's Iron Sword shatters mid-swing! (-2 attack)"
+- 😵 Alice fumbles their attack badly and hurts themself!
+- ☠️ Alice is killed by themselves

--- a/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__self_attack_wound_with_weapon_worn.snap
+++ b/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__self_attack_wound_with_weapon_worn.snap
@@ -1,0 +1,8 @@
+---
+source: game/src/tributes/combat_beat.rs
+expression: lines
+---
+- "🗡️ Alice's Iron Sword is showing signs of wear"
+- 🤦 Alice tries to attack themself!
+- "🔪 Alice attacks Alice, and wins!"
+- 🤕 Alice wounds Alice

--- a/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__wound_with_both_worn.snap
+++ b/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__wound_with_both_worn.snap
@@ -1,0 +1,8 @@
+---
+source: game/src/tributes/combat_beat.rs
+expression: lines
+---
+- "🗡️ Alice's Iron Sword is showing signs of wear"
+- "🛡️ Bob's Iron Buckler is showing signs of wear"
+- "🔪 Alice attacks Bob, and wins!"
+- 🤕 Alice wounds Bob

--- a/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__wound_with_pristine_weapon_and_shield.snap
+++ b/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__wound_with_pristine_weapon_and_shield.snap
@@ -1,0 +1,6 @@
+---
+source: game/src/tributes/combat_beat.rs
+expression: lines
+---
+- "🔪 Alice attacks Bob, and wins!"
+- 🤕 Alice wounds Bob

--- a/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__wound_with_stress_fallback_to_attacker.snap
+++ b/game/src/tributes/snapshots/game__tributes__combat_beat__tests__snapshots__wound_with_stress_fallback_to_attacker.snap
@@ -1,0 +1,7 @@
+---
+source: game/src/tributes/combat_beat.rs
+expression: lines
+---
+- "🔪 Alice attacks Bob, and wins!"
+- 🤕 Alice wounds Bob
+- "😱 Alice is horrified by the violence, loses 6 sanity."


### PR DESCRIPTION
## Summary

- Lock the `CombatBeat::to_log_lines()` baseline before any mechanics rework (hangrier_games-93m / -6rt) so drift in narration shows up as snapshot diffs rather than silent regressions.
- Adds 8 gap-coverage snapshots (22 → 30) targeting branches the original suite missed.

## Changes

- `game/src/tributes/combat_beat.rs` — new snapshot cases:
  - `wound_with_pristine_weapon_and_shield` — the `WearOutcomeReport::Pristine` no-op branch.
  - `wound_with_both_worn` — both weapon and shield worn (not broken) in one beat.
  - `wound_with_stress_fallback_to_attacker` — `StressReport.stressed = None` falls back to attacker name.
  - `critical_hit_with_weapon_break_and_stress` — Critical + break-with-penalty + attacker stress.
  - `block_wound_with_shield_break_and_stress` — counter (PerfectBlock) + shield-break + defender stress.
  - `attacker_died_with_defender_stress` — counter killed attacker, defender takes stress.
  - `fumble_death_with_weapon_break` — fumble that kills the attacker after weapon break.
  - `self_attack_wound_with_weapon_worn` — self-targeted swing still wears gear.
- 8 corresponding `.snap` files under `game/src/tributes/snapshots/`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --tests -- -D warnings`
- `cargo test -p game --lib -- tributes::combat_beat` → 30 passed
- Spot-checked snapshots: pristine emits no wear lines; stress fallback uses attacker name.

## Follow-ups

- bd `hangrier_games-93m` — Combat mechanics rework (next; will land snapshot updates as deliberate diffs).
- bd `hangrier_games-6rt` — Variable wear amounts in combat.

Closes hangrier_games-b84.