### PR TITLE
feat(api): htmx PR2 — game detail, tributes, areas, log pages

### DIFF
--- a/api/src/games.rs
+++ b/api/src/games.rs
@@ -830,7 +830,7 @@ async fn get_full_game(identifier: Uuid, db: &Surreal<Any>) -> Result<Json<Game>
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub(crate) struct GameLog {
+pub struct GameLog {
     pub id: RecordId,
     pub identifier: String,
     pub source: MessageSource,

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -3,6 +3,8 @@ extern crate core;
 use api::auth::AUTH_ROUTER;
 use api::cleanup::start_cleanup_scheduler;
 use api::games::GAMES_ROUTER;
+use api::templates::base_layout;
+use api::templates::game_detail;
 use api::templates::pages;
 use api::users::{USERS_PROTECTED_ROUTER, USERS_PUBLIC_ROUTER};
 use api::{AppState, AuthDb};
@@ -18,6 +20,7 @@ use axum::response::Html;
 use axum::response::{IntoResponse, Response};
 use axum::{Json, Router, middleware};
 use base64_url::decode;
+use maud::html;
 use serde_json::Value;
 use shared::ListDisplayGame;
 use std::collections::hash_map::DefaultHasher;
@@ -289,6 +292,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .route("/", axum::routing::get(home_handler))
         .route("/games", axum::routing::get(games_list_handler))
+        .route("/games/{id}", axum::routing::get(game_detail_handler))
+        .route(
+            "/games/{id}/tributes",
+            axum::routing::get(game_tributes_handler),
+        )
+        .route("/games/{id}/areas", axum::routing::get(game_areas_handler))
+        .route("/games/{id}/log", axum::routing::get(game_log_handler))
         .route(
             "/health",
             axum::routing::get(|State(state): State<AppState>| async move {
@@ -541,4 +551,122 @@ async fn games_list_handler(
     };
 
     Html(pages::games_list_page(&games))
+}
+
+// ── Game detail HTMX handlers ─────────────────────────────────────────
+
+async fn game_detail_handler(
+    State(state): State<AppState>,
+    axum::extract::Path(game_identifier): axum::extract::Path<uuid::Uuid>,
+) -> Html<maud::Markup> {
+    let identifier = game_identifier.to_string();
+    let result = state
+        .db
+        .query("SELECT * FROM fn::get_display_game($identifier);")
+        .bind(("identifier", identifier.clone()))
+        .await;
+
+    let game = match result {
+        Ok(mut result) => {
+            let game: Option<shared::DisplayGame> = result.take(0).unwrap_or_default();
+            game
+        }
+        Err(_) => None,
+    };
+
+    match game {
+        Some(game) => Html(game_detail::game_detail_page(&game)),
+        None => Html(base_layout(
+            "Not Found",
+            html! {
+                div class="text-center py-12" {
+                    h1 class="text-2xl font-bold text-red-400" { "Game Not Found" }
+                    a href="/games" class="text-amber-400 hover:text-amber-300 mt-4 inline-block" {
+                        "Back to Games"
+                    }
+                }
+            },
+        )),
+    }
+}
+
+async fn game_tributes_handler(
+    State(state): State<AppState>,
+    axum::extract::Path(game_identifier): axum::extract::Path<uuid::Uuid>,
+) -> Html<maud::Markup> {
+    let identifier = game_identifier.to_string();
+    let result = state
+        .db
+        .query("SELECT * FROM fn::get_tributes_by_game($identifier);")
+        .bind(("identifier", identifier.clone()))
+        .await;
+
+    let tributes = match result {
+        Ok(mut result) => {
+            let tributes: Vec<Vec<game::tributes::Tribute>> =
+                result.take("tributes").unwrap_or_default();
+            tributes.into_iter().next().unwrap_or_default()
+        }
+        Err(_) => vec![],
+    };
+
+    Html(game_detail::tributes_page(&identifier, &tributes))
+}
+
+async fn game_areas_handler(
+    State(state): State<AppState>,
+    axum::extract::Path(game_identifier): axum::extract::Path<uuid::Uuid>,
+) -> Html<maud::Markup> {
+    let identifier = game_identifier.to_string();
+    let result = state
+        .db
+        .query(
+            r#"
+SELECT (
+    SELECT *, ->items->item[*] AS items
+    FROM ->areas->area
+) AS areas FROM game WHERE identifier = $identifier;
+"#,
+        )
+        .bind(("identifier", identifier.clone()))
+        .await;
+
+    let areas = match result {
+        Ok(mut result) => {
+            let areas: Vec<Vec<game::areas::AreaDetails>> =
+                result.take("areas").unwrap_or_default();
+            areas.into_iter().next().unwrap_or_default()
+        }
+        Err(_) => vec![],
+    };
+
+    Html(game_detail::areas_page(&identifier, &areas))
+}
+
+async fn game_log_handler(
+    State(state): State<AppState>,
+    axum::extract::Path(game_identifier): axum::extract::Path<uuid::Uuid>,
+) -> Html<maud::Markup> {
+    let identifier = game_identifier.to_string();
+    let result = state
+        .db
+        .query(
+            r#"SELECT * FROM message
+            WHERE string::starts_with(subject, $identifier)
+            ORDER BY game_day, phase, tick, emit_index;"#,
+        )
+        .bind(("identifier", identifier.clone()))
+        .await;
+
+    let messages = match result {
+        Ok(mut logs) => {
+            let rows: Vec<api::games::GameLog> = logs.take(0).unwrap_or_default();
+            rows.into_iter()
+                .map(shared::messages::GameMessage::from)
+                .collect()
+        }
+        Err(_) => vec![],
+    };
+
+    Html(game_detail::log_page(&identifier, &messages))
 }

--- a/api/src/templates/game_detail.rs
+++ b/api/src/templates/game_detail.rs
@@ -1,0 +1,485 @@
+use maud::html;
+use shared::{DisplayGame, GameStatus};
+
+use super::pages::status_color;
+use super::{base_layout, icon, narrative_icon};
+
+/// Full game detail page with navigation tabs.
+pub fn game_detail_page(game: &DisplayGame) -> maud::Markup {
+    base_layout(
+        &game.name,
+        html! {
+            div {
+                // Header section
+                div class="mb-6" {
+                    div class="flex items-center justify-between" {
+                        div {
+                            h1 class="text-2xl font-bold text-amber-400" { (game.name) }
+                            p class="text-sm text-gray-400 mt-1" {
+                                "Day " (game.day.unwrap_or(0))
+                                " · "
+                                span class=(status_color(&game.status.to_string())) { (game.status) }
+                                " · "
+                                (game.living_count) "/" (game.tribute_count) " alive"
+                            }
+                        }
+                        @if game.is_mine {
+                            div class="flex gap-2" {
+                                @if game.status == GameStatus::NotStarted {
+                                    button
+                                        class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded font-semibold"
+                                        hx-put=(format!("/api/games/{}/next", game.identifier))
+                                        hx-target="#game-status"
+                                        hx-swap="innerHTML"
+                                        hx-disabled-elt="this" {
+                                        "Start Game"
+                                    }
+                                } @else if game.status == GameStatus::InProgress {
+                                    button
+                                        class="bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded font-semibold"
+                                        hx-put=(format!("/api/games/{}/next", game.identifier))
+                                        hx-target="#game-status"
+                                        hx-swap="innerHTML"
+                                        hx-disabled-elt="this" {
+                                        "Play Day " (game.day.unwrap_or(0))
+                                    }
+                                }
+                            }
+                        } @else {
+                            p class="text-sm text-gray-500" {
+                                "By " (game.created_by.username)
+                            }
+                        }
+                    }
+                }
+
+                // Status update target for HTMX
+                div id="game-status" {
+                    @if game.status == GameStatus::Finished {
+                        @if let Some(winner) = &game.winner {
+                            div class="mb-4 p-3 bg-amber-900/30 border border-amber-700 rounded-lg" {
+                                p class="text-amber-300 font-semibold" {
+                                    (icon("trophy"))
+                                    " Winner: " (winner.name)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Navigation tabs
+                nav class="flex gap-4 border-b border-gray-800 mb-6" {
+                    a href=(format!("/games/{}/tributes", game.identifier))
+                        class="pb-2 px-1 text-sm font-medium text-gray-400 hover:text-white border-b-2 border-transparent hover:border-amber-500" {
+                        "Tributes"
+                    }
+                    a href=(format!("/games/{}/areas", game.identifier))
+                        class="pb-2 px-1 text-sm font-medium text-gray-400 hover:text-white border-b-2 border-transparent hover:border-amber-500" {
+                        "Areas"
+                    }
+                    a href=(format!("/games/{}/log", game.identifier))
+                        class="pb-2 px-1 text-sm font-medium text-gray-400 hover:text-white border-b-2 border-transparent hover:border-amber-500" {
+                        "Log"
+                    }
+                }
+
+                // Content area — sub-pages load here via HTMX
+                div id="detail-content" {
+                    p class="text-gray-500" { "Select a tab above" }
+                }
+            }
+        },
+    )
+}
+
+/// Tribute list page — grid grouped by district.
+pub fn tributes_page(game_id: &str, tributes: &[game::tributes::Tribute]) -> maud::Markup {
+    base_layout(
+        "Tributes",
+        html! {
+            div {
+                a href=(format!("/games/{}", game_id))
+                    class="text-sm text-gray-400 hover:text-white mb-4 inline-block" {
+                    (icon("arrow-left"))
+                    " Back to Game"
+                }
+                h2 class="text-xl font-bold text-amber-400 mb-4" { "Tributes" }
+
+                @if tributes.is_empty() {
+                    p class="text-gray-500" { "No tributes yet." }
+                } @else {
+                    // Group by district
+                    @for district_num in 1..=12 {
+                        @let district_tributes: Vec<_> = tributes.iter()
+                            .filter(|t| t.district == district_num)
+                            .collect();
+                        @if !district_tributes.is_empty() {
+                            div class="mb-6" {
+                                h3 class="text-sm font-semibold text-gray-300 mb-2" {
+                                    "District " (district_num)
+                                }
+                                div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" {
+                                    @for tribute in &district_tributes {
+                                        (tribute_card(tribute))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+
+/// Single tribute card with stats strip.
+fn tribute_card(tribute: &game::tributes::Tribute) -> maud::Markup {
+    let is_alive = tribute.is_alive();
+    let status_class = if is_alive {
+        "text-green-400"
+    } else {
+        "text-red-400"
+    };
+    let status_icon = if is_alive { "check-circle" } else { "x-circle" };
+
+    html! {
+        div class="bg-gray-900 border border-gray-800 rounded-lg p-3" {
+            div class="flex items-center justify-between mb-2" {
+                span class="font-semibold text-white text-sm" { (tribute.name) }
+                span class=(status_class) { (icon(status_icon)) }
+            }
+
+            // Stats strip
+            div class="space-y-1 text-xs" {
+                // Health
+                div class="flex items-center gap-1" {
+                    (icon("heart"))
+                    span class="text-gray-400" { "HP" }
+                    span class="text-gray-200 ml-auto" { (tribute.attributes.health) }
+                }
+                // Sanity
+                div class="flex items-center gap-1" {
+                    (icon("brain"))
+                    span class="text-gray-400" { "SAN" }
+                    span class="text-gray-200 ml-auto" { (tribute.attributes.sanity) }
+                }
+                // Movement
+                div class="flex items-center gap-1" {
+                    (icon("zap"))
+                    span class="text-gray-400" { "MOV" }
+                    span class="text-gray-200 ml-auto" { (tribute.attributes.movement) }
+                }
+                // Strength
+                div class="flex items-center gap-1" {
+                    (icon("sword"))
+                    span class="text-gray-400" { "STR" }
+                    span class="text-gray-200 ml-auto" { (tribute.attributes.strength) }
+                }
+            }
+
+            // Survival bands
+            div class="mt-2 pt-2 border-t border-gray-800 flex gap-2 text-xs" {
+                span class=(hunger_color(tribute.hunger)) { "H: " (hunger_label(tribute.hunger)) }
+                span class=(thirst_color(tribute.thirst)) { "T: " (thirst_label(tribute.thirst)) }
+                span class=(stamina_color(tribute.stamina, tribute.max_stamina)) {
+                    "S: " (stamina_label(tribute.stamina, tribute.max_stamina))
+                }
+            }
+
+            // Area location
+            div class="mt-1 text-xs text-gray-500" {
+                (icon("map-pin"))
+                " " (tribute.area)
+            }
+
+            // Inventory
+            @if !tribute.items.is_empty() {
+                div class="mt-2 pt-2 border-t border-gray-800" {
+                    p class="text-xs text-gray-500 mb-1" { "Items:" }
+                    div class="flex flex-wrap gap-1" {
+                        @for item in &tribute.items {
+                            span class="text-xs bg-gray-800 text-gray-300 px-1.5 py-0.5 rounded" {
+                                (icon("backpack"))
+                                " " (item.name)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Areas list page.
+pub fn areas_page(game_id: &str, areas: &[game::areas::AreaDetails]) -> maud::Markup {
+    base_layout(
+        "Areas",
+        html! {
+            div {
+                a href=(format!("/games/{}", game_id))
+                    class="text-sm text-gray-400 hover:text-white mb-4 inline-block" {
+                    (icon("arrow-left"))
+                    " Back to Game"
+                }
+                h2 class="text-xl font-bold text-amber-400 mb-4" { "Areas" }
+
+                @if areas.is_empty() {
+                    p class="text-gray-500" { "No areas yet." }
+                } @else {
+                    div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" {
+                        @for area in areas {
+                            (area_card(area))
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+
+/// Single area card.
+fn area_card(area: &game::areas::AreaDetails) -> maud::Markup {
+    let is_open = area.events.is_empty();
+    let status_text = if is_open { "Open" } else { "Active Events" };
+    let status_class = if is_open {
+        "text-green-400"
+    } else {
+        "text-orange-400"
+    };
+
+    html! {
+        div class="bg-gray-900 border border-gray-800 rounded-lg p-3" {
+            div class="flex items-center justify-between mb-2" {
+                h3 class="font-semibold text-white text-sm" {
+                    (icon("map-pin"))
+                    " " (area.name)
+                }
+                span class=(status_class) {
+                    @if is_open {
+                        (icon("unlock"))
+                    } @else {
+                        (icon("triangle-alert"))
+                    }
+                    " " (status_text)
+                }
+            }
+
+            // Items
+            @if !area.items.is_empty() {
+                div class="mt-2" {
+                    p class="text-xs text-gray-500 mb-1" { "Items:" }
+                    div class="flex flex-wrap gap-1" {
+                        @for item in &area.items {
+                            span class="text-xs bg-gray-800 text-gray-300 px-1.5 py-0.5 rounded" {
+                                (icon("backpack"))
+                                " " (item.name)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Events
+            @if !area.events.is_empty() {
+                div class="mt-2 pt-2 border-t border-gray-800" {
+                    p class="text-xs text-gray-500 mb-1" { "Events:" }
+                    ul class="text-xs text-gray-400 space-y-0.5" {
+                        @for event in &area.events {
+                            li { (narrative_icon("event")) " " (event) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Game log page — scrollable message list.
+pub fn log_page(game_id: &str, messages: &[shared::messages::GameMessage]) -> maud::Markup {
+    base_layout(
+        "Log",
+        html! {
+            div {
+                a href=(format!("/games/{}", game_id))
+                    class="text-sm text-gray-400 hover:text-white mb-4 inline-block" {
+                    (icon("arrow-left"))
+                    " Back to Game"
+                }
+                h2 class="text-xl font-bold text-amber-400 mb-4" { "Game Log" }
+
+                @if messages.is_empty() {
+                    p class="text-gray-500" { "No messages yet." }
+                } @else {
+                    div class="max-h-[70vh] overflow-y-auto space-y-2 pr-2" {
+                        @for msg in messages {
+                            (log_entry(msg))
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+
+/// Single log entry.
+fn log_entry(msg: &shared::messages::GameMessage) -> maud::Markup {
+    let kind_icon = message_kind_icon(&msg.payload);
+    let phase_label = msg.phase.to_string();
+    let kind_label = message_kind_label(&msg.payload);
+    let kind_clr = kind_color(&msg.payload);
+
+    html! {
+        div class="bg-gray-900 border border-gray-800 rounded p-3" {
+            div class="flex items-center gap-2 text-xs text-gray-500 mb-1" {
+                span { "Day " (msg.game_day) }
+                span { "·" }
+                span class="capitalize" { (phase_label) }
+                span { "·" }
+                (kind_icon)
+                span class=(kind_clr) { (kind_label) }
+            }
+            p class="text-sm text-gray-200" { (msg.content) }
+            @if !msg.subject.is_empty() {
+                p class="text-xs text-gray-500 mt-1" { (msg.subject) }
+            }
+        }
+    }
+}
+
+/// Human-readable label for message kind.
+fn message_kind_label(payload: &shared::messages::MessagePayload) -> &'static str {
+    use shared::messages::MessageKind;
+    match payload.kind() {
+        MessageKind::Death => "Death",
+        MessageKind::Combat => "Combat",
+        MessageKind::CombatSwing => "Combat",
+        MessageKind::Alliance => "Alliance",
+        MessageKind::Movement => "Movement",
+        MessageKind::Item => "Item",
+        MessageKind::SponsorGift => "Sponsor",
+        MessageKind::State => "State",
+        MessageKind::Trauma => "Trauma",
+    }
+}
+
+/// Icon for message kind.
+fn message_kind_icon(payload: &shared::messages::MessagePayload) -> maud::Markup {
+    use shared::messages::MessagePayload;
+    let name = match payload {
+        MessagePayload::TributeKilled { .. } | MessagePayload::Combat(_) => "sword",
+        MessagePayload::TributeWounded { .. } | MessagePayload::TributeAttacked { .. } => "heart",
+        MessagePayload::AllianceFormed { .. } | MessagePayload::AllianceProposed { .. } => "users",
+        MessagePayload::AllianceDissolved { .. } | MessagePayload::BetrayalTriggered { .. } => {
+            "user-x"
+        }
+        MessagePayload::TributeMoved { .. } | MessagePayload::TributeHidden { .. } => "map-pin",
+        MessagePayload::AreaClosed { .. } | MessagePayload::AreaEvent { .. } => "triangle-alert",
+        MessagePayload::ItemFound { .. }
+        | MessagePayload::ItemUsed { .. }
+        | MessagePayload::ItemDropped { .. } => "backpack",
+        MessagePayload::SponsorGift { .. } => "gift",
+        MessagePayload::TributeRested { .. } => "bed",
+        MessagePayload::TributeStarved { .. } | MessagePayload::TributeDehydrated { .. } => "skull",
+        MessagePayload::SanityBreak { .. } => "brain",
+        MessagePayload::HungerBandChanged { .. }
+        | MessagePayload::ThirstBandChanged { .. }
+        | MessagePayload::StaminaBandChanged { .. } => "activity",
+        MessagePayload::ShelterSought { .. } => "tent",
+        MessagePayload::Foraged { .. } => "search",
+        MessagePayload::Drank { .. } => "droplet",
+        MessagePayload::Ate { .. } => "utensils",
+        MessagePayload::CycleStart { .. } | MessagePayload::CycleEnd { .. } => "sunrise",
+        MessagePayload::PhaseStarted { .. } | MessagePayload::PhaseEnded { .. } => "clock",
+        MessagePayload::TributeSlept { .. } => "moon",
+        MessagePayload::TributeWoke { .. } => "sun",
+        MessagePayload::GameEnded { .. } => "trophy",
+        MessagePayload::CombatSwing(_) => "sword",
+        MessagePayload::TrustShockBreak { .. } => "heart-crack",
+        MessagePayload::AfflictionAcquired { .. }
+        | MessagePayload::AfflictionProgressed { .. }
+        | MessagePayload::AfflictionHealed { .. }
+        | MessagePayload::AfflictionCascaded { .. } => "bandage",
+        MessagePayload::TraumaAcquired { .. } | MessagePayload::TraumaReinforced { .. } => "brain",
+        MessagePayload::PhobiaAcquired { .. } | MessagePayload::PhobiaTriggered { .. } => "eye",
+    };
+    icon(name)
+}
+
+/// Color class for message kind.
+fn kind_color(payload: &shared::messages::MessagePayload) -> &'static str {
+    use shared::messages::MessageKind;
+    match payload.kind() {
+        MessageKind::Death => "text-red-400",
+        MessageKind::Combat | MessageKind::CombatSwing => "text-orange-400",
+        MessageKind::Alliance => "text-blue-400",
+        MessageKind::Movement => "text-purple-400",
+        MessageKind::Item | MessageKind::SponsorGift => "text-yellow-400",
+        MessageKind::State | MessageKind::Trauma => "text-gray-400",
+    }
+}
+
+// ── Survival band helpers ─────────────────────────────────────────────
+
+fn hunger_label(hunger: u8) -> &'static str {
+    match hunger {
+        0 => "Sated",
+        1..=2 => "Peckish",
+        3..=4 => "Hungry",
+        _ => "Starving",
+    }
+}
+
+fn hunger_color(hunger: u8) -> &'static str {
+    match hunger {
+        0 => "text-green-400",
+        1..=2 => "text-yellow-400",
+        3..=4 => "text-orange-400",
+        _ => "text-red-400",
+    }
+}
+
+fn thirst_label(thirst: u8) -> &'static str {
+    match thirst {
+        0 => "Sated",
+        1..=2 => "Thirsty",
+        3..=4 => "Parched",
+        _ => "Dehydrated",
+    }
+}
+
+fn thirst_color(thirst: u8) -> &'static str {
+    match thirst {
+        0 => "text-green-400",
+        1..=2 => "text-yellow-400",
+        3..=4 => "text-orange-400",
+        _ => "text-red-400",
+    }
+}
+
+fn stamina_label(stamina: u32, max_stamina: u32) -> &'static str {
+    if max_stamina == 0 {
+        return "N/A";
+    }
+    let ratio = stamina as f64 / max_stamina as f64;
+    if ratio > 0.66 {
+        "Fresh"
+    } else if ratio > 0.33 {
+        "Winded"
+    } else {
+        "Exhausted"
+    }
+}
+
+fn stamina_color(stamina: u32, max_stamina: u32) -> &'static str {
+    if max_stamina == 0 {
+        return "text-gray-500";
+    }
+    let ratio = stamina as f64 / max_stamina as f64;
+    if ratio > 0.66 {
+        "text-green-400"
+    } else if ratio > 0.33 {
+        "text-yellow-400"
+    } else {
+        "text-red-400"
+    }
+}

--- a/api/src/templates/mod.rs
+++ b/api/src/templates/mod.rs
@@ -1,5 +1,6 @@
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 
+pub mod game_detail;
 pub mod pages;
 
 pub fn base_layout(title: &str, content: Markup) -> Markup {

--- a/api/src/templates/pages.rs
+++ b/api/src/templates/pages.rs
@@ -71,7 +71,7 @@ fn game_card(game: &ListDisplayGame) -> maud::Markup {
     }
 }
 
-fn status_color(status: &str) -> &'static str {
+pub fn status_color(status: &str) -> &'static str {
     match status {
         "NotStarted" => "text-gray-400",
         "InProgress" => "text-green-400",


### PR DESCRIPTION
## Summary
Migrate game detail pages from Dioxus SPA to server-rendered HTMX/Maud templates.

## Changes
- New `api/src/templates/game_detail.rs` with templates for game detail, tributes, areas, and log
- 4 new HTMX route handlers in `main.rs`: `GET /games/{id}`, `/tributes`, `/areas`, `/log`
- Tribute cards with district grouping, stats, state bands, inventory
- Area cards with items and events
- Game log with kind-specific icons and colors
- Start/Play buttons via HTMX hx-put

## Verification
- cargo check: PASS
- cargo clippy: PASS
- cargo fmt: PASS

## Follow-ups
- bead: htmx-002 (hangrier_games-1o18)
- Next: htmx-003 (timeline + period pages)