### PR TITLE
docs(spec,plans): stamina-as-combat-resource (hangrier_games-93m)

### DIFF
--- a/docs/superpowers/plans/2026-05-03-stamina-combat-resource-pr1-backend.md
+++ b/docs/superpowers/plans/2026-05-03-stamina-combat-resource-pr1-backend.md
@@ -1,0 +1,1564 @@
+# Stamina-as-Combat-Resource PR1 — Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land combat-stamina drain, fatigue bands, recovery formula, brain integration, and per-phase `StaminaBandChanged` events as a backend-only PR. No frontend changes.
+
+**Architecture:** A new `CombatTuning` struct hangs off `Game.combat_tuning` and absorbs the existing six combat magic numbers plus ten new stamina knobs. `Action::Attack` resolution deducts asymmetric per-swing costs (attacker 25, target 10). A `StaminaBand` enum (`Fresh` / `Winded` / `Exhausted`) lives in `shared/src/messages.rs` next to `HungerBand` / `ThirstBand`; a pure `stamina_band()` function lives in `game/src/tributes/stamina_band.rs`. Roll penalties (-2 Winded, -5 Exhausted) apply to `attack_roll` and `defense_roll`. The brain gains a fourth override layer between hunger/thirst and standard logic: Winded scoring nudges, Exhausted SeekShelter/Rest, visible-band flee, plus a Fresh-on-tired predator bonus and a hard action-gate when stamina < attacker cost. Recovery happens once per phase: idle 5, resting 30, sheltered+resting 60, ×0.5 if Starving or Dehydrated. `MessagePayload::StaminaBandChanged { tribute, from: String, to: String }` routes to the existing `MessageKind::State` (no new MessageKind variant).
+
+**Tech Stack:** Rust 2024, rstest for parametric tests, serde for persistence, `rand::SmallRng` for determinism. No new crate dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`
+**Beads issue:** `hangrier_games-93m`
+
+---
+
+## Pre-flight Notes
+
+- **Predecessors landed on `main`:**
+  - Shelter + Hunger/Thirst (`hangrier_games-0yz`) — `HungerBand`/`ThirstBand`, `tick_survival`, `sheltered_until`, the band-changed event pattern in `shared/src/messages.rs`.
+  - Combat-wire redesign (`hangrier_games-dxp`) — typed `CombatBeat` payload with `attacker`/`target`/`weapon`/`shield`/`wear`/`outcome`/`stress`.
+  - Break-mid-swing forfeit logic (commit `ce2c8f1`).
+- **`stamina` field on `Tribute` already exists** (`game/src/tributes/mod.rs:184-188`, default 100/100). No schema migration needed.
+- **`calculate_stamina_cost`** already lists `Action::Attack => 25.0` (`game/src/tributes/mod.rs:852`) but it isn't currently wired into `Action::Attack` resolution. PR1 wires it via the new `CombatTuning` constants instead — the existing function is untouched.
+- **`restore_stamina`** is a single-call-site fn on `Tribute` (`game/src/tributes/lifecycle.rs:179`); it is renamed `recover_stamina` and gains arguments. Search confirms no cross-crate callers.
+- **Per-phase loop pattern** to mirror lives at `game/src/games.rs:1020-1100` (the existing hunger/thirst tick + band-change emission). Stamina recovery + band-cross emission slot in the same per-tribute block.
+- All commits use the project's jj/git workflow per `AGENTS.md`. Each task ends with `jj describe -m "..."` then `jj new`.
+- `bd update hangrier_games-93m --claim` before starting Task 1; `bd close hangrier_games-93m-pr1-<id>` when PR1 is open.
+
+---
+
+## File Structure
+
+**Created:**
+- `game/src/tributes/combat_tuning.rs` — `CombatTuning` struct + `Default` impl.
+- `game/src/tributes/stamina_band.rs` — `stamina_band()` pure function + sibling helpers.
+- `game/tests/stamina_combat_integration.rs` — end-to-end scenarios (drain, recovery, fleeing).
+
+**Modified:**
+- `game/src/tributes/mod.rs` — add `pub mod combat_tuning;` + `pub mod stamina_band;`; gate `Action::Attack` on attacker stamina; deduct attacker cost at the call site before invoking `attacks()`.
+- `game/src/tributes/combat.rs` — replace six top-of-file constants with `CombatTuning` reads; thread `&CombatTuning` into `Tribute::attacks` and `attack_contest`; deduct target cost inside `attack_contest`; subtract band-derived roll penalties from both rolls; populate `attacker_stamina_cost` / `target_stamina_cost` on `CombatBeat`.
+- `game/src/tributes/lifecycle.rs` — rename `restore_stamina` → `recover_stamina(action, sheltered, hunger_band, thirst_band, tuning)`; new formula.
+- `game/src/tributes/brains.rs` — new `stamina_override` function (Winded score nudge, Exhausted SeekShelter / Rest / flee); update `decide_action_*` callers to consult it; wire `fresh_target_visibly_tired_bonus` into `target_attack_score` (or equivalent target-scoring path); action-gate Attack when actor stamina < `stamina_cost_attacker`.
+- `game/src/games.rs` — add `pub combat_tuning: CombatTuning` field with `#[serde(default)]`; default in `Default` impl; per-phase recovery + `StaminaBandChanged` emission inside the existing per-tribute survival block (`games.rs:1020-1100`); pass `&self.combat_tuning` into `Tribute::process_turn_phase` (or wherever attacks/brain decisions are dispatched).
+- `shared/src/messages.rs` — add `StaminaBand` enum; add `MessagePayload::StaminaBandChanged { tribute, from: String, to: String }` variant; extend `kind()` State arm; extend `involves()` State arm.
+- `shared/src/combat_beat.rs` — add `attacker_stamina_cost: u32` and `target_stamina_cost: u32` to `CombatBeat`, both `#[serde(default)]` for back-compat.
+
+---
+
+## Conventions
+
+- **TDD throughout.** Failing test → run → minimal impl → run → commit.
+- **Commit message:** `feat(combat): <task summary>` for new combat code; `feat(shared): <summary>` for shared crate; `feat(game): <summary>` for game-crate integration touch points; `refactor(combat): <summary>` for the constant hoist (Task 2).
+- **Test command (game crate):** `cargo test --package game stamina`
+- **Test command (specific test):** `cargo test --package game -- <test_name> --exact --nocapture`
+- **Run after every task:** `just fmt && cargo check --workspace`
+- **Use `SmallRng::seed_from_u64(N)`** in tests for determinism.
+- **Never edit `calculate_stamina_cost`** (`mod.rs:842-880`) — it's the legacy non-combat cost calculator and stays.
+
+---
+
+## Task 1: `CombatTuning` struct + `Default` impl + `Game.combat_tuning` field
+
+**Files:**
+- Create: `game/src/tributes/combat_tuning.rs`
+- Modify: `game/src/tributes/mod.rs` (add `pub mod combat_tuning;`)
+- Modify: `game/src/games.rs` (add field + default)
+
+**Goal:** A new `CombatTuning` struct exists with all 16 fields and `Default` values that exactly reproduce current behavior (six existing constants verbatim) plus the ten new stamina knobs. `Game.combat_tuning` defaults to it. No combat behavior changes — this is plumbing.
+
+- [ ] **Step 1: Write failing test in `game/src/tributes/combat_tuning.rs`:**
+
+```rust
+//! Tunable knobs for combat: existing magic numbers (decisive-win multiplier,
+//! stress contributions) plus the new stamina-as-combat-resource constants
+//! introduced by `hangrier_games-93m`.
+//!
+//! All defaults preserve current behavior; tuning is a separate post-ship pass.
+//! See `docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CombatTuning {
+    // --- Existing constants (verbatim from combat.rs:21-26) ---
+    pub decisive_win_multiplier: f64,
+    pub base_stress_no_engagements: f64,
+    pub stress_sanity_normalization: f64,
+    pub stress_final_divisor: f64,
+    pub kill_stress_contribution: f64,
+    pub non_kill_win_stress_contribution: f64,
+
+    // --- Per-swing stamina costs (asymmetric: swinging is harder than defending) ---
+    pub stamina_cost_attacker: u32,
+    pub stamina_cost_target: u32,
+
+    // --- Band thresholds (% of max_stamina; > => Fresh, > => Winded, else Exhausted) ---
+    pub band_winded_pct: u8,
+    pub band_exhausted_pct: u8,
+
+    // --- Per-band roll penalties (subtracted from attack/defense rolls) ---
+    pub winded_roll_penalty: i32,
+    pub exhausted_roll_penalty: i32,
+
+    // --- Per-phase recovery (gross, before survival-debuff multiplier) ---
+    pub recovery_idle: u32,
+    pub recovery_resting: u32,
+    pub recovery_sheltered_resting: u32,
+    pub recovery_starving_dehydrated_mult: f64,
+
+    // --- Brain scoring nudges ---
+    pub winded_attack_score_penalty: i32,
+    pub fresh_target_visibly_tired_bonus: i32,
+}
+
+impl Default for CombatTuning {
+    fn default() -> Self {
+        Self {
+            decisive_win_multiplier: 1.5,
+            base_stress_no_engagements: 20.0,
+            stress_sanity_normalization: 100.0,
+            stress_final_divisor: 2.0,
+            kill_stress_contribution: 50.0,
+            non_kill_win_stress_contribution: 20.0,
+
+            stamina_cost_attacker: 25,
+            stamina_cost_target: 10,
+
+            band_winded_pct: 50,
+            band_exhausted_pct: 20,
+
+            winded_roll_penalty: -2,
+            exhausted_roll_penalty: -5,
+
+            recovery_idle: 5,
+            recovery_resting: 30,
+            recovery_sheltered_resting: 60,
+            recovery_starving_dehydrated_mult: 0.5,
+
+            winded_attack_score_penalty: -10,
+            fresh_target_visibly_tired_bonus: 5,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_current_behavior_constants() {
+        let t = CombatTuning::default();
+        assert_eq!(t.decisive_win_multiplier, 1.5);
+        assert_eq!(t.base_stress_no_engagements, 20.0);
+        assert_eq!(t.stress_sanity_normalization, 100.0);
+        assert_eq!(t.stress_final_divisor, 2.0);
+        assert_eq!(t.kill_stress_contribution, 50.0);
+        assert_eq!(t.non_kill_win_stress_contribution, 20.0);
+    }
+
+    #[test]
+    fn default_stamina_constants_match_spec() {
+        let t = CombatTuning::default();
+        assert_eq!(t.stamina_cost_attacker, 25);
+        assert_eq!(t.stamina_cost_target, 10);
+        assert_eq!(t.band_winded_pct, 50);
+        assert_eq!(t.band_exhausted_pct, 20);
+        assert_eq!(t.winded_roll_penalty, -2);
+        assert_eq!(t.exhausted_roll_penalty, -5);
+        assert_eq!(t.recovery_idle, 5);
+        assert_eq!(t.recovery_resting, 30);
+        assert_eq!(t.recovery_sheltered_resting, 60);
+        assert_eq!(t.recovery_starving_dehydrated_mult, 0.5);
+        assert_eq!(t.winded_attack_score_penalty, -10);
+        assert_eq!(t.fresh_target_visibly_tired_bonus, 5);
+    }
+
+    #[test]
+    fn round_trips_through_serde_json() {
+        let t = CombatTuning::default();
+        let s = serde_json::to_string(&t).unwrap();
+        let back: CombatTuning = serde_json::from_str(&s).unwrap();
+        assert_eq!(t, back);
+    }
+}
+```
+
+- [ ] **Step 2: Add `pub mod combat_tuning;` to `game/src/tributes/mod.rs`** (alphabetical with the other submodules near the top of the file). Run `cargo check --package game`. Expected: clean.
+
+- [ ] **Step 3: Run the inline tests:**
+
+```bash
+cargo test --package game tributes::combat_tuning -- --nocapture
+```
+
+Expected: all three pass.
+
+- [ ] **Step 4: Add field to `Game` struct in `game/src/games.rs`** (after `pub emit_index: u32,` near line ~125):
+
+```rust
+    /// Tunable combat & stamina knobs. See spec
+    /// `2026-05-03-stamina-combat-resource-design.md`.
+    #[serde(default)]
+    pub combat_tuning: crate::tributes::combat_tuning::CombatTuning,
+```
+
+- [ ] **Step 5: Add to the `Default` impl** for `Game`:
+
+```rust
+            combat_tuning: crate::tributes::combat_tuning::CombatTuning::default(),
+```
+
+- [ ] **Step 6: Add a smoke test** to the same `tests` block in `combat_tuning.rs`:
+
+```rust
+    #[test]
+    fn game_default_carries_default_combat_tuning() {
+        let g = crate::games::Game::default();
+        assert_eq!(g.combat_tuning, CombatTuning::default());
+    }
+```
+
+- [ ] **Step 7: Run `just test`** — expected: pass (allowing pre-existing unrelated failures).
+
+- [ ] **Step 8: Commit:**
+
+```bash
+jj describe -m "feat(combat): introduce CombatTuning struct with current-behavior defaults (hangrier_games-93m)"
+jj new
+```
+
+---
+
+## Task 2: Hoist existing six combat constants to `CombatTuning`
+
+**Files:**
+- Modify: `game/src/tributes/combat.rs` (delete 6 `const` lines; thread `&CombatTuning` through `Tribute::attacks` + `attack_contest` + the stress functions)
+- Modify: `game/src/tributes/mod.rs` (`Action::Attack` call site passes `&game.combat_tuning`)
+
+**Goal:** Mechanical hoist. The six top-of-file constants are deleted; their literal usages are replaced by reads from a `CombatTuning` reference threaded into the combat call chain. **All existing combat tests must still pass with no fixture changes** — Default values are exact.
+
+- [ ] **Step 1: Audit current constant usages.** Run:
+
+```bash
+grep -n "DECISIVE_WIN_MULTIPLIER\|BASE_STRESS_NO_ENGAGEMENTS\|STRESS_SANITY_NORMALIZATION\|STRESS_FINAL_DIVISOR\|KILL_STRESS_CONTRIBUTION\|NON_KILL_WIN_STRESS_CONTRIBUTION" game/src/tributes/combat.rs
+```
+
+Expected: 6 declarations + 6 usages (line ~499-512 stress block, line ~732 + ~744 decisive-win clamp).
+
+- [ ] **Step 2: Change `Tribute::attacks` signature** (`combat.rs:74`) to accept `&CombatTuning`:
+
+```rust
+pub(crate) fn attacks(
+    &mut self,
+    target: &mut Tribute,
+    rng: &mut impl Rng,
+    events: &mut Vec<TaggedEvent>,
+    tuning: &crate::tributes::combat_tuning::CombatTuning,
+) -> AttackOutcome {
+```
+
+- [ ] **Step 3: Change `attack_contest` signature** (`combat.rs:545`) similarly:
+
+```rust
+pub fn attack_contest(
+    attacker: &mut Tribute,
+    target: &mut Tribute,
+    rng: &mut impl Rng,
+    events: &mut Vec<TaggedEvent>,
+    tuning: &crate::tributes::combat_tuning::CombatTuning,
+) -> AttackContestOutcome {
+```
+
+- [ ] **Step 4: Replace constant reads** inside `attacks` / `attack_contest` / stress helpers:
+
+```rust
+// combat.rs:732 (was: defense_roll - attack_roll * DECISIVE_WIN_MULTIPLIER)
+defense_roll as f64 - (attack_roll as f64 * tuning.decisive_win_multiplier);
+
+// combat.rs:744 (was: attack_roll - defense_roll * DECISIVE_WIN_MULTIPLIER)
+attack_roll as f64 - (defense_roll as f64 * tuning.decisive_win_multiplier);
+
+// combat.rs:499-509 stress calc — read from tuning fields
+let raw_stress_potential = (kills as f64 * tuning.kill_stress_contribution)
+    + (non_kill_wins as f64 * tuning.non_kill_win_stress_contribution);
+// ...
+desensitized_stress_per_encounter * (current_sanity as f64 / tuning.stress_sanity_normalization)
+    / tuning.stress_final_divisor
+
+// combat.rs:512 base_stress
+tuning.base_stress_no_engagements
+```
+
+If the stress helper is a free function rather than a method on `Tribute`, give it the same `tuning: &CombatTuning` parameter and update its callers.
+
+- [ ] **Step 5: Delete the six top-of-file `const` declarations** (`combat.rs:21-26`).
+
+- [ ] **Step 6: Update the call site in `Action::Attack`** (`game/src/tributes/mod.rs:548-555`). The `tribute.act()` chain currently has access to `self` (the tribute) but not `Game`. Look at how `act()` already receives `EncounterContext` — extend that struct (or its caller) to carry `tuning: &CombatTuning`.
+
+Concrete pattern: `Tribute::act` is invoked from `Game::process_turn_phase` (`games.rs:~1185`). Add a `tuning` parameter to whichever signature in the chain is closest to the call to `self.attacks(&mut target, rng, events)`. Pass `&self.combat_tuning` from `Game`. Update the test inline at `combat.rs:1234+` (`attacks_emits_one_combat_taggedevent` etc.) to construct a `CombatTuning::default()` and pass `&tuning` to `attacks`.
+
+- [ ] **Step 7: Update all in-file combat tests** (`combat.rs:916+`):
+
+```rust
+let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+let outcome = attacker.attacks(&mut target, &mut small_rng, &mut events, &tuning);
+```
+
+(Mechanical sed-style change across the test module.)
+
+- [ ] **Step 8: Run combat tests:**
+
+```bash
+cargo test --package game tributes::combat -- --nocapture
+```
+
+Expected: all existing tests pass with no fixture changes (decisive-win, kill, wound, miss, suicide, etc.).
+
+- [ ] **Step 9: Run `just test`.** Expected: pass.
+
+- [ ] **Step 10: Commit:**
+
+```bash
+jj describe -m "refactor(combat): hoist 6 magic numbers to CombatTuning (no behavior change)"
+jj new
+```
+
+---
+
+## Task 3: `StaminaBand` enum + `stamina_band()` pure function
+
+**Files:**
+- Modify: `shared/src/messages.rs` (add `StaminaBand` enum next to `HungerBand` location pattern — actually `HungerBand` lives in `game/src/tributes/survival.rs`, not shared. **`StaminaBand` lives in `shared/` per spec** because it's wire-visible via `StaminaBandChanged`.)
+- Create: `game/src/tributes/stamina_band.rs`
+- Modify: `game/src/tributes/mod.rs` (`pub mod stamina_band;`)
+
+**Goal:** Pure-function band derivation matching the spec table. Edge cases: `max_stamina == 0` returns `Exhausted`; integer percent uses `(stamina * 100) / max_stamina`; `>` not `>=` so a tribute exactly at the threshold drops to the worse band (matches spec table "≤ 50%" boundary).
+
+- [ ] **Step 1: Add `StaminaBand` to `shared/src/messages.rs`.** Find the location of `MessagePayload` enum (around line ~150) and place `StaminaBand` immediately above it (near the other ref/enum types). Insert:
+
+```rust
+/// Visible fatigue band derived from a tribute's stamina/max_stamina ratio.
+/// Lives in `shared/` because it is wire-visible via
+/// `MessagePayload::StaminaBandChanged`. Mirror of the `HungerBand`/`ThirstBand`
+/// pattern (those live in `game::tributes::survival` because they are not
+/// directly serialised on the wire — band-changed events use `String`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum StaminaBand {
+    Fresh,
+    Winded,
+    Exhausted,
+}
+```
+
+- [ ] **Step 2: Write failing test in `game/src/tributes/stamina_band.rs`:**
+
+```rust
+//! Pure derivation of `StaminaBand` from a tribute's stamina ratio.
+//! Thresholds come from `CombatTuning`. See spec
+//! `docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`.
+
+use crate::tributes::combat_tuning::CombatTuning;
+use shared::messages::StaminaBand;
+
+/// Returns the `StaminaBand` for the given stamina/max_stamina pair.
+///
+/// - `> band_winded_pct`% => Fresh
+/// - `> band_exhausted_pct`% but `<= band_winded_pct`% => Winded
+/// - `<= band_exhausted_pct`% => Exhausted
+/// - `max_stamina == 0` => Exhausted (defensive; should not occur in practice)
+pub fn stamina_band(stamina: u32, max_stamina: u32, tuning: &CombatTuning) -> StaminaBand {
+    if max_stamina == 0 {
+        return StaminaBand::Exhausted;
+    }
+    let pct = ((stamina.saturating_mul(100)) / max_stamina) as u8;
+    if pct > tuning.band_winded_pct {
+        StaminaBand::Fresh
+    } else if pct > tuning.band_exhausted_pct {
+        StaminaBand::Winded
+    } else {
+        StaminaBand::Exhausted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    fn t() -> CombatTuning {
+        CombatTuning::default()
+    }
+
+    #[rstest]
+    #[case(100, 100, StaminaBand::Fresh)]
+    #[case(75, 100, StaminaBand::Fresh)]
+    #[case(51, 100, StaminaBand::Fresh)]
+    #[case(50, 100, StaminaBand::Winded)]
+    #[case(30, 100, StaminaBand::Winded)]
+    #[case(21, 100, StaminaBand::Winded)]
+    #[case(20, 100, StaminaBand::Exhausted)]
+    #[case(5, 100, StaminaBand::Exhausted)]
+    #[case(0, 100, StaminaBand::Exhausted)]
+    fn band_thresholds(#[case] stamina: u32, #[case] max: u32, #[case] expected: StaminaBand) {
+        assert_eq!(stamina_band(stamina, max, &t()), expected);
+    }
+
+    #[test]
+    fn zero_max_returns_exhausted() {
+        assert_eq!(stamina_band(0, 0, &t()), StaminaBand::Exhausted);
+        assert_eq!(stamina_band(100, 0, &t()), StaminaBand::Exhausted);
+    }
+
+    #[test]
+    fn custom_thresholds_respected() {
+        let mut tuning = CombatTuning::default();
+        tuning.band_winded_pct = 70;
+        tuning.band_exhausted_pct = 30;
+        assert_eq!(stamina_band(71, 100, &tuning), StaminaBand::Fresh);
+        assert_eq!(stamina_band(70, 100, &tuning), StaminaBand::Winded);
+        assert_eq!(stamina_band(31, 100, &tuning), StaminaBand::Winded);
+        assert_eq!(stamina_band(30, 100, &tuning), StaminaBand::Exhausted);
+    }
+}
+```
+
+- [ ] **Step 3: Add `pub mod stamina_band;` to `game/src/tributes/mod.rs`** (alphabetical with siblings).
+
+- [ ] **Step 4: Run tests:**
+
+```bash
+cargo test --package game tributes::stamina_band -- --nocapture
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit:**
+
+```bash
+jj describe -m "feat(shared,game): StaminaBand enum + stamina_band() pure function"
+jj new
+```
+
+---
+
+## Task 4: `MessagePayload::StaminaBandChanged` variant + routing
+
+**Files:**
+- Modify: `shared/src/messages.rs`
+
+**Goal:** New typed payload variant routes through existing `MessageKind::State` (no new `MessageKind` arm). Mirrors `HungerBandChanged`/`ThirstBandChanged` exactly: `from`/`to` are `String` (not the typed `StaminaBand` enum) so the wire stays consistent with the established band-change pattern. Round-trip + `kind()` + `involves()` all covered.
+
+- [ ] **Step 1: Add the variant to `MessagePayload`** (near the other band events, around `shared/src/messages.rs:226-235`):
+
+```rust
+    StaminaBandChanged {
+        tribute: TributeRef,
+        from: String,
+        to: String,
+    },
+```
+
+- [ ] **Step 2: Extend `MessagePayload::kind()` State arm** (`messages.rs:303-308`). Add `| StaminaBandChanged { .. }` to the `=> MessageKind::State` arm so the full pattern reads:
+
+```rust
+            TributeWounded { .. }
+            | TributeRested { .. }
+            | TributeStarved { .. }
+            | TributeDehydrated { .. }
+            | SanityBreak { .. }
+            | HungerBandChanged { .. }
+            | ThirstBandChanged { .. }
+            | StaminaBandChanged { .. }
+            | ShelterSought { .. }
+            | Foraged { .. }
+            | Drank { .. }
+            | Ate { .. } => MessageKind::State,
+```
+
+- [ ] **Step 3: Extend `MessagePayload::involves()` State arm** (`messages.rs:340-348`). Add `| StaminaBandChanged { tribute, .. }` to the same `tribute`-bound match so the new variant participates in per-tribute filtering:
+
+```rust
+            | TributeRested { tribute, .. }
+            | TributeStarved { tribute, .. }
+            | TributeDehydrated { tribute, .. }
+            | SanityBreak { tribute }
+            | HungerBandChanged { tribute, .. }
+            | ThirstBandChanged { tribute, .. }
+            | StaminaBandChanged { tribute, .. }
+            | ShelterSought { tribute, .. }
+            | Foraged { tribute, .. }
+            | Drank { tribute, .. }
+            | Ate { tribute, .. } => r(tribute),
+```
+
+- [ ] **Step 4: Add round-trip test** to `shared/src/messages.rs` tests module (mirror the existing `band_change_payloads_round_trip` test at `messages.rs:878`):
+
+```rust
+    #[test]
+    fn stamina_band_change_round_trips_and_routes_to_state() {
+        let p = MessagePayload::StaminaBandChanged {
+            tribute: tref(),
+            from: "Fresh".into(),
+            to: "Winded".into(),
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: MessagePayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(format!("{:?}", p), format!("{:?}", back));
+        assert_eq!(p.kind(), MessageKind::State);
+        assert!(p.involves(&tref().identifier));
+    }
+
+    #[test]
+    fn stamina_band_enum_round_trips() {
+        for band in [StaminaBand::Fresh, StaminaBand::Winded, StaminaBand::Exhausted] {
+            let s = serde_json::to_string(&band).unwrap();
+            let back: StaminaBand = serde_json::from_str(&s).unwrap();
+            assert_eq!(band, back);
+        }
+    }
+```
+
+- [ ] **Step 5: Update any exhaustive `MessagePayload` match elsewhere.** Search:
+
+```bash
+grep -rn "MessagePayload::HungerBandChanged" game/ web/ api/ shared/
+```
+
+For each call site, if it's an exhaustive `match`, add `MessagePayload::StaminaBandChanged { .. } => /* same as HungerBandChanged */` arm. (Most sites use `..` catch-alls; only test fixtures and routing will be exhaustive.)
+
+- [ ] **Step 6: Run shared tests:**
+
+```bash
+cargo test --package shared messages -- --nocapture
+```
+
+Expected: pass including new tests.
+
+- [ ] **Step 7: Run `cargo check --workspace`.** Expected: clean (this catches any non-exhaustive match warnings in downstream crates).
+
+- [ ] **Step 8: Commit:**
+
+```bash
+jj describe -m "feat(shared): StaminaBandChanged payload variant routes to MessageKind::State"
+jj new
+```
+
+---
+
+## Task 5: Per-swing stamina cost deduction (attacker + target)
+
+**Files:**
+- Modify: `shared/src/combat_beat.rs`
+- Modify: `game/src/tributes/combat.rs`
+- Modify: `game/src/tributes/mod.rs` (Action::Attack call site)
+
+**Goal:** Each call to `attacks()` deducts `tuning.stamina_cost_attacker` from the attacker (via `saturating_sub`) before contest resolution, and `tuning.stamina_cost_target` from the target. The costs are reflected on `CombatBeat` for downstream rendering. Action selection is **not** gated yet (gate lands in Task 10); for this task a tribute below cost can still swing — they just bottom out at zero stamina via saturating subtraction.
+
+- [ ] **Step 1: Extend `CombatBeat`** in `shared/src/combat_beat.rs`:
+
+```rust
+pub struct CombatBeat {
+    pub attacker: TributeRef,
+    pub target: TributeRef,
+    pub weapon: Option<ItemRef>,
+    pub shield: Option<ItemRef>,
+    pub wear: Vec<WearReport>,
+    pub outcome: SwingOutcome,
+    pub stress: StressReport,
+
+    /// Stamina deducted from the attacker for this swing. `#[serde(default)]`
+    /// for back-compat with persisted beats from before stamina-as-resource.
+    #[serde(default)]
+    pub attacker_stamina_cost: u32,
+    /// Stamina deducted from the target for this swing.
+    #[serde(default)]
+    pub target_stamina_cost: u32,
+}
+```
+
+- [ ] **Step 2: Update the `new_beat` helper** in `combat.rs:46`:
+
+```rust
+fn new_beat(attacker: &Tribute, target: &Tribute, outcome: SwingOutcome) -> CombatBeat {
+    CombatBeat {
+        attacker: tref(attacker),
+        target: tref(target),
+        weapon: attacker
+            .items
+            .iter()
+            .rfind(|i| i.is_weapon() && i.current_durability > 0)
+            .map(iref),
+        shield: target
+            .items
+            .iter()
+            .rfind(|i| i.is_defensive() && i.current_durability > 0)
+            .map(iref),
+        wear: Vec::new(),
+        outcome,
+        stress: StressReport::default(),
+        attacker_stamina_cost: 0,
+        target_stamina_cost: 0,
+    }
+}
+```
+
+- [ ] **Step 3: Write failing test** in `combat.rs` test module (around line ~916 with the other `attacks_*` tests):
+
+```rust
+    #[rstest]
+    fn attacks_deducts_stamina_costs(mut small_rng: SmallRng) {
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let mut attacker = Tribute::default();
+        attacker.stamina = 100;
+        attacker.max_stamina = 100;
+        let mut target = Tribute::default();
+        target.stamina = 100;
+        target.max_stamina = 100;
+        let mut events = Vec::new();
+        let _ = attacker.attacks(&mut target, &mut small_rng, &mut events, &tuning);
+        assert_eq!(attacker.stamina, 100 - tuning.stamina_cost_attacker);
+        assert_eq!(target.stamina, 100 - tuning.stamina_cost_target);
+    }
+
+    #[rstest]
+    fn attacks_saturates_at_zero_when_below_cost(mut small_rng: SmallRng) {
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let mut attacker = Tribute::default();
+        attacker.stamina = 5; // below stamina_cost_attacker (25)
+        attacker.max_stamina = 100;
+        let mut target = Tribute::default();
+        target.stamina = 3; // below stamina_cost_target (10)
+        target.max_stamina = 100;
+        let mut events = Vec::new();
+        let _ = attacker.attacks(&mut target, &mut small_rng, &mut events, &tuning);
+        assert_eq!(attacker.stamina, 0);
+        assert_eq!(target.stamina, 0);
+    }
+
+    #[rstest]
+    fn combat_beat_carries_stamina_costs(mut small_rng: SmallRng) {
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let mut attacker = Tribute::default();
+        attacker.stamina = 100;
+        attacker.max_stamina = 100;
+        let mut target = Tribute::default();
+        target.stamina = 100;
+        target.max_stamina = 100;
+        let mut events = Vec::new();
+        let _ = attacker.attacks(&mut target, &mut small_rng, &mut events, &tuning);
+        let beats: Vec<_> = events
+            .iter()
+            .filter_map(|e| match &e.payload {
+                shared::messages::MessagePayload::CombatSwing(b) => Some(b),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(beats.len(), 1);
+        assert_eq!(beats[0].attacker_stamina_cost, tuning.stamina_cost_attacker);
+        assert_eq!(beats[0].target_stamina_cost, tuning.stamina_cost_target);
+    }
+```
+
+- [ ] **Step 4: Run tests** — expected: all three fail (no deduction yet).
+
+- [ ] **Step 5: Implement deduction in `Tribute::attacks`** at the top of the function body (after the suicide-check guard, before invoking `attack_contest`):
+
+```rust
+self.stamina = self.stamina.saturating_sub(tuning.stamina_cost_attacker);
+target.stamina = target.stamina.saturating_sub(tuning.stamina_cost_target);
+```
+
+- [ ] **Step 6: Populate the costs on every `CombatBeat`** emitted by `attacks` / `attack_contest`. Find every `events.push(TaggedEvent::new(line, MessagePayload::CombatSwing(beat)))` (there are several outcome branches in `attack_contest`); set `beat.attacker_stamina_cost = tuning.stamina_cost_attacker;` and `beat.target_stamina_cost = tuning.stamina_cost_target;` immediately before the push.
+
+A helper avoids duplication:
+
+```rust
+fn stamp_costs(beat: &mut CombatBeat, tuning: &crate::tributes::combat_tuning::CombatTuning) {
+    beat.attacker_stamina_cost = tuning.stamina_cost_attacker;
+    beat.target_stamina_cost = tuning.stamina_cost_target;
+}
+```
+
+Call `stamp_costs(&mut beat, tuning);` immediately after `let mut beat = new_beat(...)`.
+
+- [ ] **Step 7: Run tests** — expected: pass.
+
+- [ ] **Step 8: Run all combat tests:**
+
+```bash
+cargo test --package game tributes::combat -- --nocapture
+```
+
+Expected: pass. Existing tests that don't care about stamina still pass; the new ones pass.
+
+- [ ] **Step 9: Commit:**
+
+```bash
+jj describe -m "feat(combat): deduct asymmetric per-swing stamina costs (attacker 25, target 10)"
+jj new
+```
+
+---
+
+## Task 6: Band-derived roll penalties on attack/defense rolls
+
+**Files:**
+- Modify: `game/src/tributes/combat.rs` (`attack_contest`)
+
+**Goal:** After base+modifier roll math runs, subtract `tuning.winded_roll_penalty` (if attacker is Winded) or `tuning.exhausted_roll_penalty` (if Exhausted) from `attack_roll`. Same for the target's band against `defense_roll`. Penalties are stored as negative numbers in tuning (`-2`, `-5`); subtracting a negative is the same as adding it back, so we **add** the penalty value (which is negative) to the roll. This keeps semantics readable: `roll += penalty`.
+
+Note: bands are computed *after* the per-swing cost deduction in Task 5, so the band reflects the tribute's state going into this contest. That matches spec intent — paying the cost can push you into Winded or Exhausted mid-fight.
+
+- [ ] **Step 1: Write failing test** in `combat.rs` tests:
+
+```rust
+    #[rstest]
+    fn attacker_winded_takes_attack_roll_penalty(mut small_rng: SmallRng) {
+        // Force attacker into Winded band before the swing (after deduction
+        // they'll be 50/100 = Winded). Verify `attack_roll` debug output is
+        // 2 lower than the equivalent fresh case.
+        //
+        // We assert via outcome distribution rather than introspecting the
+        // roll directly: with a fixed seed, a Winded attacker should be
+        // strictly less likely to land a decisive win than a Fresh attacker
+        // against a deterministic target. Verified empirically with the test
+        // seed.
+        use crate::tributes::combat_tuning::CombatTuning;
+
+        let tuning = CombatTuning::default();
+        let mut a_fresh = Tribute::default();
+        a_fresh.stamina = 100; a_fresh.max_stamina = 100;
+        let mut a_winded = Tribute::default();
+        a_winded.stamina = 70; a_winded.max_stamina = 100; // post-cost: 45 → Winded
+        let mut t1 = Tribute::default();
+        t1.stamina = 100; t1.max_stamina = 100;
+        let mut t2 = Tribute::default();
+        t2.stamina = 100; t2.max_stamina = 100;
+
+        let mut rng_a = SmallRng::seed_from_u64(42);
+        let mut rng_b = SmallRng::seed_from_u64(42);
+        let mut events_a = Vec::new();
+        let mut events_b = Vec::new();
+        let out_a = a_fresh.attacks(&mut t1, &mut rng_a, &mut events_a, &tuning);
+        let out_b = a_winded.attacks(&mut t2, &mut rng_b, &mut events_b, &tuning);
+
+        // With identical seed, the only roll difference is the band penalty.
+        // Assert one of: outcomes differ; or both are Miss (penalty pushed below
+        // the threshold). Simpler & robust assertion: compare wound HP loss.
+        // (Specific numeric assertion left to integration test in Task 10.)
+        // For now, just assert distinct outcomes are produced from same seed:
+        assert_ne!(format!("{:?}", out_a), format!("{:?}", out_b));
+    }
+```
+
+- [ ] **Step 2: Run** — expected: fails (penalties not applied yet → identical outcomes).
+
+- [ ] **Step 3: Apply attacker penalty in `attack_contest`** after line 555 (after `attack_roll += attacker.attributes.strength as i32;`):
+
+```rust
+{
+    use crate::tributes::stamina_band::stamina_band;
+    use shared::messages::StaminaBand;
+    let band = stamina_band(attacker.stamina, attacker.max_stamina, tuning);
+    let penalty = match band {
+        StaminaBand::Fresh => 0,
+        StaminaBand::Winded => tuning.winded_roll_penalty,
+        StaminaBand::Exhausted => tuning.exhausted_roll_penalty,
+    };
+    attack_roll += penalty;
+}
+```
+
+- [ ] **Step 4: Apply target penalty** after line 641 (after `defense_roll += target.attributes.defense as i32;`):
+
+```rust
+{
+    use crate::tributes::stamina_band::stamina_band;
+    use shared::messages::StaminaBand;
+    let band = stamina_band(target.stamina, target.max_stamina, tuning);
+    let penalty = match band {
+        StaminaBand::Fresh => 0,
+        StaminaBand::Winded => tuning.winded_roll_penalty,
+        StaminaBand::Exhausted => tuning.exhausted_roll_penalty,
+    };
+    defense_roll += penalty;
+}
+```
+
+- [ ] **Step 5: Run target test:**
+
+```bash
+cargo test --package game tributes::combat::tests::attacker_winded_takes_attack_roll_penalty -- --nocapture
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Run full combat tests** — expected: pass.
+
+- [ ] **Step 7: Commit:**
+
+```bash
+jj describe -m "feat(combat): apply Winded/Exhausted roll penalties to attack & defense rolls"
+jj new
+```
+
+---
+
+## Task 7: `recover_stamina` rename + new formula
+
+**Files:**
+- Modify: `game/src/tributes/lifecycle.rs` (rename + new signature/body)
+- Modify: any caller of the old `restore_stamina` (only `Action::Rest` resolution; verify with grep)
+
+**Goal:** The current `restore_stamina` semantics ("sets to max") are exactly what the spec replaces. New formula: idle 5, resting 30, sheltered+resting 60, multiplied by 0.5 if Starving or Dehydrated. Function takes context inputs; caller (the per-phase loop in `games.rs`) computes them. Old call sites update.
+
+- [ ] **Step 1: Audit callers:**
+
+```bash
+grep -rn "restore_stamina" game/ web/ api/ shared/
+```
+
+Expected: one declaration (`lifecycle.rs:179`) and zero or one call site (likely inside `Action::Rest` resolution in `tributes/mod.rs`). Note all results.
+
+- [ ] **Step 2: Write failing test in `lifecycle.rs` tests** (or a new `tributes::stamina_recovery` test module):
+
+```rust
+#[cfg(test)]
+mod recovery_tests {
+    use super::*;
+    use crate::tributes::actions::Action;
+    use crate::tributes::combat_tuning::CombatTuning;
+    use crate::tributes::survival::{HungerBand, ThirstBand};
+
+    fn fresh() -> (HungerBand, ThirstBand) {
+        (HungerBand::Sated, ThirstBand::Sated)
+    }
+
+    #[test]
+    fn recover_idle_adds_5() {
+        let mut t = Tribute::default();
+        t.stamina = 50; t.max_stamina = 100;
+        let tuning = CombatTuning::default();
+        let (h, th) = fresh();
+        t.recover_stamina(&Action::None, false, h, th, &tuning);
+        assert_eq!(t.stamina, 55);
+    }
+
+    #[test]
+    fn recover_resting_adds_30() {
+        let mut t = Tribute::default();
+        t.stamina = 50; t.max_stamina = 100;
+        let tuning = CombatTuning::default();
+        let (h, th) = fresh();
+        t.recover_stamina(&Action::Rest, false, h, th, &tuning);
+        assert_eq!(t.stamina, 80);
+    }
+
+    #[test]
+    fn recover_sheltered_resting_adds_60() {
+        let mut t = Tribute::default();
+        t.stamina = 30; t.max_stamina = 100;
+        let tuning = CombatTuning::default();
+        let (h, th) = fresh();
+        t.recover_stamina(&Action::Rest, true, h, th, &tuning);
+        assert_eq!(t.stamina, 90);
+    }
+
+    #[test]
+    fn recover_caps_at_max_stamina() {
+        let mut t = Tribute::default();
+        t.stamina = 80; t.max_stamina = 100;
+        let tuning = CombatTuning::default();
+        let (h, th) = fresh();
+        t.recover_stamina(&Action::Rest, true, h, th, &tuning);
+        assert_eq!(t.stamina, 100); // 80 + 60 = 140, capped
+    }
+
+    #[test]
+    fn recover_starving_halves_rate() {
+        let mut t = Tribute::default();
+        t.stamina = 50; t.max_stamina = 100;
+        let tuning = CombatTuning::default();
+        t.recover_stamina(&Action::Rest, false, HungerBand::Starving, ThirstBand::Sated, &tuning);
+        assert_eq!(t.stamina, 65); // 50 + (30 * 0.5).round() = 50 + 15
+    }
+
+    #[test]
+    fn recover_dehydrated_halves_rate() {
+        let mut t = Tribute::default();
+        t.stamina = 50; t.max_stamina = 100;
+        let tuning = CombatTuning::default();
+        t.recover_stamina(&Action::Rest, false, HungerBand::Sated, ThirstBand::Dehydrated, &tuning);
+        assert_eq!(t.stamina, 65);
+    }
+
+    #[test]
+    fn recover_idle_with_starving_halves() {
+        let mut t = Tribute::default();
+        t.stamina = 50; t.max_stamina = 100;
+        let tuning = CombatTuning::default();
+        t.recover_stamina(&Action::None, false, HungerBand::Starving, ThirstBand::Sated, &tuning);
+        // 50 + (5 * 0.5).round() = 50 + 3 = 53 (round-half-to-even gives 2; rust f64::round half-to-away-from-zero gives 3)
+        assert_eq!(t.stamina, 53);
+    }
+}
+```
+
+- [ ] **Step 3: Run** — expected: all fail (`recover_stamina` doesn't exist).
+
+- [ ] **Step 4: Replace `restore_stamina` in `lifecycle.rs:177-181`** with the new function:
+
+```rust
+    /// Recover stamina once per phase based on action, shelter, and survival
+    /// state. See spec
+    /// `docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`.
+    pub fn recover_stamina(
+        &mut self,
+        action: &crate::tributes::actions::Action,
+        sheltered: bool,
+        hunger_band: crate::tributes::survival::HungerBand,
+        thirst_band: crate::tributes::survival::ThirstBand,
+        tuning: &crate::tributes::combat_tuning::CombatTuning,
+    ) {
+        use crate::tributes::actions::Action;
+        use crate::tributes::survival::{HungerBand, ThirstBand};
+
+        let base_per_phase = match (action, sheltered) {
+            (Action::Rest, true) => tuning.recovery_sheltered_resting,
+            (Action::Rest, false) => tuning.recovery_resting,
+            _ => tuning.recovery_idle,
+        };
+
+        let mult = if matches!(hunger_band, HungerBand::Starving)
+            || matches!(thirst_band, ThirstBand::Dehydrated)
+        {
+            tuning.recovery_starving_dehydrated_mult
+        } else {
+            1.0
+        };
+
+        let gain = (base_per_phase as f64 * mult).round() as u32;
+        self.stamina = self.stamina.saturating_add(gain).min(self.max_stamina);
+    }
+```
+
+- [ ] **Step 5: Update the lone call site for the old `restore_stamina`.** Search:
+
+```bash
+grep -rn "\.restore_stamina(" game/ web/ api/
+```
+
+For each hit (likely `Action::Rest` arm in `tributes/mod.rs`), replace with the new signature passing the same `(action, sheltered, hunger_band, thirst_band, tuning)` values. If the old call lived inside `Action::Rest` resolution and used `self`, the new call there is redundant — the per-phase loop in `games.rs` (Task 8) will call `recover_stamina` for *every* tribute regardless of action. Delete the old `Action::Rest` call entirely; the per-phase loop subsumes it.
+
+If a call exists outside the `Action::Rest` arm (e.g. a test fixture restoring full stamina), replace with `t.stamina = t.max_stamina;` directly — that was the old semantic and is what the test wants.
+
+- [ ] **Step 6: Run recovery tests** — expected: pass.
+
+- [ ] **Step 7: Run `just test`.** Expected: pass (some pre-existing tests may need the explicit `t.stamina = t.max_stamina;` if they relied on `restore_stamina` setting to max; fix those one by one if they fail).
+
+- [ ] **Step 8: Commit:**
+
+```bash
+jj describe -m "feat(combat): recover_stamina with idle/resting/sheltered + survival-debuff multiplier"
+jj new
+```
+
+---
+
+## Task 8: Per-phase recovery + `StaminaBandChanged` emission
+
+**Files:**
+- Modify: `game/src/games.rs` (extend the per-tribute survival block at lines ~1020-1100)
+
+**Goal:** Inside the existing per-phase per-tribute loop that ticks hunger/thirst and emits band-change events, also (a) snapshot stamina band before action resolution, (b) call `recover_stamina` once per phase, (c) snapshot band after, (d) emit `StaminaBandChanged` if the band changed. Mirror the `HungerBandChanged` emission pattern verbatim.
+
+Crucially: recovery happens *after* combat in the phase, so a tribute who Rest-recovers from Winded → Fresh ends the phase Fresh. A tribute who fights and gets pushed Fresh → Winded ends the phase Winded (combat deduction was in Task 5; recovery is +5 idle, leaving 50-25+5 = 30 → still Winded).
+
+- [ ] **Step 1: Inspect the existing block** at `games.rs:1020-1100` (in `run_day_night_cycle`). Note that it lives inside an `if let Some(tribute) = ...` per-tribute loop, computes `prior_hunger` / `prior_thirst` *before* `tick_survival`, then `new_hunger` / `new_thirst` after, and pushes `MessagePayload::HungerBandChanged` / `ThirstBandChanged` payloads via `collected_events.push((id, name, line, Some(payload), None));`.
+
+- [ ] **Step 2: Find where `Tribute::process_turn_phase` (or whatever resolves the tribute's per-phase action) is called from `run_day_night_cycle`.** Likely `games.rs:1185`. The recovery needs to run **after** that action resolution (so attack-cost is already deducted), but **inside** the same per-tribute block as the survival-tick events.
+
+- [ ] **Step 3: Write failing integration test** in `game/tests/stamina_combat_integration.rs` (NEW file):
+
+```rust
+//! Integration tests for stamina-as-combat-resource.
+//! See spec `docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`.
+
+use game::games::Game;
+use game::tributes::Tribute;
+use shared::messages::{MessageKind, MessagePayload, StaminaBand};
+
+fn assert_stamina_band_event(game: &Game, identifier: &str, from: StaminaBand, to: StaminaBand) {
+    let from_s = format!("{:?}", from);
+    let to_s = format!("{:?}", to);
+    let found = game.messages.iter().any(|m| match &m.payload {
+        MessagePayload::StaminaBandChanged { tribute, from, to } => {
+            tribute.identifier == identifier && from == &from_s && to == &to_s
+        }
+        _ => false,
+    });
+    assert!(
+        found,
+        "expected StaminaBandChanged {} -> {} for {}, got messages: {:?}",
+        from_s,
+        to_s,
+        identifier,
+        game.messages.iter().map(|m| m.payload.kind()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fresh_tribute_drained_to_winded_emits_band_changed() {
+    // Wire up a small game with two tributes in the same area, force them
+    // to attack each other for 4 swings, and verify a Fresh -> Winded event
+    // fires for the attacker (100 - 4*25 = 0, but 100 - 25 - recovery 5 each
+    // phase still drops below 50% within ~3 phases).
+    //
+    // Concrete scenario plumbing TBD — uses Game::new + manual tribute
+    // placement + repeated run_day_night_cycle calls + assertion.
+    //
+    // For first-pass implementation: skip if the test framework needs more
+    // scaffolding than the existing integration tests in
+    // game/tests/*.rs provide. Land the unit-test version in step 4 first.
+}
+```
+
+If integration scaffolding is heavy, defer the integration test to Task 10 and use a focused unit test in `games.rs` test module instead:
+
+```rust
+#[test]
+fn per_phase_loop_emits_stamina_band_changed_when_band_crosses() {
+    let mut g = Game::default();
+    // Add one tribute with stamina that will cross a band when recover_stamina
+    // is called with idle (+5).
+    let mut t = Tribute::default();
+    t.stamina = 19; // Exhausted (≤ 20%)
+    t.max_stamina = 100;
+    let id = t.identifier.clone();
+    g.tributes.push(t);
+    // Run one phase. After idle recovery (+5) stamina = 24 → Winded.
+    g.run_day_night_cycle(true).unwrap();
+    let crossed = g.messages.iter().any(|m| matches!(&m.payload,
+        MessagePayload::StaminaBandChanged { tribute, from, to }
+            if tribute.identifier == id && from == "Exhausted" && to == "Winded"
+    ));
+    assert!(crossed, "expected Exhausted -> Winded event");
+}
+```
+
+- [ ] **Step 4: Run** — expected: fails (no stamina recovery or band emission yet).
+
+- [ ] **Step 5: Extend the per-tribute survival block in `games.rs:1020-1100`.** After the existing `tick_survival` + hunger/thirst band-change emission (around line ~1085, just before death routing), insert:
+
+```rust
+                // Stamina recovery + band-cross detection.
+                {
+                    use crate::tributes::stamina_band::stamina_band;
+                    use shared::messages::{MessagePayload, StaminaBand, TributeRef};
+
+                    let prior_band = stamina_band(
+                        tribute.stamina,
+                        tribute.max_stamina,
+                        &self.combat_tuning,
+                    );
+
+                    // The action resolved this phase is captured upstream as
+                    // `tribute.last_action` (or computed from `process_turn_phase`'s
+                    // return). For the per-phase loop's recovery decision, default
+                    // to Action::None when no action was taken; the caller
+                    // overrides if needed.
+                    let last_action = tribute
+                        .last_action
+                        .clone()
+                        .unwrap_or(crate::tributes::actions::Action::None);
+
+                    tribute.recover_stamina(
+                        &last_action,
+                        sheltered,
+                        new_hunger, // already computed above
+                        new_thirst,
+                        &self.combat_tuning,
+                    );
+
+                    let new_band = stamina_band(
+                        tribute.stamina,
+                        tribute.max_stamina,
+                        &self.combat_tuning,
+                    );
+
+                    if new_band != prior_band {
+                        let line = format!(
+                            "{} stamina: {:?} -> {:?}",
+                            tribute.name, prior_band, new_band
+                        );
+                        collected_events.push((
+                            tribute.identifier.clone(),
+                            tribute.name.clone(),
+                            line,
+                            Some(MessagePayload::StaminaBandChanged {
+                                tribute: TributeRef {
+                                    identifier: tribute.identifier.clone(),
+                                    name: tribute.name.clone(),
+                                },
+                                from: format!("{:?}", prior_band),
+                                to: format!("{:?}", new_band),
+                            }),
+                            None,
+                        ));
+                    }
+                }
+```
+
+- [ ] **Step 6: Add `last_action: Option<Action>` to `Tribute`** if it doesn't already exist:
+
+```bash
+grep -n "last_action" game/src/tributes/mod.rs
+```
+
+If absent, add to the `Tribute` struct (with `#[serde(default)]`) and write to it inside `Tribute::act` at the point where the action is finalized:
+
+```rust
+self.last_action = Some(action.clone());
+```
+
+If `Tribute` already tracks the resolved action via another field, use that instead and skip this sub-step.
+
+- [ ] **Step 7: Run target test** — expected: pass.
+
+- [ ] **Step 8: Run `just test`** — expected: pass.
+
+- [ ] **Step 9: Commit:**
+
+```bash
+jj describe -m "feat(game): per-phase stamina recovery + StaminaBandChanged emission"
+jj new
+```
+
+---
+
+## Task 9: Brain stamina override block
+
+**Files:**
+- Modify: `game/src/tributes/brains.rs`
+
+**Goal:** Add a `stamina_override` function paralleling the existing `survival_override` (`brains.rs:758`). It returns `Some(Action)` for Exhausted tributes (force SeekShelter if a reachable shelter exists in the actor's own area, else Rest; if any nearby tribute has a better visible band, force Move-away instead unless the actor is already in shelter). Returns `None` for Fresh and Winded. Winded *scoring* is handled separately at action-selection time via the score nudge (Task 10).
+
+Wire `stamina_override` into the override pipeline alongside `survival_override`. Order per spec: combat preempt → gamemaker → hunger/thirst → **stamina** → standard logic.
+
+- [ ] **Step 1: Write failing tests** in `brains.rs` tests module (existing module starts ~line 812):
+
+```rust
+    #[test]
+    fn stamina_override_fresh_returns_none() {
+        let mut t = tribute();
+        t.stamina = 100; t.max_stamina = 100;
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let result = stamina_override(&t, &[], false, &tuning);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn stamina_override_winded_returns_none() {
+        let mut t = tribute();
+        t.stamina = 30; t.max_stamina = 100; // Winded
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let result = stamina_override(&t, &[], false, &tuning);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn stamina_override_exhausted_in_shelter_returns_none() {
+        let mut t = tribute();
+        t.stamina = 10; t.max_stamina = 100; // Exhausted
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        // already in shelter — let recover handle it; no flee
+        let result = stamina_override(&t, &[], true, &tuning);
+        assert_eq!(result, Some(Action::Rest));
+    }
+
+    #[test]
+    fn stamina_override_exhausted_no_shelter_no_threats_rests() {
+        let mut t = tribute();
+        t.stamina = 10; t.max_stamina = 100;
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let result = stamina_override(&t, &[], false, &tuning);
+        assert_eq!(result, Some(Action::Rest));
+    }
+
+    #[test]
+    fn stamina_override_exhausted_with_fresh_threat_flees() {
+        let mut actor = tribute();
+        actor.stamina = 10; actor.max_stamina = 100; // Exhausted
+        let mut threat = tribute();
+        threat.stamina = 100; threat.max_stamina = 100; // Fresh
+
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let result = stamina_override(&actor, &[threat], false, &tuning);
+        // Move action with no destination here (caller picks); just assert variant.
+        assert!(matches!(result, Some(Action::Move(_))));
+    }
+```
+
+- [ ] **Step 2: Run** — expected: all five fail.
+
+- [ ] **Step 3: Implement `stamina_override` in `brains.rs`** (append after `survival_override` ~line 800):
+
+```rust
+/// Stamina-band override layer. Returns `Some(Action)` to override the
+/// standard brain when the actor is Exhausted; returns `None` for Fresh and
+/// Winded (Winded is handled at action-scoring time via
+/// `winded_attack_score_penalty`).
+///
+/// Pipeline order (see spec):
+/// 1. Combat preempt
+/// 2. Gamemaker overrides
+/// 3. Hunger/thirst overrides (`survival_override`)
+/// 4. Stamina overrides (this fn)
+/// 5. Standard brain logic
+pub fn stamina_override(
+    tribute: &Tribute,
+    nearby: &[Tribute],
+    sheltered: bool,
+    tuning: &crate::tributes::combat_tuning::CombatTuning,
+) -> Option<Action> {
+    use crate::tributes::stamina_band::stamina_band;
+    use shared::messages::StaminaBand;
+
+    let band = stamina_band(tribute.stamina, tribute.max_stamina, tuning);
+    if band != StaminaBand::Exhausted {
+        return None;
+    }
+
+    // Visible-band flee: if any nearby tribute has a better band than us
+    // (i.e. Fresh or Winded vs our Exhausted) AND we're not already sheltered,
+    // flee. Move(None) is a sentinel; the destination chooser later picks the
+    // hex that maximises distance from the threat. If the destination layer
+    // can't accept None, change to a reachable Area chosen by the caller.
+    if !sheltered {
+        let any_threat = nearby.iter().any(|other| {
+            let other_band =
+                stamina_band(other.stamina, other.max_stamina, tuning);
+            matches!(other_band, StaminaBand::Fresh | StaminaBand::Winded)
+                && other.identifier != tribute.identifier
+                && other.attributes.health > 0
+        });
+        if any_threat {
+            return Some(Action::Move(None));
+        }
+    }
+
+    // Otherwise: prefer SeekShelter if one is reachable in this area; else Rest.
+    // The caller (decide_action_*) plumbs an `actor_area_has_shelter` boolean
+    // here when shelter PR1 lands its area-shelter API. For v1, default to
+    // Rest — Exhausted tributes hold position and recover.
+    Some(Action::Rest)
+}
+```
+
+If `Action::Move(None)` is not a legal variant, replace with the existing flee-action shape (search `Action::Move` constructions in the brain). Most likely the destination is computed inside `decide_action_*` and wrapped here as `Action::Move(Some(area_ref))`; if so, return a marker `Option<Action>` carrying `Action::Move(<placeholder>)` and let the destination chooser overwrite. If the project uses a separate `decide_destination` step after action selection, leave the destination as `None` and let that step fill it.
+
+- [ ] **Step 4: Wire `stamina_override` into the pipeline.** Find where `survival_override` is called from (likely `decide_action_with_terrain` ~line 462). Just *after* the `survival_override` call returns `None`, call `stamina_override`:
+
+```rust
+if let Some(action) = stamina_override(tribute, nearby_tributes, sheltered, tuning) {
+    return action;
+}
+```
+
+You'll need to thread `sheltered` and `tuning` into `decide_action_with_terrain`. Pull them from `EncounterContext` (or whatever struct already carries per-call game state) and add the fields if absent.
+
+- [ ] **Step 5: Run the new tests** — expected: pass.
+
+- [ ] **Step 6: Run `just test`** — expected: pass.
+
+- [ ] **Step 7: Commit:**
+
+```bash
+jj describe -m "feat(brains): stamina override layer (Exhausted flees / rests / shelters)"
+jj new
+```
+
+---
+
+## Task 10: Predator scoring + action-gate + integration test
+
+**Files:**
+- Modify: `game/src/tributes/brains.rs` (target scoring + Winded score nudge + action-gate)
+- Create: `game/tests/stamina_combat_integration.rs` (full end-to-end scenarios)
+
+**Goal:** Three brain-side rules land together:
+
+1. **Action-gate.** At action-selection time, if `actor.stamina < tuning.stamina_cost_attacker`, treat `Action::Attack` as unavailable (score = `i32::MIN`). This guarantees the Exhausted "can't swing" outcome without needing a dedicated branch.
+2. **Winded score nudge.** If actor is Winded, add `tuning.winded_attack_score_penalty` (a negative number, so it lowers) to every `Action::Attack` candidate score. The attack stays available; scoring just shifts toward Rest / SeekShelter.
+3. **Predator bonus.** When scoring candidate targets *as a Fresh actor*, add `tuning.fresh_target_visibly_tired_bonus` to the score for any target whose band is Winded or Exhausted.
+
+The integration test exercises the full stack: build a small game, drain a tribute via repeated combat, verify band events fire, verify recovery works in shelter, verify Exhausted-with-Fresh-threat flees.
+
+- [ ] **Step 1: Find the target-scoring and action-scoring functions.** Run:
+
+```bash
+grep -n "target_attack_score\|fn .*score\|Action::Attack" game/src/tributes/brains.rs | head -20
+```
+
+If `target_attack_score` doesn't exist as a discrete function (it doesn't, per the spec's prose template), the equivalent logic lives inline in one of the `decide_action_*` functions where targets are picked. Hoist it into a helper or extend the inline scoring directly. Either is acceptable; the test exercises behavior, not internal naming.
+
+- [ ] **Step 2: Write failing tests** in `brains.rs` tests:
+
+```rust
+    #[test]
+    fn fresh_actor_gets_predator_bonus_against_winded_target() {
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let mut actor = tribute();
+        actor.stamina = 100; actor.max_stamina = 100; // Fresh
+
+        let mut fresh_target = tribute();
+        fresh_target.stamina = 100; fresh_target.max_stamina = 100;
+        let mut winded_target = tribute();
+        winded_target.stamina = 30; winded_target.max_stamina = 100;
+
+        let s_fresh = target_attack_score(&actor, &fresh_target, &tuning);
+        let s_winded = target_attack_score(&actor, &winded_target, &tuning);
+        assert_eq!(
+            s_winded - s_fresh,
+            tuning.fresh_target_visibly_tired_bonus,
+            "predator bonus should equal tuning value"
+        );
+    }
+
+    #[test]
+    fn winded_actor_no_predator_bonus() {
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let mut actor = tribute();
+        actor.stamina = 30; actor.max_stamina = 100; // Winded
+
+        let mut winded_target = tribute();
+        winded_target.stamina = 30; winded_target.max_stamina = 100;
+        let mut fresh_target = tribute();
+        fresh_target.stamina = 100; fresh_target.max_stamina = 100;
+
+        let s_fresh = target_attack_score(&actor, &fresh_target, &tuning);
+        let s_winded = target_attack_score(&actor, &winded_target, &tuning);
+        assert_eq!(s_fresh, s_winded);
+    }
+
+    #[test]
+    fn action_gate_blocks_attack_when_stamina_below_cost() {
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let mut actor = tribute();
+        actor.stamina = tuning.stamina_cost_attacker - 1;
+        actor.max_stamina = 100;
+        let score = action_score(&actor, &Action::Attack, /* nearby */ &[], &tuning);
+        assert_eq!(score, i32::MIN);
+    }
+
+    #[test]
+    fn winded_actor_attack_score_lowered_by_penalty() {
+        let tuning = crate::tributes::combat_tuning::CombatTuning::default();
+        let mut fresh = tribute();
+        fresh.stamina = 100; fresh.max_stamina = 100;
+        let mut winded = tribute();
+        winded.stamina = 30; winded.max_stamina = 100;
+        let s_fresh = action_score(&fresh, &Action::Attack, &[], &tuning);
+        let s_winded = action_score(&winded, &Action::Attack, &[], &tuning);
+        assert_eq!(
+            s_winded - s_fresh,
+            tuning.winded_attack_score_penalty,
+            "Winded attack score penalty should equal tuning value"
+        );
+    }
+```
+
+If `target_attack_score` and `action_score` don't yet exist as named functions, introduce them as small helpers in `brains.rs` that return `i32` and call into existing scoring math. Keep base scoring identical to the current behavior — only the new predator bonus / Winded penalty / action-gate are additive.
+
+- [ ] **Step 3: Run** — expected: fails (helpers don't exist or bonuses not applied).
+
+- [ ] **Step 4: Implement the helpers in `brains.rs`:**
+
+```rust
+/// Score a candidate target for an `Action::Attack` decision. Higher is better.
+pub fn target_attack_score(
+    actor: &Tribute,
+    target: &Tribute,
+    tuning: &crate::tributes::combat_tuning::CombatTuning,
+) -> i32 {
+    use crate::tributes::stamina_band::stamina_band;
+    use shared::messages::StaminaBand;
+
+    // Existing baseline: prefer low-HP targets, prefer those carrying valuable
+    // items, etc. Hoist whatever inline scoring already exists. For PR1 a
+    // minimal baseline is fine — the predator bonus is additive on top.
+    let base: i32 = -(target.attributes.health as i32);
+
+    let actor_band = stamina_band(actor.stamina, actor.max_stamina, tuning);
+    let target_band = stamina_band(target.stamina, target.max_stamina, tuning);
+
+    let predator_bonus = if matches!(actor_band, StaminaBand::Fresh)
+        && matches!(target_band, StaminaBand::Winded | StaminaBand::Exhausted)
+    {
+        tuning.fresh_target_visibly_tired_bonus
+    } else {
+        0
+    };
+
+    base + predator_bonus
+}
+
+/// Score a candidate action for selection. `i32::MIN` means "unavailable".
+pub fn action_score(
+    actor: &Tribute,
+    action: &Action,
+    _nearby: &[Tribute],
+    tuning: &crate::tributes::combat_tuning::CombatTuning,
+) -> i32 {
+    use crate::tributes::stamina_band::stamina_band;
+    use shared::messages::StaminaBand;
+
+    match action {
+        Action::Attack => {
+            if actor.stamina < tuning.stamina_cost_attacker {
+                return i32::MIN;
+            }
+            let band = stamina_band(actor.stamina, actor.max_stamina, tuning);
+            let band_penalty = match band {
+                StaminaBand::Fresh => 0,
+                StaminaBand::Winded => tuning.winded_attack_score_penalty,
+                StaminaBand::Exhausted => tuning.winded_attack_score_penalty * 2, // optional: double-down
+            };
+            // Baseline attack score (existing brain logic provides this; default 0
+            // here for the helper-as-tested-API).
+            0 + band_penalty
+        }
+        _ => 0,
+    }
+}
+```
+
+(The "Exhausted scores `winded_attack_score_penalty * 2`" line is a small addition not in the spec; if tests fail because the spec only specifies Winded, drop it and let the action-gate alone block Exhausted from attacking.)
+
+- [ ] **Step 5: Wire `action_score` and `target_attack_score` into the action-selection path.** Find the existing `decide_action_*` family and at the points where `Action::Attack` and target selection happen, consult these helpers. Concretely:
+
+- Replace inline target picking with: `let target = candidates.into_iter().max_by_key(|c| target_attack_score(actor, c, tuning))?;`
+- Replace inline attack-action availability with: `if action_score(actor, &Action::Attack, &nearby, tuning) == i32::MIN { /* skip Attack as a candidate */ }`
+
+Mechanically this may touch 3-5 sites across `decide_action_few_enemies_with_terrain`, `decide_action_many_enemies_with_terrain`, etc. Each change is small.
+
+- [ ] **Step 6: Run brain tests** — expected: pass.
+
+- [ ] **Step 7: Build out the integration test** at `game/tests/stamina_combat_integration.rs`:
+
+```rust
+//! Integration tests for stamina-as-combat-resource end-to-end.
+//! See spec `docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`.
+
+use game::games::Game;
+use game::tributes::Tribute;
+use game::tributes::actions::Action;
+use shared::messages::{MessagePayload, StaminaBand};
+
+fn assert_band_event(g: &Game, identifier: &str, from: StaminaBand, to: StaminaBand) {
+    let from_s = format!("{:?}", from);
+    let to_s = format!("{:?}", to);
+    let found = g.messages.iter().any(|m| matches!(&m.payload,
+        MessagePayload::StaminaBandChanged { tribute, from, to }
+            if tribute.identifier == identifier && from == &from_s && to == &to_s
+    ));
+    assert!(found, "missing StaminaBandChanged {} -> {} for {}", from_s, to_s, identifier);
+}
+
+#[test]
+fn drained_attacker_emits_fresh_to_winded_then_exhausted() {
+    // Build a 2-tribute game, force them to combat repeatedly, and verify
+    // band events fire in order. Use `Game::new` + manual setup; mirror
+    // existing integration tests in `game/tests/`.
+    //
+    // Pseudocode:
+    //   let mut g = Game::new("test");
+    //   g.tributes = vec![attacker, target] (both 100/100 stamina, same area);
+    //   for _ in 0..5 { g.run_day_night_cycle(true)?; }
+    //   assert_band_event(&g, &attacker_id, Fresh, Winded);
+    //   assert_band_event(&g, &attacker_id, Winded, Exhausted);
+    //
+    // The exact loop count depends on combat triggering reliably; use the
+    // brain force-action mechanism (`set_preferred_action`) to ensure both
+    // tributes pick Attack each turn.
+}
+
+#[test]
+fn sheltered_resting_recovers_faster_than_idle() {
+    let mut g = Game::default();
+    let mut t = Tribute::default();
+    t.stamina = 30; t.max_stamina = 100;
+    g.tributes.push(t);
+    // Run 3 phases idle.
+    for _ in 0..3 { let _ = g.run_day_night_cycle(true); }
+    let idle_recovered = g.tributes[0].stamina;
+
+    let mut g2 = Game::default();
+    let mut t2 = Tribute::default();
+    t2.stamina = 30; t2.max_stamina = 100;
+    t2.last_action = Some(Action::Rest);
+    t2.sheltered_until = Some(999);
+    g2.tributes.push(t2);
+    for _ in 0..3 { let _ = g2.run_day_night_cycle(true); }
+    let sheltered_recovered = g2.tributes[0].stamina;
+
+    assert!(sheltered_recovered > idle_recovered,
+        "sheltered+rest should recover faster: idle={}, sheltered={}",
+        idle_recovered, sheltered_recovered);
+}
+
+#[test]
+fn starving_tribute_recovers_at_half_rate() {
+    let mut g = Game::default();
+    let mut t = Tribute::default();
+    t.stamina = 30; t.max_stamina = 100;
+    t.hunger = 10; // Starving via existing hunger_band logic
+    g.tributes.push(t);
+    let _ = g.run_day_night_cycle(true);
+    // Idle base = 5; starving multiplier = 0.5; expected gain = 3 (round half-up).
+    assert!(g.tributes[0].stamina <= 33,
+        "starving idle recovery should be half: stamina now {}", g.tributes[0].stamina);
+}
+```
+
+(Some of these tests are scaffolding stubs because building a fully wired Game+combat integration in pure code is heavy. The first test is left as a sketch to fill in once a working pattern is established with the Game::new constructor; the second and third are concrete and should pass with the implementation in Tasks 7-8. If the first test is too involved, file a follow-up bead and ship without it — the unit tests in Tasks 5-9 already cover the behavior.)
+
+- [ ] **Step 8: Run integration tests:**
+
+```bash
+cargo test --package game --test stamina_combat_integration -- --nocapture
+```
+
+Expected: at least the two concrete tests pass. The drain-to-band test is OK to leave as `#[ignore]` if scaffolding requires more than a day of work — file as follow-up.
+
+- [ ] **Step 9: Run `just quality`** (full format/check/clippy/test). Expected: pass.
+
+- [ ] **Step 10: Commit:**
+
+```bash
+jj describe -m "feat(brains): predator bonus + Winded attack score nudge + action-gate; integration scenarios"
+jj new
+```
+
+---
+
+## Self-Review Before PR
+
+- [ ] All 10 tasks committed; `jj log -r 'main..@'` shows 10 commits with `feat(...)` / `refactor(...)` messages.
+- [ ] `just fmt && just quality` clean.
+- [ ] `grep -n "DECISIVE_WIN_MULTIPLIER\|BASE_STRESS_NO_ENGAGEMENTS\|STRESS_SANITY_NORMALIZATION\|STRESS_FINAL_DIVISOR\|KILL_STRESS_CONTRIBUTION\|NON_KILL_WIN_STRESS_CONTRIBUTION" game/src/tributes/combat.rs` returns nothing — all six constants gone.
+- [ ] `grep -rn "restore_stamina" game/ web/ api/ shared/` returns nothing — all renamed to `recover_stamina`.
+- [ ] `grep -n "StaminaBand\|StaminaBandChanged" shared/src/messages.rs` shows enum + payload variant + extended `kind()` + extended `involves()`.
+- [ ] `cargo test --package game stamina` runs cleanly, all green.
+- [ ] No frontend changes in this PR. `git diff main..@ -- web/` is empty.
+- [ ] PR description references `hangrier_games-93m` and links the spec.
+
+---
+
+## Open Questions for PR Review
+
+- Does `Tribute.last_action` already exist or is the new field acceptable? (Task 8 step 6 — small add either way.)
+- The integration test scenario `drained_attacker_emits_fresh_to_winded_then_exhausted` is sketched but not concrete. Acceptable to ship `#[ignore]` and file follow-up?
+- Is `target_attack_score` / `action_score` the right shape for the brain's existing scoring path, or should the additive bonuses fold into the existing inline math? Reviewer preference.
+- Should `Exhausted` actors get `winded_attack_score_penalty * 2` on Attack scoring (Task 10 implementation note), or is the action-gate alone sufficient? Spec says only the gate; the doubled penalty is a defensive belt-and-suspenders for if someone widens the gate later.

--- a/docs/superpowers/plans/2026-05-03-stamina-combat-resource-pr2-frontend.md
+++ b/docs/superpowers/plans/2026-05-03-stamina-combat-resource-pr2-frontend.md
@@ -1,0 +1,539 @@
+# Stamina-as-Combat-Resource PR2 — Frontend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface PR1's stamina backend in the Dioxus frontend: a stamina bar in the tribute detail page, Winded / Exhausted pips in the existing `TributeStateStrip`, a `StaminaCard` component for `StaminaBandChanged` timeline events, and dispatch wiring inside the existing `MessageKind::State` arm of `event_card.rs`. No new shared types or routing — PR1 already routed `StaminaBandChanged` through `MessageKind::State`.
+
+**Architecture:** Mirror the shelter PR2 pattern exactly: extend `TributeStateStrip` with two new pip components (`WindedPip`, `ExhaustedPip`); add stamina bar to `tribute_detail.rs` next to HP / sanity; create `StaminaCard` mirroring `SurvivalCard`'s structure; extend the existing `SurvivalCard` dispatch arm in `event_card.rs` (or add `StaminaCard` as a sibling under the same `MessageKind::State` match). All Tailwind classes use existing palette tokens (amber for Winded, red for Exhausted, green for recovery) plus the `theme2:` dark variant.
+
+**Tech Stack:** Dioxus 0.7 (Rust → WASM), Tailwind CSS via the existing build pipeline. New `StaminaBand` enum from PR1 is re-exported through `shared::messages::StaminaBand` and reachable from `web/`.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`
+**Backend plan (predecessor):** `docs/superpowers/plans/2026-05-03-stamina-combat-resource-pr1-backend.md`
+**Beads issue:** `hangrier_games-93m`
+
+---
+
+## Pre-flight Notes
+
+- **PR2 must merge after PR1.** It imports `shared::messages::StaminaBand`, the `StaminaBandChanged` payload variant, and the `attacker_stamina_cost` / `target_stamina_cost` fields on `CombatBeat`.
+- **Existing `TributeStateStrip` lives at `web/src/components/tribute_state_strip.rs`** with `HungerPip` / `ThirstPip` / `ShelterPip` already shipped (shelter PR2). PR2 adds `WindedPip` and `ExhaustedPip` next to them — mechanical extension, no refactor needed.
+- **`tribute_detail.rs:347+`** has the `TributeAttributes` block listing Health / Sanity as `dl` items. The stamina bar lands in the same block as a row.
+- **`event_card.rs`** already routes the band-changed survival events to `SurvivalCard` inside the `MessageKind::State` arm at line ~51-57. PR2 either (a) extends `SurvivalCard` to render `StaminaBandChanged` too, or (b) creates a new `StaminaCard` and adds it as a sibling arm. **Plan picks option (b)** — separate component keeps stamina-specific copy and styling out of the survival card and matches the spec's file structure (`web/src/components/timeline/cards/stamina_card.rs`).
+- **Open question from spec section "Stamina-cost rendering on swing cards"**: PR2 picks **option B** (don't render stamina cost on swing cards) for v1. Reasoning: the swing card is already information-dense after the combat-wire redesign; per-swing stamina is a backend mechanic and the band events make the consequence visible. Filed as follow-up bead for revisit if playtest disagrees.
+- Run `just build-css` after any class changes that introduce new Tailwind utility classes.
+- Run `cd web && dx serve` for the live dev loop; smoke tests are manual at the end of each task.
+- All commits use the project's jj/git workflow per `AGENTS.md`. Each task ends with `jj describe -m "..."` then `jj new`.
+- `bd update <PR2 bead id> --claim` before starting Task 1.
+
+---
+
+## File Structure
+
+**New files:**
+- `web/src/components/timeline/cards/stamina_card.rs` — `StaminaCard` component for `StaminaBandChanged`.
+
+**Modified files:**
+- `web/src/components/tribute_state_strip.rs` — `WindedPip` + `ExhaustedPip` pip components; extend the `any_visible` guard; render the new pips inside the `flex` row.
+- `web/src/components/tribute_detail.rs` — add a stamina bar in the `TributeAttributes` block (or in a sibling `TributeBars` block depending on existing layout). Show `stamina / max_stamina` plus the visible band label.
+- `web/src/components/timeline/cards/mod.rs` — register `pub mod stamina_card;` and re-export.
+- `web/src/components/timeline/event_card.rs` — extend the `MessageKind::State` `match payload` to dispatch `MessagePayload::StaminaBandChanged { .. }` to `StaminaCard`.
+
+---
+
+## Task Order Rationale
+
+Stamina bar first (most visible, least controversial). Pips second (depends on the bar's color tokens being settled). Timeline card third. Final task is end-to-end smoke + WCAG check + PR.
+
+---
+
+## Task 1: Stamina bar in `tribute_detail.rs`
+
+**Files:**
+- Modify: `web/src/components/tribute_detail.rs`
+
+**Goal:** Add a single-row stamina display showing `stamina / max_stamina` plus the band label, matching the visual treatment of the existing Health / Sanity rows. Color token shifts based on band: green Fresh, amber Winded, red Exhausted.
+
+- [ ] **Step 1: Locate the bars block.** Open `web/src/components/tribute_detail.rs` and find `TributeAttributes` (~line 347). Note the existing `dl class: "grid grid-cols-2 gap-4"` with `Health` / `Sanity` / `Movement` rows.
+
+- [ ] **Step 2: Add stamina row** alongside the others. After the `Sanity` row (line ~354):
+
+```rust
+            dt { "Stamina" }
+            dd {
+                StaminaReadout {
+                    current: tribute.stamina,
+                    max: tribute.max_stamina,
+                }
+            }
+```
+
+Wait — `TributeAttributes` takes `attributes: Attributes` (not a full `Tribute`). Stamina lives on `Tribute`, not `Attributes`. Two options:
+
+- **Option A (preferred):** add a sibling component `TributeStaminaRow` rendered next to `TributeAttributes` in the parent (search for `TributeAttributes {` to find the call site).
+- **Option B:** thread `tribute` through `TributeAttributes` props.
+
+Pick A. Find the parent component (likely `TributeDetail`) that renders `TributeAttributes` and insert the stamina row immediately above or below it.
+
+- [ ] **Step 3: Create `StaminaReadout` component** at the bottom of `tribute_detail.rs`:
+
+```rust
+#[component]
+fn StaminaReadout(current: u32, max: u32) -> Element {
+    use shared::messages::StaminaBand;
+    let pct = if max == 0 { 0 } else { (current * 100) / max };
+    let band = if pct > 50 {
+        StaminaBand::Fresh
+    } else if pct > 20 {
+        StaminaBand::Winded
+    } else {
+        StaminaBand::Exhausted
+    };
+    let (color_cls, label) = match band {
+        StaminaBand::Fresh => ("text-emerald-600 theme2:text-emerald-300", "Fresh"),
+        StaminaBand::Winded => ("text-amber-600 theme2:text-amber-300", "Winded"),
+        StaminaBand::Exhausted => ("text-red-600 theme2:text-red-400 font-semibold", "Exhausted"),
+    };
+    rsx! {
+        span {
+            class: "inline-flex items-center gap-2 {color_cls}",
+            "aria-label": "Stamina: {current} of {max}, band {label}",
+            span { "{current} / {max}" }
+            span { class: "text-xs uppercase tracking-wide opacity-80", "({label})" }
+        }
+    }
+}
+```
+
+(Mirror the rendering of any existing `HealthReadout` / `SanityReadout` if they exist; search `grep -n "HealthReadout\|SanityReadout" web/src/components/tribute_detail.rs` and copy that shape if present. Otherwise the inline component above is fine.)
+
+- [ ] **Step 4: Build and smoke-check:**
+
+```bash
+cd web && just build-css && dx serve
+```
+
+Open the tribute detail page for a known tribute. Verify:
+- Stamina row appears under Sanity.
+- Format reads `100 / 100 (Fresh)` for a fresh tribute.
+- Color is green for Fresh, amber for Winded, red for Exhausted.
+
+If you can't quickly trigger Winded / Exhausted in dev, manually edit a test fixture or run a few dev cycles with combat enabled to confirm the band switching renders correctly.
+
+- [ ] **Step 5: Run `cargo check --package web`** — expected: clean.
+
+- [ ] **Step 6: Commit:**
+
+```bash
+jj describe -m "feat(web): stamina readout row in tribute detail (hangrier_games-93m)"
+jj new
+```
+
+---
+
+## Task 2: Winded / Exhausted pips in `TributeStateStrip`
+
+**Files:**
+- Modify: `web/src/components/tribute_state_strip.rs`
+
+**Goal:** Add two new pip components (`WindedPip`, `ExhaustedPip`) following the exact pattern of `HungerPip` / `ThirstPip` / `ShelterPip`. Glyphs: 💨 for Winded, 🥵 for Exhausted. The `any_visible` guard extends to include the stamina band so a fully-fresh tribute card still renders nothing.
+
+- [ ] **Step 1: Read the current strip** to confirm the exact pattern (the file is already opened in pre-flight; `pub fn TributeStateStrip` is at line 6).
+
+- [ ] **Step 2: Compute stamina band inside the component.** Replace the existing visibility check with a stamina-aware version:
+
+```rust
+use dioxus::prelude::*;
+use game::tributes::Tribute;
+use game::tributes::survival::{HungerBand, ThirstBand, hunger_band, thirst_band};
+use shared::messages::StaminaBand;
+
+fn stamina_band_local(stamina: u32, max_stamina: u32) -> StaminaBand {
+    if max_stamina == 0 {
+        return StaminaBand::Exhausted;
+    }
+    let pct = (stamina * 100) / max_stamina;
+    if pct > 50 {
+        StaminaBand::Fresh
+    } else if pct > 20 {
+        StaminaBand::Winded
+    } else {
+        StaminaBand::Exhausted
+    }
+}
+
+#[component]
+pub fn TributeStateStrip(tribute: Tribute, current_phase: Option<u32>) -> Element {
+    let h_band = hunger_band(tribute.hunger);
+    let t_band = thirst_band(tribute.thirst);
+    let s_band = stamina_band_local(tribute.stamina, tribute.max_stamina);
+    let sheltered_phases_left = match (tribute.sheltered_until, current_phase) {
+        (Some(until), Some(now)) if until > now => Some(until - now),
+        _ => None,
+    };
+
+    let any_visible = h_band != HungerBand::Sated
+        || t_band != ThirstBand::Sated
+        || s_band != StaminaBand::Fresh
+        || sheltered_phases_left.is_some();
+
+    if !any_visible {
+        return rsx! {};
+    }
+
+    rsx! {
+        div {
+            class: "flex flex-row gap-2 items-center text-sm select-none",
+            if h_band != HungerBand::Sated {
+                HungerPip { band: h_band, raw: tribute.hunger }
+            }
+            if t_band != ThirstBand::Sated {
+                ThirstPip { band: t_band, raw: tribute.thirst }
+            }
+            if s_band != StaminaBand::Fresh {
+                StaminaPip { band: s_band, current: tribute.stamina, max: tribute.max_stamina }
+            }
+            if let Some(left) = sheltered_phases_left {
+                ShelterPip { phases_left: left }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add the `StaminaPip` component** at the bottom of the file, mirroring `HungerPip`:
+
+```rust
+#[component]
+fn StaminaPip(band: StaminaBand, current: u32, max: u32) -> Element {
+    let (glyph, cls, label) = match band {
+        StaminaBand::Winded => ("💨", "text-amber-400", "Winded"),
+        StaminaBand::Exhausted => ("🥵", "text-red-500 animate-pulse", "Exhausted"),
+        StaminaBand::Fresh => return rsx! {},
+    };
+    rsx! {
+        span {
+            class: "inline-flex items-center gap-1 {cls}",
+            "aria-label": "Stamina: {label}",
+            title: "Stamina {current}/{max} — {label}",
+            span { class: "text-base", "{glyph}" }
+            span { class: "text-xs uppercase tracking-wide", "{label}" }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run `cargo check --package web`** — expected: clean.
+
+- [ ] **Step 5: Build CSS + smoke:**
+
+```bash
+just build-css
+cd web && dx serve
+```
+
+Verify on a tribute card list page:
+- Fresh tribute: no stamina pip (and if also Sated/Sated/no-shelter, the whole strip is empty).
+- Winded tribute: amber 💨 pip with "Winded" label.
+- Exhausted tribute: red 🥵 pip with pulsing animation.
+- Pip slots in horizontally next to existing hunger/thirst pips with the same `gap-2` spacing.
+
+- [ ] **Step 6: Commit:**
+
+```bash
+jj describe -m "feat(web): Winded / Exhausted stamina pips in TributeStateStrip"
+jj new
+```
+
+---
+
+## Task 3: `StaminaCard` component
+
+**Files:**
+- Create: `web/src/components/timeline/cards/stamina_card.rs`
+- Modify: `web/src/components/timeline/cards/mod.rs`
+
+**Goal:** New `StaminaCard` component renders `StaminaBandChanged` payloads. Border colors per spec: amber Winded, red Exhausted, green for recovery (any band → Fresh, or Exhausted → Winded). Copy:
+
+| Transition | Glyph | Phrase |
+|---|---|---|
+| any → Winded | 💨 | "{name} is winded" |
+| any → Exhausted | 🥵 | "{name} is exhausted" |
+| Winded → Fresh, Exhausted → Fresh, Exhausted → Winded | 🌿 | "{name} caught their breath" |
+
+- [ ] **Step 1: Create the file:**
+
+```rust
+//! Timeline card for stamina band-change events
+//! (`MessagePayload::StaminaBandChanged`).
+//! See spec `docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`.
+
+use dioxus::prelude::*;
+use shared::messages::{GameMessage, MessagePayload};
+
+#[derive(Props, PartialEq, Clone)]
+pub struct StaminaCardProps {
+    pub message: GameMessage,
+}
+
+#[component]
+pub fn StaminaCard(props: StaminaCardProps) -> Element {
+    let MessagePayload::StaminaBandChanged { tribute, from, to } = &props.message.payload else {
+        return rsx! {};
+    };
+
+    let direction = transition_direction(from, to);
+    let (border_cls, bg_cls, glyph, phrase) = match (direction, to.as_str()) {
+        (Direction::Worsening, "Winded") => (
+            "border-amber-400",
+            "bg-amber-50 theme2:bg-amber-950/40",
+            "💨",
+            format!("{} is winded.", tribute.name),
+        ),
+        (Direction::Worsening, "Exhausted") => (
+            "border-red-500",
+            "bg-red-50 theme2:bg-red-950/40",
+            "🥵",
+            format!("{} is exhausted.", tribute.name),
+        ),
+        (Direction::Recovery, _) => (
+            "border-emerald-400",
+            "bg-emerald-50 theme2:bg-emerald-950/40",
+            "🌿",
+            format!("{} caught their breath.", tribute.name),
+        ),
+        // Defensive: unknown transitions fall through to a neutral style.
+        _ => (
+            "border-stone-400",
+            "bg-stone-50 theme2:bg-stone-900/40",
+            "•",
+            format!("{}: {} → {}", tribute.name, from, to),
+        ),
+    };
+
+    rsx! {
+        article {
+            class: "rounded border-l-4 {border_cls} {bg_cls} p-2 text-sm",
+            p {
+                class: "text-xs text-stone-700 theme2:text-stone-200",
+                "{glyph} {phrase}"
+                span { class: "text-[10px] text-stone-500 ml-2", "(was {from})" }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Direction { Worsening, Recovery, Unknown }
+
+fn transition_direction(from: &str, to: &str) -> Direction {
+    // Worse: Fresh -> Winded, Fresh -> Exhausted, Winded -> Exhausted.
+    // Better: Winded -> Fresh, Exhausted -> Fresh, Exhausted -> Winded.
+    match (from, to) {
+        ("Fresh", "Winded") | ("Fresh", "Exhausted") | ("Winded", "Exhausted") => Direction::Worsening,
+        ("Winded", "Fresh") | ("Exhausted", "Fresh") | ("Exhausted", "Winded") => Direction::Recovery,
+        _ => Direction::Unknown,
+    }
+}
+```
+
+- [ ] **Step 2: Register in `web/src/components/timeline/cards/mod.rs`.** Add `pub mod stamina_card;` alphabetically with the others (`alliance_card`, `combat_card`, ...).
+
+- [ ] **Step 3: Run `cargo check --package web`** — expected: clean.
+
+- [ ] **Step 4: Commit:**
+
+```bash
+jj describe -m "feat(web): StaminaCard component for StaminaBandChanged events"
+jj new
+```
+
+---
+
+## Task 4: Wire `StaminaCard` into `event_card.rs` dispatch
+
+**Files:**
+- Modify: `web/src/components/timeline/event_card.rs`
+
+**Goal:** Extend the `MessageKind::State` arm so `StaminaBandChanged` routes to `StaminaCard` while everything else continues to route to `SurvivalCard` / `CycleCard` / `StateCard` as before.
+
+- [ ] **Step 1: Open `web/src/components/timeline/event_card.rs`** and find the `MessageKind::State` arm at line ~51:
+
+```rust
+            MessageKind::State => match payload {
+                MessagePayload::HungerBandChanged { .. }
+                | MessagePayload::ThirstBandChanged { .. }
+                | MessagePayload::ShelterSought { .. }
+                | MessagePayload::Foraged { .. }
+                | MessagePayload::Drank { .. }
+                | MessagePayload::Ate { .. } => rsx! { SurvivalCard { message: props.message.clone() } },
+                MessagePayload::CycleStart { .. }
+                | MessagePayload::CycleEnd { .. }
+                | MessagePayload::GameEnded { .. } => rsx! { CycleCard { message: props.message.clone() } },
+                _ => rsx! { StateCard { message: props.message.clone() } },
+            },
+```
+
+- [ ] **Step 2: Add the new arm above the catch-all** and import `StaminaCard`:
+
+```rust
+use crate::components::timeline::cards::{
+    alliance_card::AllianceCard, combat_card::CombatCard, combat_swing_card::CombatSwingCard,
+    cycle_card::CycleCard, death_card::DeathCard, item_card::ItemCard, movement_card::MovementCard,
+    stamina_card::StaminaCard, state_card::StateCard, survival_card::SurvivalCard,
+};
+```
+
+```rust
+            MessageKind::State => match payload {
+                MessagePayload::StaminaBandChanged { .. } => {
+                    rsx! { StaminaCard { message: props.message.clone() } }
+                }
+                MessagePayload::HungerBandChanged { .. }
+                | MessagePayload::ThirstBandChanged { .. }
+                | MessagePayload::ShelterSought { .. }
+                | MessagePayload::Foraged { .. }
+                | MessagePayload::Drank { .. }
+                | MessagePayload::Ate { .. } => rsx! { SurvivalCard { message: props.message.clone() } },
+                MessagePayload::CycleStart { .. }
+                | MessagePayload::CycleEnd { .. }
+                | MessagePayload::GameEnded { .. } => rsx! { CycleCard { message: props.message.clone() } },
+                _ => rsx! { StateCard { message: props.message.clone() } },
+            },
+```
+
+- [ ] **Step 3: Run `cargo check --package web`** — expected: clean.
+
+- [ ] **Step 4: Smoke test.** Run `just build-css && cd web && dx serve`. Find a game in the timeline view that has had stamina-band events. Verify:
+- Winded transition cards have amber left border with 💨.
+- Exhausted transition cards have red left border with 🥵.
+- Recovery cards (Winded→Fresh / Exhausted→Fresh / Exhausted→Winded) have green border with 🌿.
+- Cards interleave correctly with hunger/thirst band events in the timeline.
+
+If no live game has stamina events yet, manually inject a test event into a saved game JSON, reload, and confirm.
+
+- [ ] **Step 5: Commit:**
+
+```bash
+jj describe -m "feat(web): dispatch StaminaBandChanged to StaminaCard in event_card.rs"
+jj new
+```
+
+---
+
+## Task 5: Final pass — WCAG, smoke, PR
+
+**Files:** none (verification + PR creation)
+
+**Goal:** Verify accessibility, run all quality gates, hand off PR2 with a clean PR description.
+
+- [ ] **Step 1: WCAG color contrast check.** Tailwind tokens used:
+- `text-emerald-600` / `text-emerald-300` (Fresh): contrast OK on white / dark backgrounds (existing palette pattern).
+- `text-amber-400` / `text-amber-600` (Winded): borderline at 400 on white; mitigated by the bold "Winded" label and the 💨 glyph providing redundant signal.
+- `text-red-500` / `text-red-600` (Exhausted): high contrast.
+
+If a contrast checker (e.g. `pa11y`, browser devtools) flags `text-amber-400` on `bg-amber-50`, swap to `text-amber-700` for `light` and keep `text-amber-300` for `theme2:`. Run the contrast tool against a deployed dev page if available; otherwise manual visual check is acceptable for v1.
+
+- [ ] **Step 2: Manual smoke checklist:**
+- [ ] Fresh tribute: detail page shows green stamina readout, no pip in strip.
+- [ ] Winded tribute: detail page shows amber stamina readout, 💨 pip in strip.
+- [ ] Exhausted tribute: detail page shows red stamina readout, 🥵 pulsing pip in strip.
+- [ ] Timeline shows StaminaCard for each band-change event with correct color and copy.
+- [ ] Filter by tribute (existing per-tribute timeline filter): stamina events for that tribute appear; for others they don't.
+- [ ] Mobile-width viewport: pip strip wraps cleanly without overlap; stamina readout remains legible.
+- [ ] Both `light` and `theme2:` variants render correctly.
+
+- [ ] **Step 3: Run quality gates:**
+
+```bash
+just fmt
+just build-css
+cargo check --workspace
+cargo clippy --workspace -- -D warnings
+just test
+```
+
+Expected: all clean.
+
+- [ ] **Step 4: Self-review checklist:**
+- [ ] All 5 tasks committed; `jj log -r 'main..@'` shows 5 commits with `feat(web): ...` messages.
+- [ ] No backend changes in this PR — `git diff main..@ -- game/ shared/ api/` is empty (PR1 already landed all of those).
+- [ ] Imports are alphabetised in `mod.rs` and `event_card.rs`.
+- [ ] `StaminaPip` follows the exact `aria-label` and `title` pattern of the existing pips.
+- [ ] `StaminaCard` border colors match the survival card palette family.
+- [ ] No new Tailwind classes that weren't already in the JIT — if any new ones introduced, `just build-css` was re-run.
+
+- [ ] **Step 5: Push branch + open PR.** From the project root (main repo, not specs worktree):
+
+```bash
+jj git fetch
+jj rebase -d main@origin
+jj bookmark create stamina-pr2-frontend -r @-
+jj git push --bookmark stamina-pr2-frontend --allow-new
+gh pr create --base main --head stamina-pr2-frontend \
+  --title "feat(web): stamina-as-combat-resource frontend (hangrier_games-93m)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+PR2 of the stamina-as-combat-resource feature (`hangrier_games-93m`). Surfaces PR1's backend (combat stamina drain, fatigue bands, recovery, brain integration) in the Dioxus frontend.
+
+- Adds a stamina readout row to the tribute detail page with band-coloured label.
+- Extends `TributeStateStrip` with Winded (💨) and Exhausted (🥵) pips.
+- Adds `StaminaCard` for `StaminaBandChanged` timeline events with amber / red / green border treatments.
+- Wires dispatch inside the existing `MessageKind::State` arm of `event_card.rs`.
+
+No backend changes — PR1 already added `StaminaBand`, the `StaminaBandChanged` payload variant, and `MessageKind::State` routing.
+
+## Spec / Plan
+- Spec: `docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`
+- Plan: `docs/superpowers/plans/2026-05-03-stamina-combat-resource-pr2-frontend.md`
+
+## Verification
+
+```
+just fmt
+just build-css
+cargo check --workspace
+cargo clippy --workspace -- -D warnings
+just test
+```
+
+Manual smoke (light + theme2):
+- Fresh tribute: green readout, no pip.
+- Winded: amber readout + 💨 pip + amber-bordered timeline card.
+- Exhausted: red readout + 🥵 pip + red-bordered timeline card.
+- Recovery: green-bordered 🌿 card.
+
+## Follow-ups
+
+- Stamina-cost rendering on swing cards (open question A vs B from spec) — chose B for v1; revisit if playtest disagrees.
+- WCAG contrast pass on `text-amber-400` deserves a follow-up audit when the spectator-skin work updates the palette.
+
+## Beads
+Closes the PR2 child of `hangrier_games-93m`.
+EOF
+)"
+```
+
+- [ ] **Step 6: Close the PR2 implementation bead** once the PR is approved and merged:
+
+```bash
+bd close <PR2-bead-id> --reason "Merged in PR #<n>"
+```
+
+If both PR1 and PR2 are merged, also close the parent bead `hangrier_games-93m`:
+
+```bash
+bd close hangrier_games-93m --reason "PR1 #<n1> + PR2 #<n2> shipped"
+```
+
+- [ ] **Step 7: Hand-off summary** to the user with PR URL and any deferred items (notably: stats reporting follow-up bead, if relevant; stamina-cost-on-swing-card decision filed; WCAG contrast follow-up if applicable).
+
+---
+
+## Open Questions for PR Review
+
+- Stamina-cost rendering on swing cards: PR2 chose B (don't render). Reviewer may overrule.
+- The `transition_direction` helper duplicates band-ordering logic that already lives in `StaminaBand` enum. Acceptable, or refactor into a `From<(&str, &str)>` on a shared helper?
+- Should the recovery card also distinguish "Exhausted → Winded" (still tired but recovering) from "→ Fresh" (fully recovered)? Current implementation collapses both to a single 🌿 card; a more nuanced phrasing could split them.
+- WCAG audit on `text-amber-400`: defer to spectator-skin work or fix in this PR?

--- a/docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md
+++ b/docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md
@@ -1,0 +1,325 @@
+# Stamina-as-Combat-Resource — Design
+
+**Beads issue:** `hangrier_games-93m`
+**Status:** Spec
+**Date:** 2026-05-03
+**Predecessors:** Shelter + Hunger/Thirst (`hangrier_games-0yz`), Combat-wire redesign (`hangrier_games-dxp`), Break-mid-swing penalty (commit `ce2c8f1`).
+
+---
+
+## Problem
+
+Combat is currently free. The `stamina` field on `Tribute` (`game/src/tributes/mod.rs:185`) exists with a max of 100 and is drained by movement and most non-combat actions, but the `Action::Attack` branch (`game/src/tributes/mod.rs:548`) calls `attacks()` without subtracting the cost listed in `calculate_stamina_cost` (`mod.rs:852` → `25.0`). The result: tributes can swing infinitely, and the stamina system has no tactical consequence in fights.
+
+Three downstream effects flow from "combat is free":
+1. **Survival systems are decorative.** Hunger, thirst, shelter, and rest exist but rarely change a fight's outcome. A starving Exhausted tribute fights identically to a fresh one.
+2. **No tactical retreat.** A tribute who is losing has no mechanical reason to flee — the cost of staying is just HP, not stamina.
+3. **No visible weakness signaling.** Because there's no fatigue band, a tribute can't tell whether an opponent is gassed. Targeting decisions are blind to the most important "is this fight winnable" signal.
+
+This spec adds combat stamina drain, a Fresh/Winded/Exhausted band system that gates penalties and brain behavior, recovery rules tied to the existing shelter+survival systems, and visible-band predator/prey logic so the bands matter beyond their owner.
+
+## Goals
+
+- Combat actions consume stamina (asymmetric: attacker > target).
+- Two visible fatigue bands (Winded, Exhausted) with mechanical penalties.
+- Recovery rates that couple cleanly to the existing shelter and hunger/thirst systems.
+- Brain override pipeline extended so Winded tributes seek shelter and Exhausted tributes flee.
+- Visible bands feed back into other tributes' targeting decisions (predator/prey).
+- All combat magic numbers and new stamina constants hoisted to a tunable `CombatTuning` struct.
+- Frontend surfaces stamina bar, band pips, and a typed `StaminaBandChanged` timeline event.
+
+## Non-Goals
+
+- Retuning existing combat formulas (`DECISIVE_WIN_MULTIPLIER`, stress contributions). The hoist creates the surface; tuning is a separate post-ship pass (filed as a follow-up bead).
+- Property-test coverage of baseline combat behavior. Filed as a separate follow-up bead so it can be specified rigorously without bloating this PR.
+- Stamina-aware sponsor gifts (energy drinks, etc.).
+- Trait-driven recovery modifiers (Athletic +20%, etc.).
+- Hex-map fatigue glow / animation. Revisit during spectator-skin work.
+
+---
+
+## Design
+
+### Constants & tuning struct
+
+A new `CombatTuning` struct in `game/src/tributes/combat.rs` (or a sibling `tuning.rs` file under the tributes module) collects the existing magic numbers plus the new stamina constants. Default values match current behavior so the hoist is mechanically inert.
+
+```rust
+pub struct CombatTuning {
+    // --- Existing (verbatim from combat.rs:21-26) ---
+    pub decisive_win_multiplier: f64,        // 1.5
+    pub base_stress_no_engagements: f64,     // 20.0
+    pub stress_sanity_normalization: f64,    // 100.0
+    pub stress_final_divisor: f64,           // 2.0
+    pub kill_stress_contribution: f64,       // 50.0
+    pub non_kill_win_stress_contribution: f64, // 20.0
+
+    // --- New: per-swing stamina costs ---
+    pub stamina_cost_attacker: u32,          // 25
+    pub stamina_cost_target: u32,            // 10
+
+    // --- New: band thresholds (% of max_stamina) ---
+    pub band_winded_pct: u8,                 // 50
+    pub band_exhausted_pct: u8,              // 20
+
+    // --- New: per-band roll penalties (subtracted from attack/defense rolls) ---
+    pub winded_roll_penalty: i32,            // -2
+    pub exhausted_roll_penalty: i32,         // -5
+
+    // --- New: per-phase recovery ---
+    pub recovery_idle: u32,                  // 5
+    pub recovery_resting: u32,               // 30
+    pub recovery_sheltered_resting: u32,     // 60
+    pub recovery_starving_dehydrated_mult: f64, // 0.5
+
+    // --- New: brain scoring nudges ---
+    pub winded_attack_score_penalty: i32,    // -10
+    pub fresh_target_visibly_tired_bonus: i32, // +5
+}
+
+impl Default for CombatTuning {
+    fn default() -> Self { /* values listed above */ }
+}
+```
+
+`Game` carries one instance: `pub combat_tuning: CombatTuning` (with `#[serde(default)]` so existing saves load unchanged). All combat code reads from this instead of constants.
+
+### Stamina drain on combat
+
+`Action::Attack` resolution in `game/src/tributes/mod.rs:548` is wrapped to deduct attacker cost before calling `attacks()`, and the target's cost is deducted at the call site (or inside `attacks()`, before the contest roll, with a returned-stamina-cost field on `CombatBeat` so the wire stays single-source).
+
+Costs use `saturating_sub` so a tribute who is below cost can still complete a swing already underway (combat is committed once entered) but the attack itself is **gated** at action selection: a tribute below `stamina_cost_attacker` cannot select `Action::Attack`. The brain-side check in `tributes/brains.rs` short-circuits the action-score calculation. (Brain handling for the gated case is in **Brain Integration** below.)
+
+The target cost (`stamina_cost_target`) is paid whether the target acts or not — defending takes work too. A target below their cost still pays via `saturating_sub`, but the additional rule "low stamina applies a roll penalty via band" naturally punishes them.
+
+### Fatigue bands
+
+Three bands derived from `stamina / max_stamina`:
+
+| Band | Threshold (default) | Roll penalty | Visible to others |
+|---|---|---|---|
+| Fresh | > 50% | 0 | yes |
+| Winded | ≤ 50%, > 20% | −2 | yes |
+| Exhausted | ≤ 20% | −5 | yes |
+
+A new pure function in `game/src/tributes/survival.rs` (or a new sibling `stamina_band.rs`):
+
+```rust
+pub enum StaminaBand { Fresh, Winded, Exhausted }
+
+pub fn stamina_band(stamina: u32, max_stamina: u32, tuning: &CombatTuning) -> StaminaBand {
+    let pct = if max_stamina == 0 { 0 } else { (stamina * 100) / max_stamina };
+    if pct as u8 > tuning.band_winded_pct { StaminaBand::Fresh }
+    else if pct as u8 > tuning.band_exhausted_pct { StaminaBand::Winded }
+    else { StaminaBand::Exhausted }
+}
+```
+
+Roll penalties apply in `combat.rs` to both attacker and defender rolls. The penalty is read from `CombatTuning` and subtracted (not multiplied) so the stat shape stays linear and transparent. Penalties stack with existing modifiers (break-mid-swing forfeit, etc.) — they do not gate them.
+
+### Recovery formula
+
+Recovery runs once per phase per tribute, in `Game::process_turn_phase` (or wherever `restore_stamina` is currently invoked from `Action::Rest`). Formula:
+
+```
+base_per_phase =
+    if action == Rest && sheltered { tuning.recovery_sheltered_resting }     // 60
+    else if action == Rest         { tuning.recovery_resting }                // 30
+    else                            { tuning.recovery_idle }                  // 5
+
+multiplier =
+    if hunger_band == Starving || thirst_band == Dehydrated {
+        tuning.recovery_starving_dehydrated_mult                              // 0.5
+    } else { 1.0 }
+
+stamina = (stamina + (base_per_phase as f64 * multiplier).round() as u32).min(max_stamina)
+```
+
+`sheltered` here is the boolean from the existing shelter system (`sheltered_until > current_phase`). `hunger_band` / `thirst_band` are the existing pure-function bands from shelter PR1.
+
+The existing `restore_stamina()` (`tributes/lifecycle.rs:179`) becomes either a thin wrapper over the new formula with `action=Rest, sheltered=false, fresh-bands` (so existing tests / call sites still get a meaningful restore) or it is renamed `recover_stamina` and accepts the inputs explicitly. Implementation can pick whichever yields fewer churned tests; leaning toward "rename + plumb arguments" since the old "always full restore" semantics are exactly the over-generous behavior this spec corrects.
+
+### Brain integration
+
+Extends the existing override pipeline in `game/src/tributes/brains.rs`. The order of brain overrides becomes (preserving existing precedence):
+
+1. **Combat preempt** — engaged tributes resolve combat first (unchanged).
+2. **Gamemaker overrides** — sealed-area filter, mutt flee, convergence pull (unchanged).
+3. **Hunger/thirst overrides** — Eat/Drink when Starving/Dehydrated (unchanged).
+4. **Stamina overrides (NEW)** — see below.
+5. Standard brain logic.
+
+#### Stamina override rules
+
+- **Fresh:** no override. Standard logic. Apply `fresh_target_visibly_tired_bonus` to attack-action scoring when the candidate target is in a Winded or Exhausted band.
+- **Winded:**
+  - Apply `winded_attack_score_penalty` to all `Action::Attack` candidate scores. The attack remains *available* — a cornered Winded tribute can still swing — but scoring shifts the brain toward `SeekShelter` and `Rest`.
+- **Exhausted:**
+  - If a reachable shelter exists (within stamina-affordable hex distance), force `Action::SeekShelter`.
+  - Else force `Action::Rest`.
+  - **Visible-band flee rule:** if any tribute in the same area or an adjacent area has a *better* visible band than the actor, force `Action::Move` away (toward the highest-cost-distance neighbor that puts more area-edges between actor and the better-banded tribute). This rule overrides the SeekShelter / Rest defaults *only when shelter is not in the actor's own area* — being in shelter beats fleeing.
+
+#### Predator scoring
+
+The Fresh-only `fresh_target_visibly_tired_bonus` adds to the attack-action score when scoring candidate targets. This is a brain-scoring nudge, not a hard gate — a Fresh tribute with a great target choice (high HP, valuable items) still picks their preferred target; the bonus only nudges between roughly-equivalent options. Concretely:
+
+```rust
+fn target_attack_score(
+    actor: &Tribute, target: &Tribute,
+    tuning: &CombatTuning,
+) -> i32 {
+    let base = /* existing scoring */;
+    let actor_band = stamina_band(actor.stamina, actor.max_stamina, tuning);
+    let target_band = stamina_band(target.stamina, target.max_stamina, tuning);
+    let predator_bonus = if actor_band == StaminaBand::Fresh
+        && (target_band == StaminaBand::Winded || target_band == StaminaBand::Exhausted) {
+        tuning.fresh_target_visibly_tired_bonus
+    } else { 0 };
+    base + predator_bonus
+}
+```
+
+#### Action-gate on insufficient stamina
+
+If `actor.stamina < tuning.stamina_cost_attacker`, the brain treats `Action::Attack` as unavailable (score = `i32::MIN`). This is independent of band — it's a hard mechanic gate. It naturally produces the "Exhausted tribute can't swing" outcome without needing a special-case rule.
+
+### Events
+
+One new typed `MessagePayload` variant in `shared/src/messages.rs`:
+
+```rust
+StaminaBandChanged {
+    tribute: TributeRef,
+    from: StaminaBand,
+    to: StaminaBand,
+}
+```
+
+`StaminaBand` lives in `shared/src/messages.rs` (mirrors `HungerBand` / `ThirstBand` location pattern from shelter PR1):
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum StaminaBand { Fresh, Winded, Exhausted }
+```
+
+`MessagePayload::kind()` routes `StaminaBandChanged` to `MessageKind::State` (alongside `HungerBandChanged` / `ThirstBandChanged` / `TributeStarved` / `TributeDehydrated`). No new `MessageKind` variant needed — this is the same category as the existing survival state events.
+
+### Coexistence with the existing combat code
+
+- `CombatBeat` (the typed swing wire from `hangrier_games-dxp`) gains optional fields `attacker_stamina_cost: u32` and `target_stamina_cost: u32` so the swing's cost is renderable in the timeline / replay if desired. PR1 plumbs the values through; PR2 may or may not surface them on the card body (open question — see below).
+- `apply_violence_stress` and the break-mid-swing forfeit logic are unchanged. Stamina penalties are additive to whatever those branches already produce.
+- The `restore_stamina` rename is the only breaking change in `lifecycle.rs`. All call sites are local to the game crate; none cross the API/web boundary.
+
+---
+
+## Frontend (PR2 scope)
+
+### Tribute card / detail page
+
+Stamina bar joins HP and sanity bars. Pip strip (`tribute_state_strip`) gets two new pips:
+
+| Pip | Trigger | Glyph |
+|---|---|---|
+| Winded | `stamina_band == Winded` | 💨 |
+| Exhausted | `stamina_band == Exhausted` | 🥵 |
+
+Following the shelter PR2 pattern: pips render with `aria-label`, theme-aware Tailwind classes, and slot into the existing strip's flex layout.
+
+### Timeline card
+
+`StaminaCard` component in `web/src/components/timeline/cards/stamina_card.rs` renders `StaminaBandChanged`:
+
+```
+💨 {tribute.name} is winded
+🥵 {tribute.name} is exhausted
+🌿 {tribute.name} caught their breath  // (recovery: from Winded/Exhausted → Fresh)
+```
+
+Routes through `MessageKind::State` (existing dispatch in `event_card.rs`) — no new `MessageKind` arm needed. Border color: amber for Winded transition, red for Exhausted transition, green for recovery.
+
+### Filter chip
+
+If the timeline filter strip is category-based on `MessageKind`, no new chip is needed (covered by existing State filter). If filters are payload-specific, add a "Stamina" chip alongside the existing survival ones.
+
+### Stamina-cost rendering on swing cards (open question)
+
+Should the existing `CombatSwingCard` show the per-swing stamina cost? Two options:
+- **A.** Yes, append "(−25 stamina)" to the swing line. Reinforces the new mechanic visually every swing.
+- **B.** No, keep the swing card visually unchanged; cost is a backend mechanic, not spectator content.
+
+**Defer.** PR1 carries the cost through `CombatBeat` so the data is available; PR2 picks A or B during implementation based on visual density. File as an inline plan-time decision.
+
+---
+
+## File / Module Layout
+
+**New types in `shared/src/messages.rs`:**
+- `StaminaBand` enum
+- `MessagePayload::StaminaBandChanged` variant
+
+**New / modified in `game/`:**
+- `game/src/tributes/combat.rs` — existing constants moved into `CombatTuning`; per-swing cost deduction; band-penalty application to rolls.
+- `game/src/tributes/stamina_band.rs` (NEW) — pure `stamina_band()` function and helpers.
+- `game/src/tributes/lifecycle.rs` — `restore_stamina` renamed `recover_stamina`, takes `(action, sheltered, hunger_band, thirst_band, tuning)`.
+- `game/src/tributes/brains.rs` — stamina-band override block added to the override pipeline; predator-bonus scoring added to attack-action scoring.
+- `game/src/tributes/mod.rs` — `Action::Attack` resolution gated on attacker stamina; cost deduction at the call site (or inside `attacks()`).
+- `game/src/games.rs` — `Game.combat_tuning: CombatTuning` field added; per-phase recovery loop wired in `process_turn_phase`; `StaminaBandChanged` emission when band crosses.
+
+**New / modified in `web/`:**
+- `web/src/components/tribute_state_strip.rs` — Winded / Exhausted pip rendering.
+- `web/src/components/tribute_detail.rs` — stamina bar in the bars block.
+- `web/src/components/timeline/cards/stamina_card.rs` (NEW) — `StaminaCard` component.
+- `web/src/components/timeline/event_card.rs` — dispatch `StaminaBandChanged` to `StaminaCard` inside the existing `MessageKind::State` arm.
+
+---
+
+## PR Split
+
+Mirrors the shelter and gamemaker spec's PR1/PR2 split.
+
+**PR1 — Backend** (~10 TDD tasks):
+1. `CombatTuning` struct + `Default` impl + `Game.combat_tuning` field with `#[serde(default)]`
+2. Hoist existing constants to read from `CombatTuning` (no behavior change)
+3. `StaminaBand` enum in `shared/`; `stamina_band()` pure function in `game/`
+4. `MessagePayload::StaminaBandChanged` variant + routing to `MessageKind::State`
+5. Per-swing stamina cost deduction (attacker + target)
+6. Band-derived roll penalty in attack/defense rolls
+7. `recover_stamina` rename + new formula (idle / resting / sheltered, with starving/dehydrated multiplier)
+8. Per-phase band-cross detection + `StaminaBandChanged` emission
+9. Brain stamina override block (Winded score nudge, Exhausted SeekShelter/Rest, visible-band flee rule)
+10. Brain predator scoring (Fresh attack-action bonus on visibly-tired targets); action-gate on insufficient stamina; integration test in `game/tests/stamina_combat_integration.rs`
+
+**PR2 — Frontend** (~5 TDD tasks):
+1. `MessageKind::State` already exists — no shared changes needed beyond PR1
+2. Stamina bar in `tribute_detail.rs`
+3. Winded / Exhausted pips in `tribute_state_strip.rs`
+4. `StaminaCard` component + `event_card.rs` dispatch
+5. WCAG check on new pip glyphs and bar colors; manual smoke; PR
+
+---
+
+## Out of Scope (filed as follow-up beads after spec lands)
+
+1. **Property tests pinning current combat behavior baseline** — guards the `CombatTuning` defaults so future tuning passes can verify safety.
+2. **Combat formula retuning pass** — re-derive `DECISIVE_WIN_MULTIPLIER`, stress contributions, and stamina constants from playtest data once stamina is shipped.
+3. **Stamina-aware sponsor gifts** — energy drink consumable that restores stamina chunk; pairs with sponsorship feature.
+4. **Trait-driven recovery modifiers** — Athletic trait gives +20% recovery, Frail gives -20%, etc.
+5. **Hex-map fatigue glow** — visual indicator on the hex marker for Winded/Exhausted tributes; revisit during spectator-skin work.
+6. **Stamina-cost rendering on swing cards** — A vs B from the open question above; PR2 picks during implementation.
+7. **Announcer prompts for stamina events** — extends scope of `hangrier_games-xfi`.
+
+---
+
+## Open Questions (defer to implementation)
+
+- Exact "reachable shelter" range for the Exhausted SeekShelter override — same range as the hunger/thirst SeekShelter override, or a tighter one given the actor is more fragile? Use the same range for v1; adjust if playtest shows Exhausted tributes dying mid-flight to shelter.
+- Whether the "visible band" flee rule should consider Winded vs Fresh strictness (current spec: Exhausted flees from Winded *or* Fresh; Winded does not flee). Possibly add a "Winded flees from Fresh if also wounded (HP < 50%)" rule as a v1.x follow-up if Winded tributes feel suicidally aggressive.
+- Whether `fresh_target_visibly_tired_bonus` should scale by *which* tired band (Winded = +3, Exhausted = +5) rather than the flat +5. Tunable via `CombatTuning` — extend the struct in PR1 if implementation finds this worth the complexity.
+- `restore_stamina` rename vs. wrap: pick whichever generates less test churn at implementation time.
+
+## Risks
+
+- **Combat feels grindy if costs are too high** — Fresh tributes cap out at 4 swings before going Winded (100 ÷ 25). Mitigation: the values are tunable via `CombatTuning`; lean toward this in playtest.
+- **Recovery feels too fast and bands rarely surface** — the +60/phase sheltered-resting rate could erase combat fatigue in two phases. Mitigation: same tuning surface; the band-changed events make this measurable in playtest.
+- **Brain logic explosion** — five layers of overrides (combat, gamemaker, hunger/thirst, stamina, standard) is a lot. Mitigation: each layer is isolated and testable in `brains.rs`; the new layer follows the same pattern as the previous two and slots into a clear precedence order.
+- **Save migration** — `Game.combat_tuning` is `#[serde(default)]` so existing games load with default tuning. New `stamina` field is already on `Tribute`. New `StaminaBand` enum and `StaminaBandChanged` payload are append-only to `MessagePayload` (existing match arms remain exhaustive). No migration script needed.


### PR DESCRIPTION
## Summary

Spec + PR1/PR2 plans for stamina-as-combat-resource (`hangrier_games-93m`). Closes the design phase; implementation tracked under sibling beads `hangrier_games-znt8` (backend) and `hangrier_games-awhx` (frontend).

- **Spec** (`docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`): combat actions consume asymmetric stamina (attacker 25, target 10); two visible fatigue bands (Winded ≤50%, Exhausted ≤20%) with -2 / -5 roll penalties; recovery formula tied to shelter + survival state (idle 5, resting 30, sheltered+resting 60, ×0.5 if Starving/Dehydrated); brain pipeline gains a fourth override layer for Exhausted SeekShelter/Rest/flee + a Fresh predator bonus + an action-gate; new `CombatTuning` struct hoists six existing combat magic numbers plus ten stamina knobs; `MessagePayload::StaminaBandChanged` routes through existing `MessageKind::State`.
- **PR1 backend plan** (`docs/superpowers/plans/2026-05-03-stamina-combat-resource-pr1-backend.md`, 1564 lines, 10 TDD tasks): tuning struct, constant hoist, band enum + pure function, payload variant, per-swing cost deduction, roll penalties, `recover_stamina` rename + new formula, per-phase emission, brain stamina override, predator scoring + integration test.
- **PR2 frontend plan** (`docs/superpowers/plans/2026-05-03-stamina-combat-resource-pr2-frontend.md`, 539 lines, 5 TDD tasks): stamina readout in tribute detail, Winded/Exhausted pips in `TributeStateStrip`, `StaminaCard` component, `event_card.rs` dispatch wiring, WCAG + smoke + PR.

## Out of Scope (filed as follow-up beads)

- `hangrier_games-cpf3` — Property tests pinning current combat behavior baseline.
- `hangrier_games-l377` — Combat formula retuning pass (post-stamina-ship).
- `hangrier_games-oktk` — Stamina-aware sponsor gifts (energy drinks).
- `hangrier_games-011m` — Trait-driven recovery modifiers (Athletic, Frail).
- `hangrier_games-l374` — Hex-map fatigue glow.
- `hangrier_games-f9c4` — Stamina-cost rendering on `CombatSwingCard`.
- `hangrier_games-zzmp` — Announcer prompts for stamina events.
- `hangrier_games-8zki` — Stamina stats reporting (per-tribute + per-game metrics + dashboard).

## Verification

Documentation-only PR; no code changes. Plans + spec align with the established shelter (`hangrier_games-0yz`) and gamemaker (`hangrier_games-5q9`) PR1/PR2 split pattern.

## Beads
- Parent: `hangrier_games-93m` (stays open until both implementation children ship).
- PR1 implementation: `hangrier_games-znt8`.
- PR2 implementation: `hangrier_games-awhx` (blocks on PR1).