### PR TITLE
engine(sleep): brain scoring + sleep tick + natural wake (bd-9sjj)

### DIFF
--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -19,6 +19,18 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use uuid::Uuid;
 
+/// Stamina restored per phase to a sleeping tribute (PR2c.1, bd-9sjj).
+/// Placeholder pending observability tuning per spec
+/// `2026-05-03-four-phase-day-design.md` §6.4.
+const SLEEP_STAMINA_PER_PHASE: u32 = 25;
+/// HP restored per phase to a sleeping tribute, gated on absence of
+/// Wounded / Infected / Sick.
+const SLEEP_HP_PER_PHASE: u32 = 5;
+/// Soft cap for sleep-driven HP regen so it never exceeds the natural
+/// 100-point ceiling. (Tributes' `attributes.health` is `u32` without an
+/// explicit per-tribute max field.)
+const SLEEP_HP_CAP: u32 = 100;
+
 /// Errors that can occur during game operations.
 #[derive(Debug, Clone, PartialEq)]
 pub enum GameError {
@@ -198,6 +210,11 @@ type CollectedEvent = (
 struct CycleContext {
     /// True for the day half of the cycle, false for night.
     is_day: bool,
+    /// Full four-phase value (Dawn / Day / Dusk / Night) for this cycle.
+    /// Threaded through to `EnvironmentContext` and the sleep tick handler
+    /// so brain scoring and `TributeSlept` / `TributeWoke` payloads see the
+    /// real phase rather than reconstructing it from `is_day`.
+    phase: crate::messages::Phase,
     /// Current game day (1-indexed). Mirrors `Game::day.unwrap_or(1)` and
     /// is forwarded into `EnvironmentContext::current_day`.
     current_day: u32,
@@ -1053,6 +1070,7 @@ impl Game {
 
         CycleContext {
             is_day: day,
+            phase,
             current_day: self.day.unwrap_or(1),
             action_suggestion,
             area_details_map,
@@ -1073,6 +1091,7 @@ impl Game {
     fn execute_cycle(&mut self, ctx: CycleContext, rng: &mut SmallRng) -> Result<(), GameError> {
         let CycleContext {
             is_day: day,
+            phase,
             current_day,
             action_suggestion,
             area_details_map,
@@ -1264,6 +1283,70 @@ impl Game {
                 }
             }
 
+            // Sleep tick (PR2c.1, bd-9sjj). Sleeping tributes skip the
+            // brain pipeline entirely: regen stamina (always) and HP
+            // (gated on absence of Wounded / Infected / Sick per spec
+            // §6.4), then decrement `sleep_remaining`. When the
+            // countdown drains to zero, flip `sleeping = false`, reset
+            // `cycles_awake`, and emit `TributeWoke { Rested }`.
+            // Interruption handling lives in PR2c.2 (bd-1zju); this PR
+            // ships the natural-wake path only.
+            if tribute.sleeping {
+                use crate::messages::{MessagePayload, TributeRef};
+                use shared::messages::WakeReason;
+
+                let blocked = matches!(
+                    tribute.status,
+                    TributeStatus::Wounded | TributeStatus::Infected | TributeStatus::Sick
+                );
+                let prior_stamina = tribute.stamina;
+                let prior_hp = tribute.attributes.health;
+                tribute.stamina = tribute
+                    .stamina
+                    .saturating_add(SLEEP_STAMINA_PER_PHASE)
+                    .min(tribute.max_stamina);
+                if !blocked {
+                    tribute.attributes.health = tribute
+                        .attributes
+                        .health
+                        .saturating_add(SLEEP_HP_PER_PHASE)
+                        .min(SLEEP_HP_CAP);
+                }
+                let restored_stamina = tribute.stamina.saturating_sub(prior_stamina);
+                let restored_hp = tribute.attributes.health.saturating_sub(prior_hp);
+
+                // The TributeSlept emission for the *entry* phase happens
+                // in process_turn_phase. Each subsequent phase the sleeper
+                // is silent except for the final TributeWoke; we do not
+                // re-emit per-phase regen events to avoid log spam. The
+                // restored_* totals are consumed by the consolidated
+                // TributeWoke payload.
+                tribute.sleep_remaining = tribute.sleep_remaining.saturating_sub(1);
+                if tribute.sleep_remaining == 0 {
+                    tribute.sleeping = false;
+                    tribute.cycles_awake = 0;
+                    let tref = TributeRef {
+                        identifier: tribute.identifier.clone(),
+                        name: tribute.name.clone(),
+                    };
+                    let line = crate::output::GameOutput::TributeWakesRested(tribute.name.as_str())
+                        .to_string();
+                    collected_events.push((
+                        tribute.identifier.clone(),
+                        tribute.name.clone(),
+                        line,
+                        Some(MessagePayload::TributeWoke {
+                            tribute: tref,
+                            phase,
+                            reason: WakeReason::Rested,
+                        }),
+                        None,
+                    ));
+                }
+                let _ = (restored_stamina, restored_hp);
+                continue;
+            }
+
             let area_index = match area_details_map.get(&tribute.area) {
                 Some(&idx) => idx,
                 None => continue,
@@ -1299,6 +1382,7 @@ impl Game {
 
             let mut environment_details = EnvironmentContext {
                 is_day: day,
+                phase,
                 area_details,
                 closed_areas: &closed_areas,
                 available_destinations,
@@ -2997,5 +3081,94 @@ mod tests {
                 MessagePayload::TributeKilled { cause, .. } if cause == CAUSE_DEHYDRATION)
         });
         assert!(killed, "expected a TributeKilled with cause=dehydration");
+    }
+
+    // ---- Sleep tick (PR2c.1, bd-9sjj) ----
+
+    #[test]
+    fn sleeping_tribute_naturally_wakes_after_duration_emits_tribute_woke() {
+        use crate::messages::{MessagePayload, Phase};
+        let mut t = create_tribute("Sleeper", true);
+        t.sleeping = true;
+        t.sleep_remaining = 1;
+        t.cycles_awake = 9;
+        t.stamina = 50;
+        let mut game = create_test_game_with_tributes(vec![t.clone()]);
+        let area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
+        game.areas.push(area);
+        let mut rng = SmallRng::from_rng(&mut rand::rng());
+        let _ = game.run_tribute_cycle(Phase::Night, &mut rng, vec![], vec![t], 1);
+
+        let woken = &game.tributes[0];
+        assert!(!woken.sleeping, "tribute should be awake");
+        assert_eq!(woken.sleep_remaining, 0);
+        assert_eq!(woken.cycles_awake, 0, "natural wake resets cycles_awake");
+
+        let woke = game.messages.iter().any(|m| {
+            matches!(
+                &m.payload,
+                MessagePayload::TributeWoke {
+                    reason: shared::messages::WakeReason::Rested,
+                    ..
+                }
+            )
+        });
+        assert!(woke, "expected a TributeWoke{{Rested}} message");
+    }
+
+    #[test]
+    fn sleeping_tribute_regenerates_stamina_each_phase() {
+        use crate::messages::Phase;
+        let mut t = create_tribute("Sleeper", true);
+        t.sleeping = true;
+        t.sleep_remaining = 3; // multi-phase sleep
+        t.stamina = 10;
+        t.max_stamina = 100;
+        let prior = t.stamina;
+        let mut game = create_test_game_with_tributes(vec![t.clone()]);
+        let area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
+        game.areas.push(area);
+        let mut rng = SmallRng::from_rng(&mut rand::rng());
+        let _ = game.run_tribute_cycle(Phase::Night, &mut rng, vec![], vec![t], 1);
+
+        let after = &game.tributes[0];
+        assert!(after.sleeping, "still mid-sleep");
+        assert_eq!(after.sleep_remaining, 2);
+        assert!(after.stamina > prior, "stamina should regen");
+    }
+
+    #[test]
+    fn sleeping_wounded_tribute_does_not_regen_hp() {
+        use crate::messages::Phase;
+        let mut t = create_tribute("Sleeper", true);
+        t.sleeping = true;
+        t.sleep_remaining = 3;
+        t.attributes.health = 40;
+        t.status = TributeStatus::Wounded;
+        let prior_hp = t.attributes.health;
+        let mut game = create_test_game_with_tributes(vec![t.clone()]);
+        let area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
+        game.areas.push(area);
+        let mut rng = SmallRng::from_rng(&mut rand::rng());
+        let _ = game.run_tribute_cycle(Phase::Night, &mut rng, vec![], vec![t], 1);
+        assert_eq!(
+            game.tributes[0].attributes.health, prior_hp,
+            "wounded tributes do not heal while sleeping"
+        );
+    }
+
+    #[test]
+    fn cycles_awake_does_not_increment_while_sleeping() {
+        use crate::messages::Phase;
+        let mut t = create_tribute("Sleeper", true);
+        t.sleeping = true;
+        t.sleep_remaining = 3;
+        t.cycles_awake = 4;
+        let mut game = create_test_game_with_tributes(vec![t.clone()]);
+        let area = AreaDetails::new(Some("Lake".to_string()), Area::Cornucopia);
+        game.areas.push(area);
+        let mut rng = SmallRng::from_rng(&mut rand::rng());
+        let _ = game.run_tribute_cycle(Phase::Night, &mut rng, vec![], vec![t], 1);
+        assert_eq!(game.tributes[0].cycles_awake, 4);
     }
 }

--- a/game/src/output.rs
+++ b/game/src/output.rs
@@ -21,6 +21,10 @@ pub enum GameOutput<'a> {
     TributeWins(&'a str),
     TributeRest(&'a str),
     TributeLongRest(&'a str),
+    /// Tribute begins a multi-phase sleep (PR2c.1).
+    TributeSleeps(&'a str),
+    /// Tribute wakes naturally after their planned sleep duration elapses.
+    TributeWakesRested(&'a str),
     TributeHide(&'a str),
     TributeTravel(&'a str, &'a str, &'a str),
     TributeTakeItem(&'a str, &'a str),
@@ -136,6 +140,12 @@ impl<'a> Display for GameOutput<'a> {
                     "💤 {} rests and recovers a little health and sanity",
                     tribute
                 )
+            }
+            GameOutput::TributeSleeps(tribute) => {
+                write!(f, "😴 {} settles in to sleep", tribute)
+            }
+            GameOutput::TributeWakesRested(tribute) => {
+                write!(f, "🌅 {} wakes, well-rested", tribute)
             }
             GameOutput::TributeHide(tribute) => {
                 write!(f, "🫥 {} tries to hide", tribute)

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -11,6 +11,11 @@ use std::collections::HashMap;
 
 const LOW_ENEMY_LIMIT: u32 = 6;
 
+/// Sleep gating thresholds (PR2c.1, bd-9sjj). See `Brain::should_sleep`.
+const SLEEP_DOMINANT_THRESHOLD: u32 = 12;
+const SLEEP_WANT_THRESHOLD: u32 = 6;
+const SLEEP_EXHAUSTED_PCT: u32 = 25;
+
 /// Score penalty applied per enemy in a destination area, used by
 /// `Brain::choose_destination` to disperse crowded tributes.
 const CROWD_PENALTY_PER_ENEMY: i32 = 8;
@@ -479,6 +484,59 @@ impl Brain {
             }
             other => other,
         }
+    }
+
+    /// Phase-aware sleep gate (PR2c.1, bd-9sjj). Decides whether the
+    /// tribute should begin a multi-phase sleep *now*, returning
+    /// `Some(Action::Sleep { duration_phases })` to preempt the standard
+    /// brain pipeline, or `None` to defer to `act`.
+    ///
+    /// Conditions (per spec `2026-05-03-four-phase-day-design.md` §6.4):
+    /// - Already-sleeping tributes never re-enter the gate (they bypass
+    ///   `process_turn_phase` entirely via the engine's sleep tick).
+    /// - Tributes mid-psychotic-break cannot choose sleep.
+    /// - At/over the dominant wakefulness threshold (12+ phases),
+    ///   tributes sleep regardless of safety. Duration: 4 phases.
+    /// - At/over the want threshold (6+ phases) AND no nearby hostiles
+    ///   AND phase is Night or Dusk: sleep. Duration: 3 phases.
+    /// - Stamina exhausted (≤25% of max) AND no nearby hostiles AND
+    ///   non-Day phase: sleep. Duration: 2 phases.
+    pub fn should_sleep(
+        &self,
+        tribute: &Tribute,
+        nearby_tributes: u32,
+        phase: shared::messages::Phase,
+        _rng: &mut impl Rng,
+    ) -> Option<Action> {
+        use shared::messages::Phase;
+
+        if !tribute.is_alive() || tribute.sleeping {
+            return None;
+        }
+        if self.psychotic_break.is_some() {
+            return None;
+        }
+
+        let safe = nearby_tributes == 0;
+        let is_night_or_dusk = matches!(phase, Phase::Night | Phase::Dusk);
+        let is_day = matches!(phase, Phase::Day);
+
+        if tribute.cycles_awake >= SLEEP_DOMINANT_THRESHOLD {
+            return Some(Action::Sleep { duration_phases: 4 });
+        }
+
+        if tribute.cycles_awake >= SLEEP_WANT_THRESHOLD && safe && is_night_or_dusk {
+            return Some(Action::Sleep { duration_phases: 3 });
+        }
+
+        let stamina_pct = (tribute.stamina * 100)
+            .checked_div(tribute.max_stamina)
+            .unwrap_or(0);
+        if stamina_pct <= SLEEP_EXHAUSTED_PCT && safe && !is_day {
+            return Some(Action::Sleep { duration_phases: 2 });
+        }
+
+        None
     }
 
     /// Shared pre-decision override pipeline. Returns `Some(action)` to
@@ -1640,6 +1698,66 @@ mod tests {
             .expect("expected a destination");
         // Tie on "others" (0 vs 0): scoring order picks the first area.
         assert_eq!(chosen, Area::Sector1);
+    }
+
+    // ---- Sleep gating (PR2c.1, bd-9sjj) ----
+
+    #[rstest]
+    fn should_sleep_dominant_threshold_overrides_safety(tribute: Tribute, mut small_rng: SmallRng) {
+        use shared::messages::Phase;
+        let mut t = tribute.clone();
+        t.cycles_awake = SLEEP_DOMINANT_THRESHOLD;
+        let action = t.brain.should_sleep(&t, 5, Phase::Day, &mut small_rng);
+        assert!(matches!(action, Some(Action::Sleep { duration_phases: 4 })));
+    }
+
+    #[rstest]
+    fn should_sleep_want_threshold_requires_safety_and_night(
+        tribute: Tribute,
+        mut small_rng: SmallRng,
+    ) {
+        use shared::messages::Phase;
+        let mut t = tribute.clone();
+        t.cycles_awake = SLEEP_WANT_THRESHOLD;
+        let action = t.brain.should_sleep(&t, 0, Phase::Night, &mut small_rng);
+        assert!(matches!(action, Some(Action::Sleep { duration_phases: 3 })));
+        let action = t.brain.should_sleep(&t, 1, Phase::Night, &mut small_rng);
+        assert!(action.is_none());
+        let action = t.brain.should_sleep(&t, 0, Phase::Day, &mut small_rng);
+        assert!(action.is_none());
+    }
+
+    #[rstest]
+    fn should_sleep_exhausted_naps_when_safe_off_day(tribute: Tribute, mut small_rng: SmallRng) {
+        use shared::messages::Phase;
+        let mut t = tribute.clone();
+        t.cycles_awake = 1;
+        t.stamina = 10;
+        let action = t.brain.should_sleep(&t, 0, Phase::Dusk, &mut small_rng);
+        assert!(matches!(action, Some(Action::Sleep { duration_phases: 2 })));
+        let action = t.brain.should_sleep(&t, 0, Phase::Day, &mut small_rng);
+        assert!(action.is_none());
+    }
+
+    #[rstest]
+    fn should_sleep_psychotic_break_blocks_sleep(tribute: Tribute, mut small_rng: SmallRng) {
+        use shared::messages::Phase;
+        let mut t = tribute.clone();
+        t.cycles_awake = SLEEP_DOMINANT_THRESHOLD + 4;
+        t.brain.psychotic_break = Some(PsychoticBreakType::Berserk);
+        let action = t.brain.should_sleep(&t, 0, Phase::Night, &mut small_rng);
+        assert!(action.is_none());
+    }
+
+    #[rstest]
+    fn should_sleep_already_sleeping_returns_none(tribute: Tribute, mut small_rng: SmallRng) {
+        use shared::messages::Phase;
+        let mut t = tribute.clone();
+        t.sleeping = true;
+        t.sleep_remaining = 2;
+        t.cycles_awake = SLEEP_DOMINANT_THRESHOLD + 10;
+        let action = t.brain.should_sleep(&t, 0, Phase::Night, &mut small_rng);
+        assert!(action.is_none());
     }
 }
 

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -113,6 +113,9 @@ pub struct ActionSuggestion {
 #[derive(Debug)]
 pub struct EnvironmentContext<'a> {
     pub is_day: bool,
+    /// Full four-phase value for the current cycle. Used by sleep scoring
+    /// (Brain::should_sleep) and emitters (TributeSlept/TributeWoke).
+    pub phase: shared::messages::Phase,
     pub area_details: &'a mut AreaDetails,
     pub closed_areas: &'a [Area],
     pub available_destinations: Vec<crate::areas::DestinationInfo>,
@@ -474,15 +477,30 @@ impl Tribute {
 
         // Get tribute action
         let number_of_nearby_tributes = encounter_context.nearby_tributes_count;
-        let action = self.brain.act(
+        // Sleep gating (PR2c.1, bd-9sjj) runs before the standard brain
+        // pipeline so a needed sleep cleanly preempts attack / move /
+        // forage scoring. `Brain::should_sleep` is a phase-aware override
+        // that returns `Some(Action::Sleep { duration_phases })` when the
+        // tribute's wakefulness, stamina, and local-safety state warrant
+        // it. Psychotic-break tributes are excluded inside the helper.
+        let action = if let Some(sleep_action) = self.brain.should_sleep(
             self,
             number_of_nearby_tributes,
-            &environment_details.available_destinations,
-            environment_details.all_areas,
-            environment_details.closed_areas,
-            environment_details.enemy_density,
+            environment_details.phase,
             rng,
-        );
+        ) {
+            sleep_action
+        } else {
+            self.brain.act(
+                self,
+                number_of_nearby_tributes,
+                &environment_details.available_destinations,
+                environment_details.all_areas,
+                environment_details.closed_areas,
+                environment_details.enemy_density,
+                rng,
+            )
+        };
 
         let closed_areas = environment_details.closed_areas;
 
@@ -731,9 +749,27 @@ impl Tribute {
             | Action::DrinkFromTerrain
             | Action::Eat(_)
             | Action::DrinkItem(_) => {}
-            // Sleep is a substrate-only variant in PR2a; brain integration
-            // and emitters land in PR2c.
-            Action::Sleep { .. } => {}
+            // Sleep entry (PR2c.1, bd-9sjj). The brain has elected to begin
+            // a multi-phase sleep; flip the flag, prime the countdown, and
+            // emit `TributeSlept` with zeroed restoration counters. The
+            // engine's per-phase sleep tick (Game::execute_cycle) will
+            // perform the actual stamina/HP regen and emit `TributeWoke`
+            // when `sleep_remaining` drains to zero. Interruptions
+            // (ambush / area-event / alliance-summons) are bd-1zju /
+            // PR2c.2.
+            Action::Sleep { duration_phases } => {
+                self.sleeping = true;
+                self.sleep_remaining = *duration_phases;
+                events.push(TaggedEvent::new(
+                    GameOutput::TributeSleeps(self.name.as_str()).to_string(),
+                    MessagePayload::TributeSlept {
+                        tribute: tribute_ref(),
+                        phase: environment_details.phase,
+                        restored_stamina: 0,
+                        restored_hp: 0,
+                    },
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

PR2c.1 of the four-phase day epic (bd-xi0z under bd-uq7p). Builds on PR #237 (sleep substrate, bd-s0je) and PR #238 (per-area environmental conditions, bd-adid). Wires the brain to actually choose `Action::Sleep`, ticks sleeping tributes through the engine, and emits `TributeSlept` / `TributeWoke{Rested}`.

## Changes

- **`Brain::should_sleep`** (game/src/tributes/brains.rs): phase-aware sleep gate, called from `Tribute::process_turn_phase` before the standard brain pipeline. Three layered conditions per spec §6.4:
  - `cycles_awake >= 12` → sleep regardless of safety (4 phases)
  - `cycles_awake >= 6` + safe + Night/Dusk → sleep (3 phases)
  - stamina ≤25% + safe + non-Day → sleep (2 phases)
  - psychotic-break and already-sleeping tributes are excluded.
- **Sleep entry** (game/src/tributes/mod.rs): the `Action::Sleep` arm now sets `sleeping = true`, primes `sleep_remaining`, and emits `MessagePayload::TributeSlept`.
- **Sleep tick** (game/src/games.rs::execute_cycle): sleeping tributes skip the brain pipeline. Each phase the engine regens `SLEEP_STAMINA_PER_PHASE` (25) and, when not Wounded/Infected/Sick per spec §6.4, `SLEEP_HP_PER_PHASE` (5). `sleep_remaining` decrements; on hitting zero, `cycles_awake` resets and a `TributeWoke{Rested}` payload is emitted.
- **Phase plumbing**: `CycleContext` and `EnvironmentContext` now carry the full `Phase` (Dawn/Day/Dusk/Night), not just `is_day`, so brain scoring and sleep emitters can use it.
- **GameOutput**: new `TributeSleeps` and `TributeWakesRested` display variants for the human-readable lines.

## Test plan

- [x] `cargo test -p game --lib` — 715/715 pass (5 new brain `should_sleep_*` tests, 4 new engine sleep-tick tests).
- [x] `cargo test -p shared` — 33/33 pass.
- [x] `cargo test -p api --tests` — all green.
- [x] `cargo clippy --workspace --tests --exclude web -- -D warnings` — clean.
- [x] `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo clippy -p web --target wasm32-unknown-unknown -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

## Follow-ups

- **bd-1zju (PR2c.2)**: interruption resolution — ambush / area-event / alliance-summons emit `TributeWoke { Interrupted { event } }` and reset `sleeping = false`. Closes the bd-xi0z epic when merged.
- Tune `SLEEP_STAMINA_PER_PHASE` / `SLEEP_HP_PER_PHASE` once observability lands.