### PR TITLE
refactor(shared): type band-change events with HungerBand/ThirstBand enums

### DIFF
--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -1079,8 +1079,8 @@ impl Game {
                         line,
                         Some(MessagePayload::HungerBandChanged {
                             tribute: tref.clone(),
-                            from: format!("{:?}", prior_hunger),
-                            to: format!("{:?}", new_hunger),
+                            from: prior_hunger,
+                            to: new_hunger,
                         }),
                         None,
                     ));
@@ -1096,8 +1096,8 @@ impl Game {
                         line,
                         Some(MessagePayload::ThirstBandChanged {
                             tribute: tref.clone(),
-                            from: format!("{:?}", prior_thirst),
-                            to: format!("{:?}", new_thirst),
+                            from: prior_thirst,
+                            to: new_thirst,
                         }),
                         None,
                     ));
@@ -1140,8 +1140,8 @@ impl Game {
                             line,
                             Some(MessagePayload::StaminaBandChanged {
                                 tribute: tref.clone(),
-                                from: format!("{:?}", prior_band),
-                                to: format!("{:?}", new_band),
+                                from: prior_band,
+                                to: new_band,
                             }),
                             None,
                         ));

--- a/game/src/tributes/survival.rs
+++ b/game/src/tributes/survival.rs
@@ -1,26 +1,14 @@
-use serde::{Deserialize, Serialize};
-
 use crate::areas::weather::Weather;
 use crate::tributes::Tribute;
 
+// Wire-visible band enums live in the `shared` crate (they are serialised
+// in `MessagePayload::{Hunger,Thirst}BandChanged`). Re-export them here so
+// existing `game::tributes::survival::{HungerBand, ThirstBand}` imports
+// keep compiling.
+pub use shared::messages::{HungerBand, ThirstBand};
+
 const HIGH_ATTR_THRESHOLD: u32 = 75;
 const LOW_ATTR_THRESHOLD: u32 = 25;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum HungerBand {
-    Sated,
-    Peckish,
-    Hungry,
-    Starving,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum ThirstBand {
-    Sated,
-    Thirsty,
-    Parched,
-    Dehydrated,
-}
 
 pub fn hunger_band(value: u8) -> HungerBand {
     match value {

--- a/game/tests/stamina_combat_integration.rs
+++ b/game/tests/stamina_combat_integration.rs
@@ -3,7 +3,7 @@
 
 use game::games::Game;
 use game::tributes::Tribute;
-use shared::messages::MessagePayload;
+use shared::messages::{MessagePayload, StaminaBand};
 
 #[test]
 fn per_phase_loop_emits_stamina_band_changed_when_band_crosses() {
@@ -23,8 +23,8 @@ fn per_phase_loop_emits_stamina_band_changed_when_band_crosses() {
         matches!(&m.payload,
             MessagePayload::StaminaBandChanged { tribute, from, to }
                 if tribute.identifier == id
-                    && from == "Exhausted"
-                    && to == "Winded"
+                    && *from == StaminaBand::Exhausted
+                    && *to == StaminaBand::Winded
         )
     });
     assert!(

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -129,14 +129,86 @@ pub enum MessageKind {
 
 /// Visible fatigue band derived from a tribute's stamina/max_stamina ratio.
 /// Lives in `shared/` because it is wire-visible via
-/// `MessagePayload::StaminaBandChanged`. Mirror of the `HungerBand`/`ThirstBand`
-/// pattern (those live in `game::tributes::survival` because they are not
-/// directly serialised on the wire — band-changed events use `String`).
+/// `MessagePayload::StaminaBandChanged`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum StaminaBand {
     Fresh,
     Winded,
     Exhausted,
+}
+
+/// Visible hunger band derived from a tribute's hunger counter. Lives in
+/// `shared/` because it is wire-visible via
+/// `MessagePayload::HungerBandChanged`. The mapping (counter → band) lives
+/// in `game::tributes::survival::hunger_band`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum HungerBand {
+    Sated,
+    Peckish,
+    Hungry,
+    Starving,
+}
+
+/// Visible thirst band derived from a tribute's thirst counter. Lives in
+/// `shared/` because it is wire-visible via
+/// `MessagePayload::ThirstBandChanged`. The mapping (counter → band) lives
+/// in `game::tributes::survival::thirst_band`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ThirstBand {
+    Sated,
+    Thirsty,
+    Parched,
+    Dehydrated,
+}
+
+impl StaminaBand {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            StaminaBand::Fresh => "Fresh",
+            StaminaBand::Winded => "Winded",
+            StaminaBand::Exhausted => "Exhausted",
+        }
+    }
+}
+
+impl std::fmt::Display for StaminaBand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl HungerBand {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HungerBand::Sated => "Sated",
+            HungerBand::Peckish => "Peckish",
+            HungerBand::Hungry => "Hungry",
+            HungerBand::Starving => "Starving",
+        }
+    }
+}
+
+impl std::fmt::Display for HungerBand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl ThirstBand {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ThirstBand::Sated => "Sated",
+            ThirstBand::Thirsty => "Thirsty",
+            ThirstBand::Parched => "Parched",
+            ThirstBand::Dehydrated => "Dehydrated",
+        }
+    }
+}
+
+impl std::fmt::Display for ThirstBand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -237,18 +309,18 @@ pub enum MessagePayload {
     // Survival events (shelter + hunger/thirst spec).
     HungerBandChanged {
         tribute: TributeRef,
-        from: String,
-        to: String,
+        from: HungerBand,
+        to: HungerBand,
     },
     ThirstBandChanged {
         tribute: TributeRef,
-        from: String,
-        to: String,
+        from: ThirstBand,
+        to: ThirstBand,
     },
     StaminaBandChanged {
         tribute: TributeRef,
-        from: String,
-        to: String,
+        from: StaminaBand,
+        to: StaminaBand,
     },
     ShelterSought {
         tribute: TributeRef,
@@ -897,16 +969,16 @@ mod survival_event_tests {
     fn band_change_payloads_round_trip() {
         let p = MessagePayload::HungerBandChanged {
             tribute: tref(),
-            from: "Sated".into(),
-            to: "Hungry".into(),
+            from: HungerBand::Sated,
+            to: HungerBand::Hungry,
         };
         let back: MessagePayload =
             serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
         assert_eq!(format!("{:?}", p), format!("{:?}", back));
         let p = MessagePayload::ThirstBandChanged {
             tribute: tref(),
-            from: "Sated".into(),
-            to: "Parched".into(),
+            from: ThirstBand::Sated,
+            to: ThirstBand::Parched,
         };
         let back: MessagePayload =
             serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
@@ -917,8 +989,8 @@ mod survival_event_tests {
     fn stamina_band_change_round_trips_and_routes_to_state() {
         let p = MessagePayload::StaminaBandChanged {
             tribute: tref(),
-            from: "Fresh".into(),
-            to: "Winded".into(),
+            from: StaminaBand::Fresh,
+            to: StaminaBand::Winded,
         };
         let json = serde_json::to_string(&p).unwrap();
         let back: MessagePayload = serde_json::from_str(&json).unwrap();

--- a/web/src/components/timeline/cards/stamina_card.rs
+++ b/web/src/components/timeline/cards/stamina_card.rs
@@ -3,7 +3,7 @@
 //! See spec `docs/superpowers/specs/2026-05-03-stamina-combat-resource-design.md`.
 
 use dioxus::prelude::*;
-use shared::messages::{GameMessage, MessagePayload};
+use shared::messages::{GameMessage, MessagePayload, StaminaBand};
 
 #[derive(Props, PartialEq, Clone)]
 pub struct StaminaCardProps {
@@ -17,14 +17,11 @@ enum Direction {
     Unknown,
 }
 
-fn transition_direction(from: &str, to: &str) -> Direction {
+fn transition_direction(from: StaminaBand, to: StaminaBand) -> Direction {
+    use StaminaBand::*;
     match (from, to) {
-        ("Fresh", "Winded") | ("Fresh", "Exhausted") | ("Winded", "Exhausted") => {
-            Direction::Worsening
-        }
-        ("Winded", "Fresh") | ("Exhausted", "Fresh") | ("Exhausted", "Winded") => {
-            Direction::Recovery
-        }
+        (Fresh, Winded) | (Fresh, Exhausted) | (Winded, Exhausted) => Direction::Worsening,
+        (Winded, Fresh) | (Exhausted, Fresh) | (Exhausted, Winded) => Direction::Recovery,
         _ => Direction::Unknown,
     }
 }
@@ -35,7 +32,7 @@ pub fn StaminaCard(props: StaminaCardProps) -> Element {
         return rsx! {};
     };
 
-    let direction = transition_direction(from, to);
+    let direction = transition_direction(*from, *to);
     let (border_cls, bg_cls, glyph, phrase) = match (direction, to.as_str()) {
         (Direction::Worsening, "Winded") => (
             "border-amber-400",

--- a/web/src/components/timeline/cards/survival_card.rs
+++ b/web/src/components/timeline/cards/survival_card.rs
@@ -1,5 +1,5 @@
 use dioxus::prelude::*;
-use shared::messages::{GameMessage, MessagePayload};
+use shared::messages::{GameMessage, HungerBand, MessagePayload, ThirstBand};
 
 #[derive(Props, PartialEq, Clone)]
 pub struct SurvivalCardProps {
@@ -10,7 +10,7 @@ pub struct SurvivalCardProps {
 pub fn SurvivalCard(props: SurvivalCardProps) -> Element {
     match &props.message.payload {
         MessagePayload::HungerBandChanged { tribute, from, to } => {
-            let cls = hunger_class(to);
+            let cls = hunger_class(*to);
             rsx! {
                 article { class: "rounded border-l-4 border-amber-400 bg-amber-50 theme2:bg-amber-950/40 p-2 text-sm",
                     p {
@@ -23,7 +23,7 @@ pub fn SurvivalCard(props: SurvivalCardProps) -> Element {
             }
         }
         MessagePayload::ThirstBandChanged { tribute, from, to } => {
-            let cls = thirst_class(to);
+            let cls = thirst_class(*to);
             rsx! {
                 article { class: "rounded border-l-4 border-sky-400 bg-sky-50 theme2:bg-sky-950/40 p-2 text-sm",
                     p {
@@ -97,18 +97,18 @@ pub fn SurvivalCard(props: SurvivalCardProps) -> Element {
     }
 }
 
-fn hunger_class(band: &str) -> &'static str {
+fn hunger_class(band: HungerBand) -> &'static str {
     match band {
-        "Hungry" => "text-amber-600 theme2:text-amber-300",
-        "Starving" => "text-red-600 theme2:text-red-400 font-semibold",
+        HungerBand::Hungry => "text-amber-600 theme2:text-amber-300",
+        HungerBand::Starving => "text-red-600 theme2:text-red-400 font-semibold",
         _ => "text-stone-600 theme2:text-stone-300",
     }
 }
 
-fn thirst_class(band: &str) -> &'static str {
+fn thirst_class(band: ThirstBand) -> &'static str {
     match band {
-        "Parched" => "text-sky-600 theme2:text-sky-300",
-        "Dehydrated" => "text-red-600 theme2:text-red-400 font-semibold",
+        ThirstBand::Parched => "text-sky-600 theme2:text-sky-300",
+        ThirstBand::Dehydrated => "text-red-600 theme2:text-red-400 font-semibold",
         _ => "text-stone-600 theme2:text-stone-300",
     }
 }


### PR DESCRIPTION
## Summary

- Move `HungerBand` / `ThirstBand` from `game/src/tributes/survival.rs` into `shared/src/messages.rs` next to `StaminaBand`
- Change `HungerBandChanged` / `ThirstBandChanged` / `StaminaBandChanged` `from`/`to` fields from `String` to the typed enums (resolves the long-standing TODO at `shared/src/messages.rs:131-134`)
- Add `Display` + `as_str()` impls for all three bands so call sites that need a label don't have to `format!(\"{:?}\", …)` anymore

## Changes

- `shared/src/messages.rs` — new `HungerBand` / `ThirstBand` enums, `Display` + `as_str` for all three bands, typed payload fields, updated round-trip tests
- `game/src/tributes/survival.rs` — drop local enum defs; `pub use shared::messages::{HungerBand, ThirstBand}` so all existing imports keep compiling
- `game/src/games.rs` — pass `prior_*` / `new_*` band values directly into payloads instead of `format!(\"{:?}\", …)`
- `web/src/components/timeline/cards/{stamina,survival}_card.rs` — match on enum variants instead of strings
- `game/tests/stamina_combat_integration.rs` — assert against `StaminaBand::Exhausted` / `Winded` instead of strings

Wire format unchanged (Serde encodes the enum variants as the same strings the previous code emitted via `Debug`), so old snapshots and clients keep deserialising.

## Verification

```
cargo fmt --all
cargo clippy --workspace --tests -- -D warnings   # clean
cargo test -p shared                               # all pass
cargo test -p game                                 # all pass
cargo test -p api --test auth_tests --test games_tests --test tributes_tests -- --test-threads=1
```

API failures match the lkxg baseline (no new regressions).

Closes hangrier_games-2v67.

💘 Generated with Crush

Assisted-by: Claude Sonnet 4.5 via Crush <crush@charm.land>