### PR TITLE
fix: update dev setup for HTMX — Tailwind in api/assets, remove web/ refs

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,9 +6,9 @@ cd "$(dirname "$0")/.."
 echo "==> Fixing volume ownership (named volumes mount as root by default)"
 sudo chown -R vscode:vscode /usr/local/cargo/registry /workspaces/hangrier_games/target 2>/dev/null || true
 
-echo "==> Installing web/assets npm deps"
-if [ -d web/assets ]; then
-  (cd web/assets && npm install --no-audit --no-fund)
+echo "==> Installing api/assets npm deps"
+if [ -d api/assets ]; then
+  (cd api/assets && npm install --no-audit --no-fund)
 fi
 
 echo "==> Building Tailwind CSS"
@@ -18,12 +18,11 @@ echo "==> Ensuring .env exists"
 if [ ! -f .env ]; then
   cat > .env <<'EOF'
 ENV=development
-APP_API_HOST=http://127.0.0.1:3000
 SURREAL_HOST=ws://localhost:8000
 SURREAL_USER=root
 SURREAL_PASS=root
 EOF
-  echo "Created default .env (SurrealDB runs in-container at ws://localhost:8000)"
+  echo "Created default .env"
 fi
 
-echo "==> Done. Run 'just dev' (starts SurrealDB + API + web in one shell)."
+echo "==> Done. Run 'just dev' (starts SurrealDB + API + Tailwind in one shell)."

--- a/.env
+++ b/.env
@@ -1,8 +1,4 @@
 ENV=development
-# Empty so the web frontend issues relative URLs ("/api/...", "/ws") that hit
-# the dx serve proxy (configured in web/Dioxus.toml). Keeps dev same-origin so
-# HttpOnly auth cookies aren't dropped as third-party. See bd-jgxd.
-APP_API_HOST=
 SURREAL_HOST=ws://localhost:8000
 SURREAL_USER=root
 SURREAL_PASS=root

--- a/api/assets/package.json
+++ b/api/assets/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "hangrier-games-assets",
+  "private": true,
+  "devDependencies": {
+    "@tailwindcss/cli": "^4.0.0",
+    "tailwindcss": "^4.0.0"
+  }
+}

--- a/api/assets/src/main.css
+++ b/api/assets/src/main.css
@@ -1,0 +1,35 @@
+@import "tailwindcss";
+
+/* Custom theme colors for Hangrier Games */
+@theme {
+  --color-amber-400: #fbbf24;
+  --color-amber-500: #f59e0b;
+  --color-amber-600: #d97706;
+  --color-gray-950: #0a0a0a;
+  --color-gray-900: #171717;
+  --color-gray-800: #262626;
+  --color-gray-700: #404040;
+  --color-gray-600: #525252;
+  --color-gray-500: #737373;
+  --color-gray-400: #a3a3a3;
+  --color-gray-300: #d4d4d3;
+  --color-red-400: #f87171;
+  --color-red-700: #b91c1c;
+  --color-red-900: #7f1d1d;
+  --color-green-400: #4ade80;
+  --color-green-600: #16a34a;
+  --color-green-700: #15803d;
+  --color-green-900: #14532d;
+  --color-blue-400: #60a5fa;
+  --color-blue-600: #2563eb;
+  --color-blue-900: #1e3a8a;
+  --color-gold: #fbbf24;
+}
+
+/* Spinner for loading states */
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+.animate-spin {
+  animation: spin 1s linear infinite;
+}

--- a/justfile
+++ b/justfile
@@ -1,5 +1,4 @@
 # Hangrier Games - Rust Workspace Justfile
-# List all available recipes
 default:
     @just --list
 
@@ -26,15 +25,15 @@ dev:
     API_PID=$!
     sleep 2
     echo "Building Tailwind CSS..."
-    (cd web/assets && npm install --silent && npx @tailwindcss/cli -i ./src/main.css -o ./dist/main.css)
+    (cd api/assets && npm install --silent && npx @tailwindcss/cli -i ./src/main.css -o ./dist/main.css)
     echo "Starting Tailwind watcher..."
-    (cd web/assets && npx @tailwindcss/cli -i ./src/main.css -o ./dist/main.css --watch) &
+    (cd api/assets && npx @tailwindcss/cli -i ./src/main.css -o ./dist/main.css --watch) &
     CSS_PID=$!
     echo ""
     echo "Development environment running:"
     echo "  - SurrealDB: ws://localhost:8000"
     echo "  - API + HTMX pages: http://localhost:3000"
-    echo "  - Tailwind: watching web/assets/src/main.css"
+    echo "  - Tailwind: watching api/assets/src/main.css"
     echo ""
     echo "Press Ctrl+C to stop all services"
     trap "kill $DB_PID $API_PID $CSS_PID 2>/dev/null" EXIT
@@ -46,7 +45,7 @@ dev:
 # Build Tailwind CSS for HTMX pages
 build-css:
     #!/usr/bin/env bash
-    cd web/assets
+    cd api/assets
     npm install
     npx @tailwindcss/cli -i ./src/main.css -o ./dist/main.css
 
@@ -102,16 +101,12 @@ setup-ollama:
     cd announcers/src
     ollama create announcers -f Modelfile.qwen
 
-# Install wasm32 target for frontend builds
-setup-wasm:
-    rustup target add wasm32-unknown-unknown
-
 # Install Node dependencies for Tailwind CSS
 setup-node:
-    cd web/assets && npm install
+    cd api/assets && npm install
 
 # Run all setup tasks
-setup: setup-wasm setup-node setup-ollama
+setup: setup-node setup-ollama
     @echo "✓ Setup complete!"
     @echo ""
     @echo "Next steps:"
@@ -125,8 +120,8 @@ setup: setup-wasm setup-node setup-ollama
 # Clean all build artifacts
 clean:
     cargo clean
-    rm -rf web/assets/dist
-    rm -rf web/assets/node_modules
+    rm -rf api/assets/dist
+    rm -rf api/assets/node_modules
 
 # Clean and rebuild everything
 rebuild: clean build-all
@@ -177,14 +172,13 @@ tree:
     @echo "  api/        - Axum REST API + HTMX pages (SurrealDB backend)"
     @echo "  shared/     - Shared types"
     @echo "  announcers/ - Ollama LLM integration"
-    @echo "  web/        - Assets (Tailwind CSS, icons)"
 
 # Show helpful development tips
 tips:
     @echo "Development tips:"
     @echo "  - API serves HTMX pages directly at http://localhost:3000"
-    @echo "  - Build Tailwind CSS before running the API"
-    @echo "  - .env file must exist with APP_API_HOST, SURREAL_HOST, etc."
+    @echo "  - Build Tailwind CSS before running the API: just build-css"
+    @echo "  - .env file must exist with SURREAL_HOST, SURREAL_USER, SURREAL_PASS"
     @echo "  - Game crate tests can be slow; workspace tests may hang"
     @echo "  - Use 'just dev' to start all services at once"
     @echo ""


### PR DESCRIPTION
## Summary
Fix development setup after Dioxus web crate removal.

## Changes
- Created `api/assets/` with Tailwind CSS v4 setup (package.json, src/main.css)
- Updated justfile: all `web/assets` → `api/assets`, removed `setup-wasm`
- Updated `.devcontainer/post-create.sh`: removed `APP_API_HOST`, fixed paths
- Updated `.env`: removed `APP_API_HOST`

## Verification
- Clippy: PASS
- Types: PASS
- Format: PASS