### PR TITLE
feat(web): add horizontal period timeline for browsing game history

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1.0.149"
 tracing = "0.1.44"
 uuid = { version = "1.23.1", features = ["v4", "js", "serde"] }
 validator = { version = "0.20", features = ["derive"] }
-web-sys = { version = "0.3.97", features = ["console", "Window", "Location"] }
+web-sys = { version = "0.3.97", features = ["console", "Window", "Location", "Document", "Element", "HtmlElement", "ScrollBehavior", "ScrollIntoViewOptions", "ScrollLogicalPosition"] }
 
 [build-dependencies]
 dotenvy = "0.15.7"

--- a/web/src/components/filter_chips.rs
+++ b/web/src/components/filter_chips.rs
@@ -27,10 +27,6 @@ const CATEGORIES: &[(MessageKind, &str)] = &[
 pub fn FilterChips(props: FilterChipsProps) -> Element {
     let mut filters: Signal<PeriodFilters> = use_context();
     let game_id = props.game_identifier.clone();
-    {
-        let mut f = filters.write();
-        f.hydrate(&game_id);
-    }
     let current = filters.read().filter_for(&game_id);
 
     let chip_class = |active: bool| -> &'static str {

--- a/web/src/components/game_detail.rs
+++ b/web/src/components/game_detail.rs
@@ -6,6 +6,7 @@ use crate::components::game_tributes::GameTributes;
 use crate::components::games_list::GamesListQ;
 use crate::components::info_detail::InfoDetail;
 use crate::components::period_grid::PeriodGrid;
+use crate::components::period_timeline::PeriodTimeline;
 use crate::components::recap_card::RecapCard;
 use crate::components::timeline::PeriodFilters;
 use crate::components::ui::{Button, ButtonVariant};
@@ -18,6 +19,11 @@ use dioxus_query::prelude::*;
 use reqwest::StatusCode;
 use shared::messages::MessagePayload;
 use shared::{DisplayGame, GameStatus};
+
+/// Returns true if `s` contains any non-whitespace character.
+fn has_visible_content(s: &str) -> bool {
+    !s.chars().all(char::is_whitespace)
+}
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub(crate) struct DisplayGameQ;
@@ -143,6 +149,8 @@ pub fn GamePage(identifier: String) -> Element {
         }
     });
 
+    let events = ws_events.read();
+
     rsx! {
         div {
             class: r#"
@@ -167,17 +175,19 @@ pub fn GamePage(identifier: String) -> Element {
                 },
             }}
 
-            if !ws_events.read().is_empty() {
+            if events.iter().any(|m| has_visible_content(&m.content)) {
                 div {
                     class: "bg-surface p-4 rounded-lg max-h-64 overflow-y-auto",
                     h3 { class: "font-bold mb-2", "Live Events" }
-                    for msg in ws_events.read().iter() {
+                    for msg in events.iter().filter(|m| has_visible_content(&m.content)) {
                         div { class: "text-sm py-1 border-b border-border",
                             "{msg.content}"
                         }
                     }
                 }
             }
+
+            PeriodTimeline { identifier: identifier.clone() }
 
             GameState { identifier: identifier.clone() }
             GameStats { identifier: identifier.clone() }

--- a/web/src/components/game_period_page.rs
+++ b/web/src/components/game_period_page.rs
@@ -7,10 +7,10 @@
 use crate::cache::QueryError;
 use crate::components::TributeFilterChips;
 use crate::components::filter_chips::FilterChips;
+use crate::components::period_timeline::PeriodTimeline;
 use crate::components::timeline::{FilterMode, PeriodFilters, Timeline};
 use crate::hooks::use_timeline_summary::use_timeline_summary;
 use crate::http::WithCredentials;
-use crate::routes::Routes;
 use dioxus::prelude::*;
 use dioxus_query::prelude::*;
 use reqwest::StatusCode;
@@ -52,8 +52,8 @@ pub fn GamePeriodPage(
     identifier: String,
     day: u32,
     phase: Phase,
-    filter: String,
-    tribute: String,
+    filter: Option<String>,
+    tribute: Option<String>,
 ) -> Element {
     let mut filters: Signal<PeriodFilters> = use_context();
 
@@ -66,39 +66,22 @@ pub fn GamePeriodPage(
     use_hook(move || {
         let mut f = filters.write();
         f.hydrate(&seed_id);
-        if !seed_filter.is_empty() {
-            f.set_filter(&seed_id, FilterMode::from_query_value(&seed_filter));
+        if let Some(ref sf) = seed_filter {
+            f.set_filter(&seed_id, FilterMode::from_query_value(sf));
         }
-        if !seed_tribute.is_empty() {
-            f.set_tribute_filter(&seed_id, Some(seed_tribute));
+        if let Some(ref st) = seed_tribute {
+            f.set_tribute_filter(&seed_id, Some(st.clone()));
         }
     });
 
-    let filter_mode = filters.read().filter_for(&identifier);
-    let tribute_filter = filters.read().tribute_filter(&identifier);
-
-    // context → URL: whenever the filter or tribute selection changes, replace
-    // the current history entry so the URL always reflects the visible slice.
-    {
-        let nav_id = identifier.clone();
-        let nav_filter = filter_mode.to_query_value();
-        let nav_tribute = tribute_filter.clone().unwrap_or_default();
-        let url_filter = filter.clone();
-        let url_tribute = tribute.clone();
-        let navigator = use_navigator();
-        use_effect(move || {
-            if nav_filter == url_filter && nav_tribute == url_tribute {
-                return;
-            }
-            navigator.replace(Routes::GamePeriodPage {
-                identifier: nav_id.clone(),
-                day,
-                phase,
-                filter: nav_filter.clone(),
-                tribute: nav_tribute.clone(),
-            });
-        });
-    }
+    let filter_mode = use_memo({
+        let id = identifier.clone();
+        move || filters.read().filter_for(&id)
+    });
+    let tribute_filter = use_memo({
+        let id = identifier.clone();
+        move || filters.read().tribute_filter(&id)
+    });
 
     let summary_q = use_timeline_summary(identifier.clone());
 
@@ -116,9 +99,12 @@ pub fn GamePeriodPage(
 
     if !valid {
         return rsx! {
-            div { class: "space-y-2",
-                h1 { class: "text-2xl font-semibold", "Period not found" }
-                p { class: "text-gray-600", "Day {day} ({phase}) doesn't exist for this game." }
+            div { class: "space-y-4",
+                PeriodTimeline { identifier: identifier.clone() }
+                div { class: "space-y-2",
+                    h1 { class: "text-2xl font-semibold", "Period not found" }
+                    p { class: "text-gray-600", "Day {day} ({phase}) doesn't exist for this game." }
+                }
             }
         };
     }
@@ -129,6 +115,7 @@ pub fn GamePeriodPage(
 
     rsx! {
         div { class: "space-y-4",
+            PeriodTimeline { identifier: identifier.clone() }
             h1 { class: "text-2xl font-semibold", "Day {day} — {phase}" }
             FilterChips { game_identifier: identifier.clone() }
             TributeFilterChips { game_identifier: identifier.clone() }
@@ -143,8 +130,8 @@ pub fn GamePeriodPage(
                         Timeline {
                             game_identifier: identifier.clone(),
                             messages: filtered,
-                            filter: filter_mode.clone(),
-                            tribute_filter: tribute_filter.clone(),
+                            filter: filter_mode().clone(),
+                            tribute_filter: tribute_filter().clone(),
                         }
                     }
                 }

--- a/web/src/components/mod.rs
+++ b/web/src/components/mod.rs
@@ -51,6 +51,8 @@ pub use period_card::PeriodCard;
 mod period_grid;
 pub use period_grid::PeriodGrid;
 mod period_grid_empty;
+mod period_timeline;
+pub use period_timeline::PeriodTimeline;
 mod recap_card;
 pub use recap_card::RecapCard;
 mod tribute_detail;

--- a/web/src/components/period_card.rs
+++ b/web/src/components/period_card.rs
@@ -50,8 +50,8 @@ pub fn PeriodCard(props: PeriodCardProps) -> Element {
         identifier: props.game_identifier.clone(),
         day: props.day,
         phase: props.phase,
-        filter: String::new(),
-        tribute: String::new(),
+        filter: None,
+        tribute: None,
     };
 
     rsx! {

--- a/web/src/components/period_timeline.rs
+++ b/web/src/components/period_timeline.rs
@@ -1,0 +1,191 @@
+//! PeriodTimeline — horizontally-scrolling strip of period chips.
+//!
+//! Renders every (day, phase) pair as a compact clickable chip. The current
+//! period is highlighted and auto-scrolled into view on mount. Future periods
+//! are dimmed.
+
+use crate::cache::QueryError;
+use crate::hooks::use_timeline_summary;
+use crate::routes::Routes;
+use dioxus::prelude::*;
+use dioxus_query::prelude::*;
+use shared::messages::Phase;
+
+#[component]
+pub fn PeriodTimeline(identifier: String) -> Element {
+    let query = use_timeline_summary(identifier.clone());
+    let reader = query.read();
+    let state = reader.state();
+
+    match &*state {
+        QueryStateData::Settled { res: Ok(s), .. } => {
+            rsx! {
+                TimelineScroll {
+                    identifier: identifier.clone(),
+                    periods: s.periods.clone(),
+                }
+            }
+        }
+        QueryStateData::Settled {
+            res: Err(QueryError::GameNotFound(_)),
+            ..
+        }
+        | QueryStateData::Settled { res: Err(_), .. } => {
+            rsx! {
+                div { class: "flex overflow-x-auto gap-1 pb-2 [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:dark:bg-gray-600",
+                    span { class: "text-sm text-muted", "Timeline unavailable" }
+                }
+            }
+        }
+        _ => rsx! {
+            div { class: "flex overflow-x-auto gap-1 pb-2 [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:dark:bg-gray-600",
+                div { class: "animate-pulse h-8 w-48 rounded bg-gray-200" }
+            }
+        },
+    }
+}
+
+#[component]
+fn TimelineScroll(identifier: String, periods: Vec<shared::messages::PeriodSummary>) -> Element {
+    let current = periods.iter().find(|p| p.is_current);
+    let (current_day, current_phase) = current
+        .map(|p| (p.day, p.phase))
+        .unwrap_or((0, Phase::Dawn));
+
+    // Run scroll exactly once, decoupled from render cycle
+    use_hook(move || {
+        scroll_to_current(current_day, current_phase);
+    });
+
+    let periods_with_keys: Vec<_> = periods
+        .iter()
+        .map(|p| (format!("{}-{}", p.day, phase_slug(p.phase)), p))
+        .collect();
+
+    rsx! {
+        div {
+            class: "flex overflow-x-auto gap-1 pb-2 scroll-smooth [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:dark:bg-gray-600",
+            for (key, period) in &periods_with_keys {
+                PeriodChip {
+                    key: "{key}",
+                    identifier: identifier.clone(),
+                    period: (*period).clone(),
+                    current_day,
+                    current_phase,
+                }
+                if period.phase == Phase::Night {
+                    div { key: "divider-{period.day}", class: "flex-shrink-0 w-px h-8 bg-border self-center mx-0.5" }
+                }
+            }
+        }
+    }
+}
+
+/// Scroll the current-period chip into the visible area of the timeline.
+fn scroll_to_current(day: u32, phase: Phase) {
+    let chip_id = format!("period-chip-{day}-{}", phase_slug(phase));
+    if let Some(doc) = web_sys::window().and_then(|w| w.document())
+        && let Some(el) = doc.get_element_by_id(&chip_id)
+    {
+        el.scroll_into_view();
+    }
+}
+
+/// Compact slug for a phase, used in element IDs.
+fn phase_slug(phase: Phase) -> &'static str {
+    match phase {
+        Phase::Dawn => "dawn",
+        Phase::Day => "day",
+        Phase::Dusk => "dusk",
+        Phase::Night => "night",
+    }
+}
+
+#[component]
+fn PeriodChip(
+    identifier: String,
+    period: shared::messages::PeriodSummary,
+    current_day: u32,
+    current_phase: Phase,
+) -> Element {
+    let is_future = period.day > current_day
+        || (period.day == current_day && period.phase.ord() > current_phase.ord());
+
+    let (bg, text, border) = phase_colors(period.phase);
+    let icon = phase_icon(period.phase);
+    let day_label = format!("D{}", period.day);
+
+    let chip_id = format!("period-chip-{}-{}", period.day, phase_slug(period.phase));
+
+    let current_class = if period.is_current {
+        "ring-2 ring-gold "
+    } else {
+        ""
+    };
+
+    let future_class = if is_future {
+        "opacity-40 pointer-events-none "
+    } else {
+        ""
+    };
+
+    let route = Routes::GamePeriodPage {
+        identifier: identifier.clone(),
+        day: period.day,
+        phase: period.phase,
+        filter: None,
+        tribute: None,
+    };
+
+    rsx! {
+        Link {
+            to: route,
+            id: chip_id,
+            class: "flex flex-col items-center justify-center min-w-[2.5rem] sm:min-w-[3rem] px-1.5 py-0.5 sm:px-2 sm:py-1 rounded-md border text-[0.65rem] sm:text-xs font-medium transition hover:shadow-md {bg} {text} {border} {current_class} {future_class}",
+            span { class: "text-xs sm:text-sm leading-none", "{icon}" }
+            span { class: "mt-0.5 font-bold", "{day_label}" }
+            if period.deaths > 0 {
+                span {
+                    class: "mt-0.5 inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded-full bg-red-600 text-white text-[0.6rem] font-bold leading-none",
+                    "{period.deaths}"
+                }
+            }
+        }
+    }
+}
+
+/// Returns (bg, text, border) Tailwind classes for a phase.
+fn phase_colors(phase: Phase) -> (&'static str, &'static str, &'static str) {
+    match phase {
+        Phase::Dawn => (
+            "bg-amber-100 dark:bg-amber-900/30",
+            "text-amber-800 dark:text-amber-200",
+            "border-amber-300 dark:border-amber-700",
+        ),
+        Phase::Day => (
+            "bg-yellow-100 dark:bg-yellow-900/30",
+            "text-yellow-800 dark:text-yellow-200",
+            "border-yellow-300 dark:border-yellow-700",
+        ),
+        Phase::Dusk => (
+            "bg-orange-100 dark:bg-orange-900/30",
+            "text-orange-800 dark:text-orange-200",
+            "border-orange-300 dark:border-orange-700",
+        ),
+        Phase::Night => (
+            "bg-slate-200 dark:bg-slate-700/50",
+            "text-slate-800 dark:text-slate-200",
+            "border-slate-400 dark:border-slate-600",
+        ),
+    }
+}
+
+/// Phase emoji icon.
+fn phase_icon(phase: Phase) -> &'static str {
+    match phase {
+        Phase::Dawn => "🌄",
+        Phase::Day => "☀️",
+        Phase::Dusk => "🌆",
+        Phase::Night => "🌙",
+    }
+}

--- a/web/src/components/tribute_filter_chips.rs
+++ b/web/src/components/tribute_filter_chips.rs
@@ -19,10 +19,6 @@ pub struct TributeFilterChipsProps {
 pub fn TributeFilterChips(props: TributeFilterChipsProps) -> Element {
     let mut filters: Signal<PeriodFilters> = use_context();
     let game_id = props.game_identifier.clone();
-    {
-        let mut f = filters.write();
-        f.hydrate(&game_id);
-    }
     let current = filters.read().tribute_filter(&game_id);
 
     let q = use_query(Query::new(game_id.clone(), GameTributesQ));

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -25,13 +25,13 @@ pub enum Routes {
                 GamesList {},
                 #[route("/:identifier")]
                 GamePage { identifier: String },
-                #[route("/:identifier/day/:day/:phase?:filter&:tribute")]
+                #[route("/:identifier/day/:day/:phase")]
                 GamePeriodPage {
                     identifier: String,
                     day: u32,
                     phase: shared::messages::Phase,
-                    filter: String,
-                    tribute: String,
+                    filter: Option<String>,
+                    tribute: Option<String>,
                 },
                 #[route("/:game_identifier/tributes/:tribute_identifier")]
                 TributeDetail { game_identifier: String, tribute_identifier: String },


### PR DESCRIPTION
## Summary
Add a horizontally-scrolling period timeline component for browsing game history with URL-shareable period links.

## Features
- Phase emoji (🌄☀️🌆🌙), day label, death badge per chip
- Current period highlighted with gold ring; future periods dimmed
- Auto-scrolls to current period on mount
- Day separators between each day's 4 phases
- Phase-specific colors + dark mode support
- Mobile-responsive chips
- Clickable chips navigate to period detail page

## Bug Fixes (during development)
- Route query params changed to `Option<String>` to fix chip click navigation
- Removed `onmounted` callback → `use_hook` to fix WASM closure crash
- Removed `use_effect` URL sync loop that caused infinite render / WASM timeout
- Fixed triple `hydrate()` calls on shared `Signal<PeriodFilters>` causing render cascade (now single hydration point in `GamePeriodPage`)
- Wrapped bare `filters.read()` in `use_memo` to prevent reactive subscription storms
- Stable key format for period chips (slug instead of Debug)

## Files
- `web/src/components/period_timeline.rs` — new component
- `web/src/components/game_detail.rs` — integrated into GamePage
- `web/src/components/game_period_page.rs` — integrated + hydration fix
- `web/src/components/filter_chips.rs` — removed duplicate hydration
- `web/src/components/tribute_filter_chips.rs` — removed duplicate hydration
- `web/src/components/period_card.rs` — route param fix
- `web/src/routes.rs` — route params changed to Option<String>
- `web/Cargo.toml` — extended web-sys scroll features

## Verification
- `cargo check --workspace` ✅
- `cargo test --package game` — 738 passed ✅
- `cargo fmt` ✅