### PR TITLE
feat(game): add phase parameter to brain pipeline + message coalescing

### DIFF
--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -1534,10 +1534,32 @@ impl Game {
     /// Per-event `emit_index` (advanced inside `push_message`) preserves
     /// intra-tribute ordering. Sites carrying a typed `MessagePayload` push
     /// that payload directly; legacy stringly sites synthesise a fallback.
+    ///
+    /// Message coalescing (spec §11.5): repeated `MovedTo` events for the
+    /// same area within a phase collapse into a single emission — only the
+    /// first is kept, duplicates are silently dropped.
     fn flush_tribute_events(&mut self, collected_events: Vec<CollectedEvent>) {
+        use crate::messages::MessagePayload;
+
         let mut last_identifier: Option<String> = None;
         let mut current_tick: u32 = self.tick_counter.boundary();
+        // Track last MovedTo area per tribute for coalescing.
+        let mut last_move_area: HashMap<String, String> = HashMap::new();
+
         for (identifier, _name, content, payload, _event) in collected_events {
+            // Coalesce: skip TributeMoved if same destination as last move for this tribute.
+            if let Some(MessagePayload::TributeMoved { to: dest_area, .. }) = &payload
+                && let Some(last_area) = last_move_area.get(&identifier)
+                && last_area == &dest_area.name
+            {
+                continue;
+            }
+
+            // Record the destination area for future coalescing.
+            if let Some(MessagePayload::TributeMoved { to: dest_area, .. }) = &payload {
+                last_move_area.insert(identifier.clone(), dest_area.name.clone());
+            }
+
             if last_identifier.as_ref() != Some(&identifier) {
                 current_tick = self.tick_counter.next();
                 last_identifier = Some(identifier.clone());

--- a/game/src/tributes/brains.rs
+++ b/game/src/tributes/brains.rs
@@ -243,9 +243,12 @@ impl Brain {
         all_areas: &[AreaDetails],
         closed_areas: &[Area],
         enemy_density: &HashMap<Area, u32>,
+        phase: shared::messages::Phase,
         rng: &mut impl Rng,
     ) -> Action {
-        if let Some(early) = self.run_pre_decision_overrides(tribute, nearby_tributes, None, rng) {
+        if let Some(early) =
+            self.run_pre_decision_overrides(tribute, nearby_tributes, None, Some(phase), rng)
+        {
             return early;
         }
 
@@ -434,11 +437,16 @@ impl Brain {
         tribute: &Tribute,
         nearby_tributes: u32,
         terrain: TerrainType,
+        phase: shared::messages::Phase,
         rng: &mut impl Rng,
     ) -> Action {
-        if let Some(early) =
-            self.run_pre_decision_overrides(tribute, nearby_tributes, Some(terrain.base), rng)
-        {
+        if let Some(early) = self.run_pre_decision_overrides(
+            tribute,
+            nearby_tributes,
+            Some(terrain.base),
+            Some(phase),
+            rng,
+        ) {
             return early;
         }
 
@@ -561,6 +569,7 @@ impl Brain {
         tribute: &Tribute,
         nearby_tributes: u32,
         terrain: Option<BaseTerrain>,
+        _phase: Option<shared::messages::Phase>,
         rng: &mut impl Rng,
     ) -> Option<Action> {
         if !tribute.is_alive() {
@@ -625,6 +634,9 @@ impl Brain {
         }
 
         // Spec §6.1: alliance proposals are a deliberate first-class action.
+        // Phase-gating is deferred to v2 per spec §13 ("Social events —
+        // alliance formation gated by phase"). The `phase` parameter is
+        // threaded through for future use.
         if self.wants_to_propose_alliance(tribute, nearby_tributes, rng) {
             return Some(Action::ProposeAlliance);
         }
@@ -1018,6 +1030,7 @@ mod tests {
     use crate::tributes::actions::Action;
     use rand::prelude::*;
     use rstest::{fixture, rstest};
+    use shared::messages::Phase;
 
     #[fixture]
     fn tribute() -> Tribute {
@@ -1051,6 +1064,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Move(None));
@@ -1067,6 +1081,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Move(None));
@@ -1083,6 +1098,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::None);
@@ -1099,6 +1115,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Rest);
@@ -1119,6 +1136,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Hide);
@@ -1134,6 +1152,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Attack);
@@ -1151,6 +1170,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Move(None));
@@ -1166,6 +1186,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Rest);
@@ -1193,6 +1214,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::UseItem(None));
@@ -1208,6 +1230,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Hide);
@@ -1224,6 +1247,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Move(None));
@@ -1239,6 +1263,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Rest);
@@ -1259,6 +1284,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Attack);
@@ -1278,6 +1304,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Attack);
@@ -1297,6 +1324,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::None);
@@ -1316,6 +1344,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Attack);
@@ -1335,6 +1364,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Move(None));
@@ -1354,6 +1384,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Hide);
@@ -1375,6 +1406,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Attack);
@@ -1463,6 +1495,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Attack);
@@ -1480,6 +1513,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::Hide);
@@ -1497,6 +1531,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         assert_eq!(action, Action::None);
@@ -1515,6 +1550,7 @@ mod tests {
             &[],
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
         // Self-destructive ignores health and attacks
@@ -1618,6 +1654,7 @@ mod tests {
             &all_areas,
             &[],
             &HashMap::new(),
+            Phase::Day,
             &mut small_rng,
         );
 

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -477,6 +477,7 @@ impl Tribute {
                 environment_details.all_areas,
                 environment_details.closed_areas,
                 environment_details.enemy_density,
+                environment_details.phase,
                 rng,
             )
         };

--- a/game/tests/ai_terrain_behavior_test.rs
+++ b/game/tests/ai_terrain_behavior_test.rs
@@ -95,7 +95,13 @@ fn test_concealed_terrain_boosts_hiding(mut small_rng: SmallRng) {
     let forest_terrain = TerrainType::new(BaseTerrain::Forest, vec![]).unwrap();
 
     // Test that action weights favor Hide in concealed terrain
-    let action = brain.decide_action_with_terrain(&tribute, 3, forest_terrain, &mut small_rng);
+    let action = brain.decide_action_with_terrain(
+        &tribute,
+        3,
+        forest_terrain,
+        shared::messages::Phase::Day,
+        &mut small_rng,
+    );
 
     // With few enemies and concealed terrain, should prefer hiding
     // (This tests the weight boost logic)
@@ -117,7 +123,13 @@ fn test_resource_scarce_terrain_boosts_search(mut small_rng: SmallRng) {
 
     // The brain should recognize Desert as resource-scarce and boost search weight
     // This is a behavioral test - we expect search/move actions in scarce terrain
-    let action = brain.decide_action_with_terrain(&tribute, 0, desert_terrain, &mut small_rng);
+    let action = brain.decide_action_with_terrain(
+        &tribute,
+        0,
+        desert_terrain,
+        shared::messages::Phase::Day,
+        &mut small_rng,
+    );
 
     // Should prefer moving/searching in resource-scarce terrain when alone
     assert!(matches!(action, game::tributes::actions::Action::Move(_)));


### PR DESCRIPTION
## Summary

Optimization items from four-phase day spec §11: phase parameter threading and message coalescing.

## Changes

- **Phase parameter in brain pipeline**: Thread `Phase` through `Brain::act()` and `run_pre_decision_overrides()` so brain layers can be phase-gated in the future (spec §11.3). Alliance phase-gating is deferred to v2 per spec §13.
- **Message coalescing**: `flush_tribute_events` now collapses repeated `TributeMoved` events to the same area within a phase into a single emission (spec §11.5).

## Verification

- `cargo test --package game` — 736 passed
- `cargo clippy --package game` — clean
- `cargo fmt --package game` — formatted

## Follow-ups

- [hangrier_games-rzbj](https://github.com/kennethlove/hangrier_games/issues/rzbj) — four-phase optimization items
- [hangrier_games-uq7p](https://github.com/kennethlove/hangrier_games/issues/uq7p) — four-phase day epic (2 of 5 children remain open)