### PR TITLE
refactor(api): split USERS_ROUTER public/protected, move session under JWT

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -3,7 +3,7 @@ extern crate core;
 use api::auth::AUTH_ROUTER;
 use api::cleanup::start_cleanup_scheduler;
 use api::games::GAMES_ROUTER;
-use api::users::USERS_ROUTER;
+use api::users::{USERS_PROTECTED_ROUTER, USERS_PUBLIC_ROUTER};
 use api::{AppState, AuthDb};
 use axum::extract::{Request, State};
 use axum::http::StatusCode;
@@ -236,7 +236,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 surreal_jwt,
             )),
         )
-        .nest("/users", USERS_ROUTER.clone())
+        .nest("/users", USERS_PUBLIC_ROUTER.clone())
+        .nest(
+            "/users",
+            USERS_PROTECTED_ROUTER
+                .clone()
+                .layer(middleware::from_fn_with_state(
+                    app_state.clone(),
+                    surreal_jwt,
+                )),
+        )
         .nest("/auth", AUTH_ROUTER.clone());
 
     let router = Router::new()

--- a/api/src/users.rs
+++ b/api/src/users.rs
@@ -1,24 +1,33 @@
 use crate::auth::{JWT_SECRET, RefreshToken, TokenResponse, store_refresh_token};
 use crate::cookies::{set_refresh_cookie, set_session_cookie};
-use crate::{AppError, AppState};
-use axum::extract::State;
+use crate::{AppError, AppState, AuthDb};
+use axum::extract::{Extension, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
-use shared::RegistrationUser;
+use shared::{RegistrationUser, UserSession};
 use std::sync::LazyLock;
 use surrealdb::opt::auth::Record;
 use surrealdb::sql::Thing;
 use validator::Validate;
 
-pub static USERS_ROUTER: LazyLock<Router<AppState>> = LazyLock::new(|| {
+/// Public users routes. Mounted in `main.rs` *outside* the `surreal_jwt`
+/// middleware because both endpoints establish auth from credentials, not
+/// from an existing session.
+pub static USERS_PUBLIC_ROUTER: LazyLock<Router<AppState>> = LazyLock::new(|| {
     Router::new()
-        .route("/", get(session).post(user_create))
+        .route("/", post(user_create))
         .route("/authenticate", post(user_authenticate))
 });
+
+/// Authenticated users routes. Must be mounted *behind* `surreal_jwt` so
+/// `session` reads `$auth` from the per-request authed `AuthDb` clone
+/// instead of the root-authed shared connection. See bd hangrier_games-p9p0.
+pub static USERS_PROTECTED_ROUTER: LazyLock<Router<AppState>> =
+    LazyLock::new(|| Router::new().route("/session", get(session)));
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct JwtClaims {
@@ -83,27 +92,31 @@ async fn create_token_pair(
     })
 }
 
-async fn session(state: State<AppState>) -> Result<Json<String>, AppError> {
-    // `RETURN <string>$session` reads connection-level session state.
-    // Use a local clone of the shared connection (independent session,
-    // same socket — SurrealDB Rust SDK 2.x multi-tenancy) so concurrent
-    // signup/signin/authenticate calls can't race on `$session`. See
-    // bd hangrier_games-c3ct (replaces the previous `auth_lock` guard;
-    // original race was bd hangrier_games-c853 / PR #181).
-    //
-    // NOTE: this endpoint is unauthenticated — the local clone inherits
-    // root auth from `state.db`, so this returns the raw root session
-    // JSON and is only meaningful as a health/info probe. See bd
-    // hangrier_games-p9p0 for moving session under the JWT-protected nest.
-    let user_db = (*state.db).clone();
-    let mut response = user_db
-        .query("RETURN <string>$session")
+/// Returns the authenticated caller's user record (`id`, `username`).
+///
+/// Mounted behind `surreal_jwt`, so the per-request `AuthDb` clone has
+/// already been `authenticate`d with the caller's JWT — `$auth` resolves
+/// to their `user:` record. Raw `$session` is not exposed; we project to
+/// the small `UserSession` shape the frontend actually needs.
+async fn session(Extension(AuthDb(db)): Extension<AuthDb>) -> Result<Json<UserSession>, AppError> {
+    #[derive(Deserialize)]
+    struct AuthRow {
+        id: Thing,
+        username: String,
+    }
+
+    let mut response = db
+        .query("SELECT id, username FROM $auth")
         .await
         .map_err(|e| AppError::DbError(format!("Failed to query session: {e}")))?;
-    let res: Option<String> = response
+    let row: Option<AuthRow> = response
         .take(0)
         .map_err(|e| AppError::DbError(format!("Failed to read session result: {e}")))?;
-    Ok(Json(res.unwrap_or("No session data found!".into())))
+    let row = row.ok_or_else(|| AppError::Unauthorized("No authenticated session".into()))?;
+    Ok(Json(UserSession {
+        id: row.id.to_string(),
+        username: row.username,
+    }))
 }
 
 async fn user_create(

--- a/api/tests/auth_tests.rs
+++ b/api/tests/auth_tests.rs
@@ -265,7 +265,7 @@ async fn test_session_endpoint() {
 
     // Call session endpoint with token
     let session_response = server
-        .get("/api/users")
+        .get("/api/users/session")
         .add_header("Authorization", format!("Bearer {}", access_token))
         .await;
 

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -102,7 +102,7 @@ impl TestDb {
 pub fn create_test_router(state: AppState) -> Router {
     use api::auth::AUTH_ROUTER;
     use api::games::GAMES_ROUTER;
-    use api::users::USERS_ROUTER;
+    use api::users::{USERS_PROTECTED_ROUTER, USERS_PUBLIC_ROUTER};
     use api::websocket::websocket_handler;
     use axum::middleware;
     use axum::routing::get;
@@ -114,7 +114,13 @@ pub fn create_test_router(state: AppState) -> Router {
                 .clone()
                 .layer(middleware::from_fn_with_state(state.clone(), surreal_jwt)),
         )
-        .nest("/users", USERS_ROUTER.clone())
+        .nest("/users", USERS_PUBLIC_ROUTER.clone())
+        .nest(
+            "/users",
+            USERS_PROTECTED_ROUTER
+                .clone()
+                .layer(middleware::from_fn_with_state(state.clone(), surreal_jwt)),
+        )
         .nest("/auth", AUTH_ROUTER.clone());
 
     Router::new()

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -259,6 +259,17 @@ pub struct CreatedBy {
     pub username: String,
 }
 
+/// Authenticated user identity returned by `GET /api/users/session`. Reads
+/// the per-request `$auth` SurrealDB record so the caller learns who they
+/// are without the frontend having to decode the JWT itself.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct UserSession {
+    /// SurrealDB record id (e.g. `user:abc123`) as a string. Useful for
+    /// cache keys and for matching `created_by` ownership on games.
+    pub id: String,
+    pub username: String,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct ListDisplayGame {
     pub identifier: String,


### PR DESCRIPTION
## Summary

- Splits `USERS_ROUTER` into `USERS_PUBLIC_ROUTER` (signup, signin) and `USERS_PROTECTED_ROUTER` (session), the latter mounted behind `surreal_jwt`. Closes the structural gap noted in the c3ct refactor: `session` was previously running outside the auth middleware and reading `$session` off the root-authed shared connection clone.
- Renames `GET /api/users` → `GET /api/users/session`. Returns a typed `shared::UserSession { id, username }` (projected from `$auth`) instead of the raw root session JSON blob. Frontend has no callsite of the old path; only the `auth_tests::test_session_authenticated` test needed updating.
- Adds `UserSession` to the `shared` crate so the web client can deserialize the response without ad-hoc JSON poking.
- Closes hangrier_games-p9p0.

## Verification

- `cargo fmt --all && cargo clippy --workspace --tests -- -D warnings` clean
- `cargo test -p api --test auth_tests -- --test-threads=1` — 6/7 (only pre-existing `test_token_refresh` failure tracked in hangrier_games-lkxg)
- `cargo test -p api --test tributes_tests -- --test-threads=1` — 8/8
- `cargo test -p api --test games_tests -- --test-threads=1` — 8/12 (4 pre-existing lkxg failures: `test_create_game`, `test_game_areas`, `test_list_games`, `timeline_summary_includes_current_period_even_when_empty`)

💘 Generated with Crush

Assisted-by: Claude Sonnet 4.5 via Crush <crush@charm.land>