### PR TITLE
fix(game,shared): suppress duplicate phase messages + fix event_count inflation

### DIFF
--- a/game/src/games.rs
+++ b/game/src/games.rs
@@ -580,6 +580,7 @@ impl Game {
         );
 
         // PhaseStarted: four-phase day substrate (spec §4 step 4).
+        // Reuse the same message — no duplicate content string.
         let phase_payload = crate::messages::MessagePayload::PhaseStarted {
             day: current_day,
             phase,
@@ -588,7 +589,7 @@ impl Game {
         self.push_message(
             crate::messages::MessageSource::Game(game_id),
             subject,
-            content,
+            String::new(),
             phase_payload,
             tick,
         );

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -632,7 +632,12 @@ pub fn summarize_periods(messages: &[GameMessage], current: (u32, Phase)) -> Vec
     for m in messages {
         let key = (m.game_day, m.phase.ord());
         let entry = bucket.entry(key).or_insert((0, 0));
-        entry.1 += 1;
+        if !matches!(
+            m.payload,
+            MessagePayload::PhaseStarted { .. } | MessagePayload::PhaseEnded { .. }
+        ) {
+            entry.1 += 1;
+        }
         if matches!(m.payload, MessagePayload::TributeKilled { .. })
             || matches!(
                 &m.payload,


### PR DESCRIPTION
## Summary
Fix doubled visible messages in Live Events panel and inflated event_count in period summaries.

## Changes
- **game/src/games.rs**: `announce_cycle_start` PhaseStarted shadow message now gets `String::new()` for content, mirroring `announce_cycle_end`
- **web/src/components/game_detail.rs**: Live Events panel filters empty/whitespace content from visibility gate and render loop; added `has_visible_content()` zero-alloc helper; bound `ws_events.read()` to local to avoid double read
- **shared/src/messages.rs**: `summarize_periods` skips `PhaseStarted`/`PhaseEnded` shadow payloads from `event_count`

## Verification
- `cargo check --workspace` ✅
- `cargo test --package game` — 929 passed ✅
- `cargo test --package shared` — 42 passed ✅
- `cargo fmt -- --check` ✅

## Follow-ups
- bd issue: hangrier_games-kucr (closed)