### PR TITLE
fix(api): replace session() unwrap chain with AppError propagation

### DIFF
--- a/api/src/users.rs
+++ b/api/src/users.rs
@@ -85,13 +85,14 @@ async fn session(state: State<AppState>) -> Result<Json<String>, AppError> {
     // mutate the shared `Surreal<Any>` session mid-query. See
     // bd hangrier_games-c853 / PR #181 for the original race.
     let _auth_guard = state.auth_lock.lock().await;
-    let res: Option<String> = state
+    let mut response = state
         .db
         .query("RETURN <string>$session")
         .await
-        .unwrap()
+        .map_err(|e| AppError::DbError(format!("Failed to query session: {e}")))?;
+    let res: Option<String> = response
         .take(0)
-        .unwrap();
+        .map_err(|e| AppError::DbError(format!("Failed to read session result: {e}")))?;
     Ok(Json(res.unwrap_or("No session data found!".into())))
 }
 


### PR DESCRIPTION
## Summary

- Replace 3-`unwrap()` chain in `session()` handler (`api/src/users.rs:82-96`) with `AppError::DbError` propagation so DB/session errors return 5xx instead of panicking the worker.
- Preserves the existing `auth_lock` guard and the doc comment referencing the original race fix (PR #181).

## Verification

- `cargo fmt --all`
- `cargo clippy --workspace --tests -- -D warnings` — clean
- `cargo test -p api --test auth_tests -- --test-threads=1` — 6/7 pass; `test_token_refresh` is the pre-existing failure tracked in hangrier_games-lkxg

## Follow-ups

- hangrier_games-c3ct (replace shared-connection auth_lock with per-request `$auth` binding)
- hangrier_games-lkxg (pre-existing api test failures)

Closes hangrier_games-d43h