### PR TITLE
ci: per-job rust-cache shared-keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          shared-key: ci-fmt
           cache-on-failure: true
       - name: Stub web/src/env.rs for fmt
         # web/build.rs would normally generate web/src/env.rs from APP_*
@@ -58,7 +58,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          shared-key: ci-clippy
           cache-on-failure: true
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -88,7 +88,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          shared-key: ci-test-game
           cache-on-failure: true
       - name: Test (game)
         run: cargo test --package game
@@ -104,7 +104,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          shared-key: ci-test-shared
           cache-on-failure: true
       - name: Test (shared)
         run: cargo test --package shared
@@ -120,7 +120,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          shared-key: ci-test-api
           cache-on-failure: true
       - name: Test (api integration)
         # api/tests/common/mod.rs spins up an in-memory SurrealDB per test


### PR DESCRIPTION
## Summary

All five CI jobs were sharing one rust-cache (`shared-key: ci`), so they raced to save it. Whichever job finished first wrote its `target/` over the others — and on the next run, slow jobs (notably `Test (api integration)`, which compiles its own per-test binaries) restored a `target/` populated by `clippy` or `Test (game)` and recompiled most crates from scratch.

PR233's `Test (api integration)` step ran for ~10 minutes despite tests themselves completing in ~1s; nearly all of that wall time was a redundant compile.

## Change

Give each job its own `shared-key` (`ci-fmt`, `ci-clippy`, `ci-test-game`, `ci-test-shared`, `ci-test-api`). Each job now restores and saves its own `target/` so subsequent runs of the same job get a warm incremental cache.

First post-merge run on each job will be a cold build; runs after that should be substantially faster, with `Test (api integration)` benefitting most.

## Verification

- `actionlint`-style review of workflow file (5 jobs, each with a distinct shared-key, aggregate `Quality` job unchanged).
- Will validate end-to-end on the PR's own CI.

## Follow-ups

- If a future job needs to share artifacts with another, switch them back to the same shared-key intentionally.