### PR TITLE
fix(web,api): same-origin dev via dx proxy (bd-jgxd)

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,8 @@
 ENV=development
-APP_API_HOST=http://127.0.0.1:3000
+# Empty so the web frontend issues relative URLs ("/api/...", "/ws") that hit
+# the dx serve proxy (configured in web/Dioxus.toml). Keeps dev same-origin so
+# HttpOnly auth cookies aren't dropped as third-party. See bd-jgxd.
+APP_API_HOST=
 SURREAL_HOST=ws://localhost:8000
 SURREAL_USER=root
 SURREAL_PASS=root

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 ENV=development
-APP_API_HOST=http://127.0.0.1:3000
+# Leave APP_API_HOST empty in dev so the web frontend issues relative URLs
+# ("/api/...", "/ws") that hit the dx serve proxy (web/Dioxus.toml). Keeps
+# dev same-origin so HttpOnly auth cookies aren't dropped as third-party.
+# In production, set this to the API origin (or leave empty if the frontend
+# is served from the same origin as the API). See bd-jgxd.
+APP_API_HOST=
 SURREAL_HOST=ws://localhost:8000
 SURREAL_USER=root
 SURREAL_PASS=root

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,13 +77,15 @@ just fmt
 Required `.env` at repo root (already exists):
 ```bash
 ENV=development
-APP_API_HOST=http://127.0.0.1:3000    # Frontend → API
+APP_API_HOST=                          # Empty in dev: relative URLs go through dx serve proxy
 SURREAL_HOST=ws://localhost:8000       # API → SurrealDB
 SURREAL_USER=root
 SURREAL_PASS=root
 ```
 
-**Frontend build.rs codegen**: Web crate reads `APP_*` env vars at build time and generates `src/env.rs`. Change requires rebuild.
+**Dev proxy**: `web/Dioxus.toml` declares `[[web.proxy]]` entries that forward `/api/*` and `/ws` from the dx dev server (`:8080`) to the API (`:3000`). This keeps frontend + backend same-origin so HttpOnly auth cookies aren't dropped as third-party. See bd-jgxd.
+
+**Frontend build.rs codegen**: Web crate reads `APP_*` env vars at build time and generates `src/env.rs`. When `APP_API_HOST` is empty, `crate::api_url::api_url()` derives the absolute URL from `window.location` at runtime (reqwest WASM requires absolute URLs).
 
 ## Critical Quirks
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -229,6 +229,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Cleanup scheduler initialized");
 
     let api_routes = Router::new()
+        .route(
+            "/version",
+            axum::routing::get(|| async { Json(env!("CARGO_PKG_VERSION")) }),
+        )
         .nest(
             "/games",
             GAMES_ROUTER.clone().layer(middleware::from_fn_with_state(

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1.0.149"
 tracing = "0.1.44"
 uuid = { version = "1.23.1", features = ["v4", "js", "serde"] }
 validator = { version = "0.20", features = ["derive"] }
-web-sys = { version = "0.3.97", features = ["console"] }
+web-sys = { version = "0.3.97", features = ["console", "Window", "Location"] }
 
 [build-dependencies]
 dotenvy = "0.15.7"

--- a/web/Dioxus.toml
+++ b/web/Dioxus.toml
@@ -36,3 +36,13 @@ script = []
 # Javascript code file
 # serve: [dev-server] only
 script = []
+
+# Proxy /api and /ws to the API server so the dev frontend is same-origin
+# with the backend. Keeps HttpOnly auth cookies out of third-party-cookie
+# territory (Chrome silently drops Set-Cookie on cross-origin responses with
+# 3p cookies blocked, which is the default). See bd-jgxd.
+[[web.proxy]]
+backend = "http://127.0.0.1:3000/api/"
+
+[[web.proxy]]
+backend = "http://127.0.0.1:3000/ws"

--- a/web/src/api_url.rs
+++ b/web/src/api_url.rs
@@ -1,0 +1,50 @@
+//! Build absolute API URLs.
+//!
+//! When [`APP_API_HOST`](crate::env::APP_API_HOST) is set at build time, the
+//! frontend uses it directly (production / Docker compose deploys). When it
+//! is empty (the default dev setup), we derive the origin from
+//! `window.location` so reqwest — which requires absolute URLs even on the
+//! WASM target — can issue requests to the same origin and hit the
+//! `dx serve` proxy declared in `web/Dioxus.toml`.
+//!
+//! See bd-jgxd: cross-origin Set-Cookie was being silently dropped as a
+//! third-party cookie, breaking auth on every dev session.
+
+use crate::env::APP_API_HOST;
+
+/// Build an absolute URL for an API path. `path` should start with `/api/...`
+/// or `/ws`. The result is suitable for `reqwest::Client::get` / `post`.
+pub fn api_url(path: &str) -> String {
+    let host = APP_API_HOST.trim_end_matches('/');
+    if !host.is_empty() {
+        return format!("{host}{path}");
+    }
+    format!("{}{path}", origin())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn origin() -> String {
+    web_sys::window()
+        .and_then(|w| w.location().origin().ok())
+        .unwrap_or_default()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn origin() -> String {
+    // Host-target tests don't have a window.
+    "http://localhost".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_host_falls_back_to_origin() {
+        // APP_API_HOST is generated at build time; the cargo-test build sees
+        // whatever .env contains. Just assert the URL ends with the path.
+        let u = api_url("/api/games");
+        assert!(u.ends_with("/api/games"), "got {u}");
+        assert!(u.starts_with("http"), "got {u}");
+    }
+}

--- a/web/src/components/accounts.rs
+++ b/web/src/components/accounts.rs
@@ -1,6 +1,5 @@
 use crate::cache::MutationError;
 use crate::components::{Input, ThemedButton};
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use crate::routes::Routes;
 use crate::storage::{AppState, use_persistent};
@@ -25,7 +24,7 @@ impl MutationCapability for RegisterUserM {
         });
 
         match client
-            .post(format!("{}/api/users", APP_API_HOST))
+            .post(crate::api_url::api_url("/api/users"))
             .with_credentials()
             .json(&json_body)
             .send()
@@ -72,7 +71,7 @@ impl MutationCapability for LoginUserM {
         });
 
         match client
-            .post(format!("{}/api/users/authenticate", APP_API_HOST))
+            .post(crate::api_url::api_url("/api/users/authenticate"))
             .with_credentials()
             .json(&json_body)
             .send()
@@ -415,7 +414,7 @@ fn LogoutButton() -> Element {
 
                 spawn(async move {
                     let _ = reqwest::Client::new()
-                        .post(format!("{}/api/auth/logout", APP_API_HOST))
+                        .post(crate::api_url::api_url("/api/auth/logout"))
                         .with_credentials()
                         .send()
                         .await;

--- a/web/src/components/area_detail.rs
+++ b/web/src/components/area_detail.rs
@@ -3,7 +3,6 @@ use crate::components::icons::lock_closed::LockClosedIcon;
 use crate::components::icons::lock_open::LockOpenIcon;
 use crate::components::icons::uturn::UTurnIcon;
 use crate::components::item_icon::ItemIcon;
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use crate::routes::Routes;
 use dioxus::prelude::*;
@@ -24,10 +23,10 @@ impl QueryCapability for AreaDetailQ {
         let request = client
             .request(
                 reqwest::Method::GET,
-                format!(
-                    "{}/api/games/{}/areas/{}",
-                    APP_API_HOST, game_identifier, area_identifier
-                ),
+                crate::api_url::api_url(&format!(
+                    "/api/games/{}/areas/{}",
+                    game_identifier, area_identifier
+                )),
             )
             .with_credentials();
         match request.send().await {

--- a/web/src/components/create_game.rs
+++ b/web/src/components/create_game.rs
@@ -2,7 +2,6 @@ use crate::LoadingState;
 use crate::cache::MutationError;
 use crate::components::games_list::GamesListQ;
 use crate::components::{Input, ThemedButton};
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use crate::routes::Routes;
 use dioxus::prelude::*;
@@ -29,7 +28,7 @@ impl MutationCapability for CreateGameM {
         };
 
         let response = client
-            .request(reqwest::Method::POST, format!("{}/api/games", APP_API_HOST))
+            .request(reqwest::Method::POST, crate::api_url::api_url("/api/games"))
             .with_credentials()
             .json(&json_body);
 

--- a/web/src/components/game_areas.rs
+++ b/web/src/components/game_areas.rs
@@ -3,7 +3,6 @@ use crate::components::icons::lock_closed::LockClosedIcon;
 use crate::components::icons::lock_open::LockOpenIcon;
 use crate::components::item_icon::ItemIcon;
 use crate::components::map::Map;
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
@@ -23,7 +22,7 @@ impl QueryCapability for GameAreasQ {
         let request = client
             .request(
                 reqwest::Method::GET,
-                format!("{}/api/games/{}/areas", APP_API_HOST, identifier),
+                crate::api_url::api_url(&format!("/api/games/{}/areas", identifier)),
             )
             .with_credentials();
         match request.send().await {

--- a/web/src/components/game_delete.rs
+++ b/web/src/components/game_delete.rs
@@ -2,7 +2,6 @@ use crate::cache::MutationError;
 use crate::components::Button;
 use crate::components::games_list::GamesListQ;
 use crate::components::icons::delete::DeleteIcon;
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
@@ -21,7 +20,7 @@ impl MutationCapability for DeleteGameM {
         let identifier = args.0.clone();
         let name = args.1.clone();
         let client = reqwest::Client::new();
-        let url: String = format!("{}/api/games/{}", APP_API_HOST, identifier);
+        let url: String = crate::api_url::api_url(&format!("/api/games/{}", identifier));
         let response = client.delete(url).with_credentials().send().await;
         match response {
             Ok(r) if r.status().is_success() => Ok((identifier, name)),

--- a/web/src/components/game_detail.rs
+++ b/web/src/components/game_detail.rs
@@ -9,7 +9,6 @@ use crate::components::info_detail::InfoDetail;
 use crate::components::period_grid::PeriodGrid;
 use crate::components::recap_card::RecapCard;
 use crate::components::timeline::PeriodFilters;
-use crate::env::APP_API_HOST;
 use crate::hooks::use_timeline_summary::use_timeline_summary;
 use crate::hooks::{ConnectionState, use_game_websocket};
 use crate::http::WithCredentials;
@@ -33,7 +32,7 @@ impl QueryCapability for DisplayGameQ {
         let request = client
             .request(
                 reqwest::Method::GET,
-                format!("{}/api/games/{}/display", APP_API_HOST, identifier),
+                crate::api_url::api_url(&format!("/api/games/{}/display", identifier)),
             )
             .with_credentials();
         match request.send().await {
@@ -89,7 +88,7 @@ impl MutationCapability for NextStepM {
     async fn run(&self, args: &String) -> Result<NextStepResult, MutationError> {
         let identifier = args.clone();
         let client = reqwest::Client::new();
-        let url: String = format!("{}/api/games/{}/next", APP_API_HOST, identifier);
+        let url: String = crate::api_url::api_url(&format!("/api/games/{}/next", identifier));
         let request = client.request(reqwest::Method::PUT, url).with_credentials();
         match request.send().await {
             Ok(response) => match response.status() {

--- a/web/src/components/game_edit.rs
+++ b/web/src/components/game_edit.rs
@@ -4,7 +4,6 @@ use crate::components::games_list::GamesListQ;
 use crate::components::icons::edit::EditIcon;
 use crate::components::modal::{Modal, Props as ModalProps};
 use crate::components::{Button, Input};
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
@@ -21,7 +20,7 @@ impl MutationCapability for EditGameM {
     async fn run(&self, args: &EditGame) -> Result<String, MutationError> {
         let identifier = args.identifier.clone();
         let client = reqwest::Client::new();
-        let url: String = format!("{}/api/games/{}", APP_API_HOST, identifier);
+        let url: String = crate::api_url::api_url(&format!("/api/games/{}", identifier));
         let response = client
             .put(url)
             .with_credentials()

--- a/web/src/components/game_period_page.rs
+++ b/web/src/components/game_period_page.rs
@@ -8,7 +8,6 @@ use crate::cache::QueryError;
 use crate::components::TributeFilterChips;
 use crate::components::filter_chips::FilterChips;
 use crate::components::timeline::{FilterMode, PeriodFilters, Timeline};
-use crate::env::APP_API_HOST;
 use crate::hooks::use_timeline_summary::use_timeline_summary;
 use crate::http::WithCredentials;
 use crate::routes::Routes;
@@ -27,7 +26,7 @@ impl QueryCapability for DayLogQ {
 
     async fn run(&self, keys: &(String, u32)) -> Result<Vec<GameMessage>, QueryError> {
         let (id, day) = keys;
-        let url = format!("{APP_API_HOST}/api/games/{id}/log/{day}");
+        let url = crate::api_url::api_url(&format!("/api/games/{id}/log/{day}"));
         let resp = reqwest::Client::new()
             .get(&url)
             .with_credentials()

--- a/web/src/components/game_tributes.rs
+++ b/web/src/components/game_tributes.rs
@@ -5,7 +5,6 @@ use crate::components::item_icon::ItemIcon;
 use crate::components::tribute_edit::TributeEdit;
 use crate::components::tribute_state_strip::TributeStateStrip;
 use crate::components::tribute_status_icon::TributeStatusIcon;
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use crate::routes::Routes;
 use dioxus::prelude::*;
@@ -34,10 +33,10 @@ impl QueryCapability for GameTributesQ {
         let request = client
             .request(
                 reqwest::Method::GET,
-                format!(
-                    "{}/api/games/{}/tributes?limit=24&offset=0",
-                    APP_API_HOST, game_identifier
-                ),
+                crate::api_url::api_url(&format!(
+                    "/api/games/{}/tributes?limit=24&offset=0",
+                    game_identifier
+                )),
             )
             .with_credentials();
         match request.send().await {

--- a/web/src/components/games_list.rs
+++ b/web/src/components/games_list.rs
@@ -3,7 +3,6 @@ use crate::components::game_edit::GameEdit;
 use crate::components::icons::eye_closed::EyeClosedIcon;
 use crate::components::icons::eye_open::EyeOpenIcon;
 use crate::components::{Button, CreateGameButton, CreateGameForm, DeleteGameModal, GameDelete};
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use crate::routes::Routes;
 use dioxus::prelude::*;
@@ -30,7 +29,7 @@ impl QueryCapability for GamesListQ {
         let request = client
             .request(
                 reqwest::Method::GET,
-                format!("{}/api/games?limit=20&offset=0", APP_API_HOST),
+                crate::api_url::api_url("/api/games?limit=20&offset=0"),
             )
             .with_credentials();
 

--- a/web/src/components/item_detail.rs
+++ b/web/src/components/item_detail.rs
@@ -1,7 +1,6 @@
 use crate::cache::QueryError;
 use crate::components::icons::uturn::UTurnIcon;
 use crate::components::item_icon::ItemIcon;
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use crate::routes::Routes;
 use dioxus::prelude::*;
@@ -22,10 +21,10 @@ impl QueryCapability for ItemDetailQ {
         let request = client
             .request(
                 reqwest::Method::GET,
-                format!(
-                    "{}/api/games/{}/items/{}",
-                    APP_API_HOST, game_identifier, item_identifier
-                ),
+                crate::api_url::api_url(&format!(
+                    "/api/games/{}/items/{}",
+                    game_identifier, item_identifier
+                )),
             )
             .with_credentials();
         match request.send().await {

--- a/web/src/components/server_version.rs
+++ b/web/src/components/server_version.rs
@@ -1,4 +1,3 @@
-use crate::env::APP_API_HOST;
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
 
@@ -12,7 +11,10 @@ impl QueryCapability for ServerVersionQ {
 
     async fn run(&self, _keys: &()) -> Result<String, ()> {
         let client = reqwest::Client::new();
-        let request = client.request(reqwest::Method::GET, APP_API_HOST.to_string());
+        let request = client.request(
+            reqwest::Method::GET,
+            crate::api_url::api_url("/api/version"),
+        );
         match request.send().await {
             Ok(response) => match response.json::<String>().await {
                 Ok(version) => Ok(version),

--- a/web/src/components/tribute_delete.rs
+++ b/web/src/components/tribute_delete.rs
@@ -1,6 +1,5 @@
 use crate::cache::MutationError;
 use crate::components::game_tributes::GameTributesQ;
-use crate::env::APP_API_HOST;
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
 use game::games::GAME;
@@ -18,10 +17,10 @@ impl MutationCapability for DeleteTributeM {
     async fn run(&self, name: &String) -> Result<String, MutationError> {
         let game_name = GAME.with_borrow(|g| g.name.clone());
         let client = reqwest::Client::new();
-        let url: String = format!(
-            "{}/api/games/{}/tributes/{}",
-            APP_API_HOST, game_name, name
-        );
+        let url: String = crate::api_url::api_url(&format!(
+            "/api/games/{}/tributes/{}",
+            game_name, name
+        ));
         let response = client.delete(url).send().await;
         match response {
             Ok(r) if r.status().is_success() => Ok(name.clone()),

--- a/web/src/components/tribute_detail.rs
+++ b/web/src/components/tribute_detail.rs
@@ -5,7 +5,6 @@ use crate::components::info_detail::InfoDetail;
 use crate::components::item_icon::ItemIcon;
 use crate::components::tribute_status_icon::TributeStatusIcon;
 use crate::components::tribute_survival_section::TributeSurvivalSection;
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use crate::routes::Routes;
 use dioxus::prelude::*;
@@ -29,10 +28,10 @@ impl QueryCapability for TributeQ {
         let request = client
             .request(
                 reqwest::Method::GET,
-                format!(
-                    "{}/api/games/{}/tributes/{}",
-                    APP_API_HOST, game_identifier, tribute_identifier
-                ),
+                crate::api_url::api_url(&format!(
+                    "/api/games/{}/tributes/{}",
+                    game_identifier, tribute_identifier
+                )),
             )
             .with_credentials();
         match request.send().await {
@@ -65,10 +64,10 @@ impl QueryCapability for TributeLogQ {
         let request = client
             .request(
                 reqwest::Method::GET,
-                format!(
-                    "{}/api/games/{}/tributes/{}/log",
-                    APP_API_HOST, game_identifier, identifier
-                ),
+                crate::api_url::api_url(&format!(
+                    "/api/games/{}/tributes/{}/log",
+                    game_identifier, identifier
+                )),
             )
             .with_credentials();
         match request.send().await {

--- a/web/src/components/tribute_edit.rs
+++ b/web/src/components/tribute_edit.rs
@@ -4,7 +4,6 @@ use crate::components::icons::edit::EditIcon;
 use crate::components::modal::{Modal, Props as ModalProps};
 use crate::components::tribute_detail::TributeQ;
 use crate::components::{Button, Input};
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
@@ -23,10 +22,10 @@ impl MutationCapability for EditTributeM {
         let identifier = tribute.identifier.clone();
         let game_identifier = args.1.clone();
         let client = reqwest::Client::new();
-        let url: String = format!(
-            "{}/api/games/{}/tributes/{}",
-            APP_API_HOST, game_identifier, identifier
-        );
+        let url: String = crate::api_url::api_url(&format!(
+            "/api/games/{}/tributes/{}",
+            game_identifier, identifier
+        ));
         let response = client
             .put(url)
             .with_credentials()
@@ -174,10 +173,10 @@ pub fn EditTributeForm() -> Element {
                 let file_data = bytes.to_vec();
 
                 let client = reqwest::Client::new();
-                let url = format!(
-                    "{}/api/games/{}/tributes/{}/avatar",
-                    APP_API_HOST, game_id, tribute_id
-                );
+                let url = crate::api_url::api_url(&format!(
+                    "/api/games/{}/tributes/{}/avatar",
+                    game_id, tribute_id
+                ));
 
                 let part = reqwest::multipart::Part::bytes(file_data).file_name(file_name.clone());
 

--- a/web/src/hooks/use_game_websocket.rs
+++ b/web/src/hooks/use_game_websocket.rs
@@ -122,8 +122,16 @@ pub fn use_game_websocket(game_id: String) -> (Signal<Vec<GameMessage>>, Signal<
 }
 
 /// Convert an `http(s)://host[/path]` API host into a `ws(s)://host/ws` URL.
+///
+/// When `api_host` is empty, derive the WS endpoint from the current page
+/// origin (`window.location`). Used by the dev setup where the dx server
+/// proxies `/api` and `/ws` to the API, so the frontend issues all
+/// requests same-origin and avoids cross-origin third-party-cookie blocks.
 pub(crate) fn build_ws_url(api_host: &str, _game_id: &str) -> String {
     let base = api_host.trim_end_matches('/');
+    if base.is_empty() {
+        return same_origin_ws_url();
+    }
     let ws_base = if let Some(rest) = base.strip_prefix("https://") {
         format!("wss://{}", rest)
     } else if let Some(rest) = base.strip_prefix("http://") {
@@ -133,6 +141,24 @@ pub(crate) fn build_ws_url(api_host: &str, _game_id: &str) -> String {
         base.to_string()
     };
     format!("{}/ws", ws_base)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn same_origin_ws_url() -> String {
+    let location = web_sys::window()
+        .and_then(|w| w.location().host().ok())
+        .unwrap_or_default();
+    let proto = web_sys::window()
+        .and_then(|w| w.location().protocol().ok())
+        .unwrap_or_default();
+    let scheme = if proto == "https:" { "wss" } else { "ws" };
+    format!("{scheme}://{location}/ws")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn same_origin_ws_url() -> String {
+    // Host-target tests don't have a window; default to localhost.
+    "ws://localhost/ws".to_string()
 }
 
 #[cfg(test)]
@@ -176,5 +202,14 @@ mod tests {
     fn unknown_scheme_passthrough() {
         // No http/https prefix and no ws prefix: caller's string is taken as-is.
         assert_eq!(build_ws_url("localhost:3000", "g"), "localhost:3000/ws");
+    }
+
+    #[test]
+    fn empty_host_falls_back_to_same_origin() {
+        // Host-target build returns the test stub; the wasm path is exercised
+        // in-browser. Assert non-empty and well-formed.
+        let url = build_ws_url("", "g");
+        assert!(url.starts_with("ws"), "got {url}");
+        assert!(url.ends_with("/ws"), "got {url}");
     }
 }

--- a/web/src/hooks/use_timeline_summary.rs
+++ b/web/src/hooks/use_timeline_summary.rs
@@ -1,5 +1,4 @@
 use crate::cache::QueryError;
-use crate::env::APP_API_HOST;
 use crate::http::WithCredentials;
 use dioxus_query::prelude::*;
 use reqwest::StatusCode;
@@ -14,7 +13,7 @@ impl QueryCapability for TimelineSummaryQ {
     type Keys = String;
 
     async fn run(&self, id: &String) -> Result<TimelineSummary, QueryError> {
-        let url = format!("{APP_API_HOST}/api/games/{id}/timeline-summary");
+        let url = crate::api_url::api_url(&format!("/api/games/{id}/timeline-summary"));
         let resp = reqwest::Client::new()
             .get(&url)
             .with_credentials()

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+pub mod api_url;
 mod cache;
 pub mod components;
 pub(crate) mod env;


### PR DESCRIPTION
## Summary

Fix the dev auth trap: even after a successful login, clicking **Quickstart** (or anything that called the API) returned 401 and redirected the user to the AccountsPage's LogoutButton view, with no `hg_session` cookie stored anywhere in the browser.

## Root cause

The frontend dev server runs at `127.0.0.1:8080` and the API at `127.0.0.1:3000` — different ports → different origins. The `Set-Cookie` response from `POST /api/users/authenticate` was therefore a third-party cookie, and Chrome (with 3p cookies blocked, the default in 2024+) silently discards it. Every subsequent request was unauthenticated.

## Fix

Make dev same-origin by proxying API + WS through dx serve:

- **`web/Dioxus.toml`**: declare `[[web.proxy]]` entries forwarding `/api/*` and `/ws` to `http://127.0.0.1:3000`.
- **`.env` / `.env.example`**: `APP_API_HOST=""` (empty) so the frontend issues relative URLs that hit the proxy.
- **`web/src/api_url.rs`** (new): `api_url(path)` helper. When `APP_API_HOST` is empty it derives the absolute URL from `window.location` (reqwest WASM requires absolute URLs).
- **`web/src/hooks/use_game_websocket.rs`**: `build_ws_url` falls back to `window.location` when the api_host is empty.
- **`api/src/main.rs`**: add `/api/version` route so the proxied ServerVersion component still works (the existing `/` version route isn't reachable through the `/api` proxy).
- All `format!("{}/api/...", APP_API_HOST, ...)` callsites in `web/` rewritten to `crate::api_url::api_url(&format!("/api/...", ...))`.
- **`AGENTS.md`**: document the proxy and the new env contract.

## Verification

- `cargo fmt --all`
- `cargo clippy --workspace --tests --exclude web -- -D warnings` ✅
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo clippy -p web --target wasm32-unknown-unknown --tests -- -D warnings` ✅
- `cargo test -p web --lib` ✅ (27 passed)
- `cargo test -p api --tests` ✅
- Manual reproduction: log in, click Quickstart — game is created, no 401.

## Notes

Production deploys (Docker compose, single ingress) are already same-origin so prod behavior is unchanged. The `/api/version` route is additive; the existing root `/` version route is left intact for direct API consumers.