### PR TITLE
feat(api): migrate game detail pages to light theme CSS

### DIFF
--- a/.beads/export-state.json
+++ b/.beads/export-state.json
@@ -1,1 +1,1 @@
-{"last_dolt_commit":"7vrragpfd1vpuqpk2vrt8ddjuhmcd1ja","timestamp":"2026-05-19T11:20:20.3867-07:00","issues":335,"memories":0}
+{"last_dolt_commit":"f80cuhu6169ae6b50lam9seeskk3td6t","timestamp":"2026-05-19T13:43:06.354733-07:00","issues":335,"memories":0}

--- a/api/assets/dist/main.css
+++ b/api/assets/dist/main.css
@@ -1,0 +1,751 @@
+/*! tailwindcss v4.3.0 | MIT License | https://tailwindcss.com */
+@layer theme, base, components, utilities;
+@layer theme {
+  :root, :host {
+    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    --radius-sm: 0.25rem;
+    --default-font-family: var(--font-sans);
+    --default-mono-font-family: var(--font-mono);
+  }
+}
+@layer base {
+  *, ::after, ::before, ::backdrop, ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  html, :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+  b, strong {
+    font-weight: bolder;
+  }
+  code, kbd, samp, pre {
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
+    font-size: 1em;
+  }
+  small {
+    font-size: 80%;
+  }
+  sub, sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+  :-moz-focusring {
+    outline: auto;
+  }
+  progress {
+    vertical-align: baseline;
+  }
+  summary {
+    display: list-item;
+  }
+  ol, ul, menu {
+    list-style: none;
+  }
+  img, svg, video, canvas, audio, iframe, embed, object {
+    display: block;
+    vertical-align: middle;
+  }
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+  button, input, select, optgroup, textarea, ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+  ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+  ::placeholder {
+    opacity: 1;
+  }
+  @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {
+    ::placeholder {
+      color: currentcolor;
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, currentcolor 50%, transparent);
+      }
+    }
+  }
+  textarea {
+    resize: vertical;
+  }
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+  ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+  ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+  ::-webkit-calendar-picker-indicator {
+    line-height: 1;
+  }
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
+    appearance: button;
+  }
+  ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none !important;
+  }
+}
+@layer utilities;
+@import url('https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,16..72,200..800;1,16..72,200..800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+:root {
+  --bg: oklch(97.5% 0.012 75);
+  --surface: oklch(99.5% 0.004 75);
+  --fg: oklch(18% 0.015 70);
+  --muted: oklch(52% 0.012 70);
+  --border: oklch(88% 0.01 75);
+  --accent: oklch(42% 0.18 285);
+  --accent-soft: var(--accent);
+  @supports (color: color-mix(in lab, red, red)) {
+    --accent-soft: color-mix(in oklch, var(--accent) 10%, transparent);
+  }
+  --fg-soft: var(--fg);
+  @supports (color: color-mix(in lab, red, red)) {
+    --fg-soft: color-mix(in oklch, var(--fg) 5%, transparent);
+  }
+  --running: oklch(60% 0.18 145);
+  --waiting: oklch(65% 0.18 55);
+  --finished: oklch(52% 0.012 70);
+  --font-display: 'Newsreader', 'Iowan Old Style', Georgia, serif;
+  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+  --fs-h1: clamp(48px, 7vw, 84px);
+  --fs-h2: clamp(28px, 3.5vw, 42px);
+  --fs-h3: 22px;
+  --fs-lead: 18px;
+  --fs-body: 15px;
+  --fs-meta: 12px;
+  --fs-xs: 11px;
+  --gap-xs: 6px;
+  --gap-sm: 12px;
+  --gap-md: 20px;
+  --gap-lg: 32px;
+  --gap-xl: 48px;
+  --container: 1200px;
+  --gutter: 28px;
+  --radius-sm: 4px;
+  --radius: 8px;
+}
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+html {
+  -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
+}
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-body);
+  font-size: var(--fs-body);
+  line-height: 1.6;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+img, svg {
+  display: block;
+  max-width: 100%;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+button {
+  font: inherit;
+  cursor: pointer;
+}
+p {
+  text-wrap: pretty;
+}
+h1, h2, h3, h4 {
+  text-wrap: balance;
+}
+.container {
+  max-width: var(--container);
+  margin-inline: auto;
+  padding-inline: var(--gutter);
+}
+.num {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+.topnav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--bg);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in oklch, var(--bg) 90%, transparent);
+  }
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+}
+.topnav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-block: 12px;
+}
+.topnav .logo {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.topnav .logo span {
+  color: var(--accent);
+}
+.topnav nav {
+  display: flex;
+  gap: var(--gap-lg);
+}
+.topnav nav a {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+  transition: color 0.15s;
+}
+.topnav nav a:hover {
+  color: var(--fg);
+}
+.topnav nav a.active {
+  color: var(--accent);
+}
+.page-header {
+  padding-block: var(--gap-xl);
+  border-bottom: 1px solid var(--border);
+}
+.page-header h1 {
+  font-family: var(--font-display);
+  font-size: var(--fs-h2);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+.page-header .deck {
+  font-size: var(--fs-lead);
+  color: var(--muted);
+  max-width: 500px;
+}
+.action-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--gap-lg);
+  padding-block: var(--gap-lg);
+  border-bottom: 1px solid var(--border);
+}
+.launch-block {
+  padding: var(--gap-lg);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+}
+.quickstart-btn {
+  padding: 18px 24px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  font-family: var(--font-display);
+  font-size: var(--fs-h3);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  text-align: left;
+  width: 100%;
+}
+.quickstart-btn:hover {
+  opacity: 0.85;
+}
+.or-divider {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  font-size: var(--fs-meta);
+  color: var(--muted);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.or-divider::before, .or-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.create-form h3 {
+  font-family: var(--font-display);
+  font-size: var(--fs-h3);
+  font-weight: 600;
+  margin: 0 0 var(--gap-sm);
+}
+.create-form form {
+  display: flex;
+  gap: var(--gap-xs);
+}
+.create-form input {
+  flex: 1;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--fs-body);
+  background: var(--bg);
+  color: var(--fg);
+  outline: none;
+}
+.create-form input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.stats-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--gap-sm);
+  align-content: start;
+}
+.summary-card {
+  padding: 20px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  text-align: center;
+}
+.summary-card .s-val {
+  font-family: var(--font-display);
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.summary-card .s-label {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin-top: 4px;
+  font-weight: 500;
+}
+.summary-card.running .s-val {
+  color: var(--running);
+}
+.summary-card.waiting .s-val {
+  color: var(--waiting);
+}
+.summary-card.finished .s-val {
+  color: var(--finished);
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: var(--radius-sm);
+  border: none;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.btn:hover {
+  opacity: 0.85;
+}
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+.btn-ghost {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+.btn-ghost:hover {
+  background: var(--fg-soft);
+}
+.btn-sm {
+  padding: 8px 16px;
+  font-size: 13px;
+}
+.game-list {
+  padding-block: var(--gap-lg);
+}
+.game-list-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: var(--gap-md);
+}
+.game-list-header h2 {
+  font-family: var(--font-display);
+  font-size: var(--fs-h3);
+  font-weight: 600;
+  margin: 0;
+}
+.filter-pills {
+  display: flex;
+  gap: 6px;
+}
+.filter-pill {
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-meta);
+  font-weight: 500;
+  cursor: pointer;
+  background: transparent;
+  color: var(--muted);
+  transition: background 0.12s, color 0.12s;
+}
+.filter-pill:hover {
+  background: var(--fg-soft);
+  color: var(--fg);
+}
+.filter-pill.active {
+  background: var(--fg);
+  color: var(--surface);
+  border-color: var(--fg);
+}
+.game-card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--gap-md);
+  padding: var(--gap-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: var(--gap-sm);
+  transition: border-color 0.12s, transform 0.12s, box-shadow 0.12s;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+.game-card:hover {
+  border-color: var(--muted);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px var(--fg);
+  @supports (color: color-mix(in lab, red, red)) {
+    box-shadow: 0 4px 16px color-mix(in oklch, var(--fg) 8%, transparent);
+  }
+}
+.game-card.running {
+  border-left: 3px solid var(--running);
+}
+.game-card.waiting {
+  border-left: 3px solid var(--waiting);
+}
+.game-card.finished {
+  border-left: 3px solid var(--finished);
+}
+.game-info .game-name {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+.game-info .game-name a:hover {
+  color: var(--accent);
+}
+.game-meta {
+  display: flex;
+  gap: var(--gap-md);
+  flex-wrap: wrap;
+}
+.game-meta span {
+  font-size: var(--fs-meta);
+  color: var(--muted);
+}
+.game-meta .num {
+  color: var(--fg);
+  font-weight: 500;
+}
+.game-status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+.status-pill {
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.status-pill.running {
+  background: var(--running);
+  color: #fff;
+}
+.status-pill.waiting {
+  background: var(--waiting);
+  color: #fff;
+}
+.status-pill.finished {
+  background: var(--finished);
+  color: #fff;
+}
+.pagefoot {
+  padding-block: var(--gap-xl);
+  color: var(--muted);
+  font-size: 13px;
+  border-top: 1px solid var(--border);
+}
+.pagefoot .row-between {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--gap-md);
+}
+.game-card.featured {
+  padding: var(--gap-lg);
+  border: 2px solid var(--running);
+  background: linear-gradient(135deg, var(--surface), var(--running));
+  @supports (color: color-mix(in lab, red, red)) {
+    background: linear-gradient(135deg, var(--surface), color-mix(in oklch, var(--running) 4%, var(--surface)));
+  }
+}
+.game-card.featured .game-name {
+  font-size: 22px;
+}
+.live-pulse {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--running);
+  margin-bottom: 8px;
+}
+.live-pulse::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  background: var(--running);
+  border-radius: 50%;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.4;
+    transform: scale(0.8);
+  }
+}
+.progress-bar {
+  margin-top: 12px;
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.progress-bar .fill {
+  height: 100%;
+  background: var(--running);
+  border-radius: 2px;
+}
+.progress-label {
+  font-size: var(--fs-meta);
+  color: var(--muted);
+  margin-top: 4px;
+  font-weight: 500;
+}
+.progress-label .num {
+  color: var(--fg);
+  font-weight: 600;
+}
+.survivor-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  margin-top: 8px;
+}
+.survivor-avatar {
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: #fff;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+}
+.game-card .reveal-actions {
+  display: flex;
+  gap: var(--gap-xs);
+  padding-top: var(--gap-sm);
+  margin-top: var(--gap-sm);
+  border-top: 1px solid var(--border);
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.2s, opacity 0.2s, margin 0.2s, padding 0.2s;
+}
+.game-card:hover .reveal-actions {
+  max-height: 40px;
+  opacity: 1;
+}
+.reveal-btn {
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  background: var(--bg);
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.reveal-btn:hover {
+  background: var(--fg);
+  color: var(--surface);
+}
+.finished-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--gap-sm);
+}
+.finished-grid .game-card {
+  margin-bottom: 0;
+}
+.auth-links {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+}
+.auth-links a {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+  transition: color 0.15s;
+}
+.auth-links a:hover {
+  color: var(--fg);
+}
+.empty-state {
+  text-align: center;
+  padding-block: var(--gap-xl);
+  color: var(--muted);
+}
+.empty-state p:first-child {
+  font-size: var(--fs-lead);
+}
+.empty-state p:last-child {
+  font-size: var(--fs-meta);
+  margin-top: var(--gap-xs);
+}
+@media (max-width: 768px) {
+  .action-row {
+    grid-template-columns: 1fr;
+  }
+  .game-card {
+    grid-template-columns: 1fr;
+  }
+  .game-status {
+    flex-direction: row;
+    align-items: center;
+  }
+  .finished-grid {
+    grid-template-columns: 1fr;
+  }
+}
+@keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}

--- a/api/assets/package-lock.json
+++ b/api/assets/package-lock.json
@@ -1,0 +1,1094 @@
+{
+  "name": "hangrier-games-assets",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hangrier-games-assets",
+      "devDependencies": {
+        "@tailwindcss/cli": "^4.0.0",
+        "tailwindcss": "^4.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/cli": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.3.0.tgz",
+      "integrity": "sha512-X9kdlqyMopO9fewbgHsEeuy31YzMHbdZ9VsKt004tB+mxSg1CNbyhZYCzvhciN0AM4R4b5lvIprPjtNq7iQxpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/watcher": "^2.5.1",
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "enhanced-resolve": "^5.21.0",
+        "mri": "^1.2.0",
+        "picocolors": "^1.1.1",
+        "tailwindcss": "4.3.0"
+      },
+      "bin": {
+        "tailwindcss": "dist/index.mjs"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.5.tgz",
+      "integrity": "sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    }
+  }
+}

--- a/api/assets/src/main.css
+++ b/api/assets/src/main.css
@@ -1,35 +1,692 @@
 @import "tailwindcss";
 
-/* Custom theme colors for Hangrier Games */
-@theme {
-  --color-amber-400: #fbbf24;
-  --color-amber-500: #f59e0b;
-  --color-amber-600: #d97706;
-  --color-gray-950: #0a0a0a;
-  --color-gray-900: #171717;
-  --color-gray-800: #262626;
-  --color-gray-700: #404040;
-  --color-gray-600: #525252;
-  --color-gray-500: #737373;
-  --color-gray-400: #a3a3a3;
-  --color-gray-300: #d4d4d3;
-  --color-red-400: #f87171;
-  --color-red-700: #b91c1c;
-  --color-red-900: #7f1d1d;
-  --color-green-400: #4ade80;
-  --color-green-600: #16a34a;
-  --color-green-700: #15803d;
-  --color-green-900: #14532d;
-  --color-blue-400: #60a5fa;
-  --color-blue-600: #2563eb;
-  --color-blue-900: #1e3a8a;
-  --color-gold: #fbbf24;
+/* Google Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,16..72,200..800;1,16..72,200..800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+:root {
+  --bg:      oklch(97.5% 0.012 75);
+  --surface: oklch(99.5% 0.004 75);
+  --fg:      oklch(18% 0.015 70);
+  --muted:   oklch(52% 0.012 70);
+  --border:  oklch(88% 0.01 75);
+  --accent:  oklch(42% 0.18 285);
+  --accent-soft: color-mix(in oklch, var(--accent) 10%, transparent);
+  --fg-soft:     color-mix(in oklch, var(--fg) 5%, transparent);
+  --running:   oklch(60% 0.18 145);
+  --waiting:   oklch(65% 0.18 55);
+  --finished:  oklch(52% 0.012 70);
+  --font-display: 'Newsreader', 'Iowan Old Style', Georgia, serif;
+  --font-body:    'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, Menlo, monospace;
+  --fs-h1: clamp(48px, 7vw, 84px);
+  --fs-h2: clamp(28px, 3.5vw, 42px);
+  --fs-h3: 22px;
+  --fs-lead: 18px;
+  --fs-body: 15px;
+  --fs-meta: 12px;
+  --fs-xs: 11px;
+  --gap-xs: 6px;
+  --gap-sm: 12px;
+  --gap-md: 20px;
+  --gap-lg: 32px;
+  --gap-xl: 48px;
+  --container: 1200px;
+  --gutter: 28px;
+  --radius-sm: 4px;
+  --radius: 8px;
 }
 
-/* Spinner for loading states */
+*, *::before, *::after { box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+body {
+  margin: 0; background: var(--bg); color: var(--fg);
+  font-family: var(--font-body); font-size: var(--fs-body);
+  line-height: 1.6; text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+img, svg { display: block; max-width: 100%; }
+a { color: inherit; text-decoration: none; }
+button { font: inherit; cursor: pointer; }
+p { text-wrap: pretty; }
+h1, h2, h3, h4 { text-wrap: balance; }
+.container { max-width: var(--container); margin-inline: auto; padding-inline: var(--gutter); }
+.num { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+
+/* Top navigation */
+.topnav {
+  position: sticky; top: 0; z-index: 10;
+  background: color-mix(in oklch, var(--bg) 90%, transparent);
+  backdrop-filter: blur(14px); border-bottom: 1px solid var(--border);
+}
+.topnav-inner { display: flex; align-items: center; justify-content: space-between; padding-block: 12px; }
+.topnav .logo { font-family: var(--font-display); font-size: 18px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.topnav .logo span { color: var(--accent); }
+.topnav nav { display: flex; gap: var(--gap-lg); }
+.topnav nav a { font-size: 13px; font-weight: 500; color: var(--muted); letter-spacing: 0.02em; transition: color 0.15s; }
+.topnav nav a:hover { color: var(--fg); }
+.topnav nav a.active { color: var(--accent); }
+
+/* Page header */
+.page-header {
+  padding-block: var(--gap-xl);
+  border-bottom: 1px solid var(--border);
+}
+.page-header h1 {
+  font-family: var(--font-display);
+  font-size: var(--fs-h2);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+.page-header .deck {
+  font-size: var(--fs-lead);
+  color: var(--muted);
+  max-width: 500px;
+}
+
+/* Action row */
+.action-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--gap-lg);
+  padding-block: var(--gap-lg);
+  border-bottom: 1px solid var(--border);
+}
+.launch-block {
+  padding: var(--gap-lg);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+}
+.quickstart-btn {
+  padding: 18px 24px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  font-family: var(--font-display);
+  font-size: var(--fs-h3);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  text-align: left;
+  width: 100%;
+}
+.quickstart-btn:hover { opacity: 0.85; }
+.or-divider {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  font-size: var(--fs-meta);
+  color: var(--muted);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.or-divider::before, .or-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.create-form h3 {
+  font-family: var(--font-display);
+  font-size: var(--fs-h3);
+  font-weight: 600;
+  margin: 0 0 var(--gap-sm);
+}
+.create-form form {
+  display: flex;
+  gap: var(--gap-xs);
+}
+.create-form input {
+  flex: 1;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--fs-body);
+  background: var(--bg);
+  color: var(--fg);
+  outline: none;
+}
+.create-form input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+/* Stats column */
+.stats-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--gap-sm);
+  align-content: start;
+}
+.summary-card {
+  padding: 20px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  text-align: center;
+}
+.summary-card .s-val {
+  font-family: var(--font-display);
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.summary-card .s-label {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin-top: 4px;
+  font-weight: 500;
+}
+.summary-card.running .s-val { color: var(--running); }
+.summary-card.waiting .s-val { color: var(--waiting); }
+.summary-card.finished .s-val { color: var(--finished); }
+
+/* Buttons */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 12px 24px;
+  border-radius: var(--radius-sm);
+  border: none;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.btn:hover { opacity: 0.85; }
+.btn-primary { background: var(--accent); color: #fff; }
+.btn-ghost { background: transparent; color: var(--fg); border: 1px solid var(--border); }
+.btn-ghost:hover { background: var(--fg-soft); }
+.btn-sm { padding: 8px 16px; font-size: 13px; }
+
+/* Game list */
+.game-list { padding-block: var(--gap-lg); }
+.game-list-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: var(--gap-md);
+}
+.game-list-header h2 {
+  font-family: var(--font-display);
+  font-size: var(--fs-h3);
+  font-weight: 600;
+  margin: 0;
+}
+.filter-pills { display: flex; gap: 6px; }
+.filter-pill {
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-meta);
+  font-weight: 500;
+  cursor: pointer;
+  background: transparent;
+  color: var(--muted);
+  transition: background 0.12s, color 0.12s;
+}
+.filter-pill:hover { background: var(--fg-soft); color: var(--fg); }
+.filter-pill.active { background: var(--fg); color: var(--surface); border-color: var(--fg); }
+
+/* Game card */
+.game-card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--gap-md);
+  padding: var(--gap-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: var(--gap-sm);
+  transition: border-color 0.12s, transform 0.12s, box-shadow 0.12s;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+.game-card:hover {
+  border-color: var(--muted);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px color-mix(in oklch, var(--fg) 8%, transparent);
+}
+.game-card.running { border-left: 3px solid var(--running); }
+.game-card.waiting { border-left: 3px solid var(--waiting); }
+.game-card.finished { border-left: 3px solid var(--finished); }
+
+.game-info .game-name {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+.game-info .game-name a:hover { color: var(--accent); }
+.game-meta { display: flex; gap: var(--gap-md); flex-wrap: wrap; }
+.game-meta span { font-size: var(--fs-meta); color: var(--muted); }
+.game-meta .num { color: var(--fg); font-weight: 500; }
+
+.game-status { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; }
+.status-pill {
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.status-pill.running { background: var(--running); color: #fff; }
+.status-pill.waiting { background: var(--waiting); color: #fff; }
+.status-pill.finished { background: var(--finished); color: #fff; }
+
+/* Footer */
+.pagefoot { padding-block: var(--gap-xl); color: var(--muted); font-size: 13px; border-top: 1px solid var(--border); }
+.pagefoot .row-between { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: var(--gap-md); }
+
+/* Featured card */
+.game-card.featured {
+  padding: var(--gap-lg);
+  border: 2px solid var(--running);
+  background: linear-gradient(135deg, var(--surface), color-mix(in oklch, var(--running) 4%, var(--surface)));
+}
+.game-card.featured .game-name { font-size: 22px; }
+
+/* Live pulse */
+.live-pulse {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--running);
+  margin-bottom: 8px;
+}
+.live-pulse::before {
+  content: ''; width: 8px; height: 8px; background: var(--running);
+  border-radius: 50%; animation: pulse 1.5s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.8); }
+}
+
+/* Progress bar */
+.progress-bar {
+  margin-top: 12px; height: 4px; background: var(--border);
+  border-radius: 2px; overflow: hidden;
+}
+.progress-bar .fill { height: 100%; background: var(--running); border-radius: 2px; }
+.progress-label {
+  font-size: var(--fs-meta); color: var(--muted); margin-top: 4px; font-weight: 500;
+}
+.progress-label .num { color: var(--fg); font-weight: 600; }
+
+/* Survivor badge */
+.survivor-badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px;
+  background: var(--accent-soft); border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-xs); font-weight: 500;
+  margin-top: 8px;
+}
+.survivor-avatar {
+  width: 20px; height: 20px; display: grid; place-items: center;
+  border-radius: var(--radius-sm); background: var(--accent);
+  color: #fff; font-family: var(--font-mono); font-size: 9px; font-weight: 700;
+}
+
+/* Reveal actions */
+.game-card .reveal-actions {
+  display: flex; gap: var(--gap-xs);
+  padding-top: var(--gap-sm); margin-top: var(--gap-sm);
+  border-top: 1px solid var(--border);
+  max-height: 0; opacity: 0; overflow: hidden;
+  transition: max-height 0.2s, opacity 0.2s, margin 0.2s, padding 0.2s;
+}
+.game-card:hover .reveal-actions {
+  max-height: 40px; opacity: 1;
+}
+.reveal-btn {
+  padding: 5px 12px; border: 1px solid var(--border); border-radius: var(--radius-sm);
+  font-size: var(--fs-xs); font-weight: 500; background: var(--bg); color: var(--muted);
+  cursor: pointer; transition: background 0.12s, color 0.12s;
+}
+.reveal-btn:hover { background: var(--fg); color: var(--surface); }
+
+/* Finished grid */
+.finished-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: var(--gap-sm);
+}
+.finished-grid .game-card { margin-bottom: 0; }
+
+/* Auth links in nav */
+.auth-links { display: flex; align-items: center; gap: var(--gap-sm); }
+.auth-links a { font-size: 13px; font-weight: 500; color: var(--muted); transition: color 0.15s; }
+.auth-links a:hover { color: var(--fg); }
+
+/* Empty state */
+.empty-state { text-align: center; padding-block: var(--gap-xl); color: var(--muted); }
+.empty-state p:first-child { font-size: var(--fs-lead); }
+.empty-state p:last-child { font-size: var(--fs-meta); margin-top: var(--gap-xs); }
+
+/* Responsive */
+@media (max-width: 768px) {
+  .action-row { grid-template-columns: 1fr; }
+  .game-card { grid-template-columns: 1fr; }
+  .game-status { flex-direction: row; align-items: center; }
+  .finished-grid { grid-template-columns: 1fr; }
+}
+
+/* ── Detail page ─────────────────────────────────────────────────── */
+
+/* Detail header: game name + meta + actions */
+.detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--gap-md);
+  padding-block: var(--gap-xl);
+  border-bottom: 1px solid var(--border);
+}
+.detail-header h1 {
+  font-family: var(--font-display);
+  font-size: var(--fs-h2);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+.detail-meta {
+  font-size: var(--fs-lead);
+  color: var(--muted);
+}
+.detail-meta .num { color: var(--fg); font-weight: 500; }
+.detail-actions {
+  display: flex;
+  gap: var(--gap-xs);
+  flex-shrink: 0;
+  align-items: center;
+}
+.detail-actions .btn { white-space: nowrap; }
+
+/* Detail tabs */
+.detail-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+}
+.detail-tab {
+  padding: 12px 16px;
+  font-size: var(--fs-body);
+  font-weight: 500;
+  color: var(--muted);
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+.detail-tab:hover { color: var(--fg); }
+.detail-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Winner banner */
+.winner-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  padding: var(--gap-sm) var(--gap-md);
+  margin-bottom: var(--gap-md);
+  background: color-mix(in oklch, var(--waiting) 8%, var(--surface));
+  border: 1px solid var(--waiting);
+  border-radius: var(--radius);
+  font-weight: 600;
+  color: var(--waiting);
+}
+
+/* Back link */
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--fs-meta);
+  color: var(--muted);
+  font-weight: 500;
+  padding: 6px 0;
+  margin-bottom: var(--gap-sm);
+  transition: color 0.12s;
+}
+.back-link:hover { color: var(--accent); }
+
+/* Card grid */
+.card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--gap-sm);
+}
+@media (min-width: 640px) {
+  .card-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1024px) {
+  .card-grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+/* District / section header */
+.section-header {
+  font-size: var(--fs-meta);
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: var(--gap-sm);
+  margin-top: var(--gap-md);
+}
+.section-header:first-child { margin-top: 0; }
+
+/* Tribute card */
+.tribute-card {
+  padding: var(--gap-sm);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+.tribute-card:hover {
+  border-color: var(--muted);
+  box-shadow: 0 2px 8px color-mix(in oklch, var(--fg) 6%, transparent);
+}
+.tribute-card .card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--gap-xs);
+}
+.tribute-card .card-name {
+  font-weight: 600;
+  font-size: var(--fs-body);
+}
+.tribute-card .card-status { font-size: var(--fs-meta); }
+.tribute-card .card-status.alive { color: var(--running); }
+.tribute-card .card-status.dead { color: oklch(55% 0.2 25); }
+.tribute-card .card-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+.tribute-card .card-stats .stat-val {
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-weight: 500;
+  text-align: right;
+}
+.tribute-card .card-bands {
+  display: flex;
+  gap: var(--gap-sm);
+  padding-top: var(--gap-xs);
+  margin-top: var(--gap-xs);
+  border-top: 1px solid var(--border);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+}
+.tribute-card .card-location {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin-top: 4px;
+}
+.tribute-card .card-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding-top: var(--gap-xs);
+  margin-top: var(--gap-xs);
+  border-top: 1px solid var(--border);
+}
+.tribute-card .item-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-xs);
+  color: var(--fg);
+}
+
+/* Area card */
+.area-card {
+  padding: var(--gap-sm);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+.area-card:hover {
+  border-color: var(--muted);
+  box-shadow: 0 2px 8px color-mix(in oklch, var(--fg) 6%, transparent);
+}
+.area-card .card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--gap-xs);
+}
+.area-card .card-name {
+  font-weight: 600;
+  font-size: var(--fs-body);
+}
+.area-card .card-status { font-size: var(--fs-meta); font-weight: 500; }
+.area-card .card-status.open { color: var(--running); }
+.area-card .card-status.active { color: var(--waiting); }
+.area-card .card-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: var(--gap-xs);
+}
+.area-card .item-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-xs);
+  color: var(--fg);
+}
+.area-card .card-events {
+  padding-top: var(--gap-xs);
+  margin-top: var(--gap-xs);
+  border-top: 1px solid var(--border);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+.area-card .card-events li { margin-bottom: 2px; }
+
+/* Log container */
+.log-container {
+  max-height: 70vh;
+  overflow-y: auto;
+  padding-right: var(--gap-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+}
+.log-container::-webkit-scrollbar { width: 6px; }
+.log-container::-webkit-scrollbar-track { background: transparent; }
+.log-container::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+/* Log entry */
+.log-entry {
+  padding: var(--gap-sm);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.log-entry .log-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-xs);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin-bottom: 6px;
+  font-weight: 500;
+}
+.log-entry .log-content {
+  font-size: var(--fs-body);
+  line-height: 1.5;
+}
+.log-entry .log-subject {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin-top: 4px;
+}
+.capitalize { text-transform: capitalize; }
+
+/* Kind colors for log entries */
+.kind-death { color: oklch(55% 0.2 25); }
+.kind-combat { color: var(--waiting); }
+.kind-alliance { color: oklch(55% 0.18 240); }
+.kind-movement { color: var(--accent); }
+.kind-item { color: oklch(65% 0.18 85); }
+.kind-state { color: var(--muted); }
+
+/* Survival band colors */
+.band-good { color: var(--running); }
+.band-warn { color: var(--waiting); }
+.band-danger { color: oklch(55% 0.2 25); }
+.band-none { color: var(--muted); }
+
+/* Spinner */
+.spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.125em;
+  animation: spin 0.8s linear infinite;
+}
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
-.animate-spin {
-  animation: spin 1s linear infinite;
+.htmx-indicator { display: none; }
+.htmx-request .htmx-indicator,
+.htmx-indicator.htmx-request { display: inline; }
+
+/* Icon sizing (replaces Tailwind w-4 h-4 inline) */
+.icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.125em;
+  flex-shrink: 0;
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -271,9 +271,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "/assets",
             tower_http::services::ServeDir::new(
                 std::path::PathBuf::from(&manifest_dir)
-                    .parent()
-                    .unwrap()
-                    .join("web")
                     .join("assets")
                     .join("dist"),
             ),
@@ -530,6 +527,8 @@ struct GamesListQuery {
     limit: u32,
     #[serde(default)]
     offset: u32,
+    #[serde(default)]
+    status: Option<String>,
 }
 
 fn default_limit() -> u32 {
@@ -552,31 +551,49 @@ async fn games_list_handler(
         .bind(("offset", offset))
         .await;
 
-    let games = match result {
-        Ok(mut result) => {
-            let games: Vec<ListDisplayGame> = result.take(0).unwrap_or_default();
-            let total = games.len() as u32;
-            let has_more = (offset + limit) < total;
-            let pagination = shared::PaginationMetadata {
-                total,
-                limit,
-                offset,
-                has_more,
-            };
-            shared::PaginatedGames { games, pagination }
-        }
-        Err(_) => shared::PaginatedGames {
-            games: vec![],
-            pagination: shared::PaginationMetadata {
-                total: 0,
-                limit,
-                offset,
-                has_more: false,
-            },
-        },
+    let all_games: Vec<ListDisplayGame> = match result {
+        Ok(mut result) => result.take(0).unwrap_or_default(),
+        Err(_) => vec![],
     };
 
-    Html(pages::games_list_page(auth, &games))
+    let games = filter_games_by_status(&all_games, params.status.as_deref());
+    let total = all_games.len() as u32;
+    let has_more = (offset + limit) < total;
+    let pagination = shared::PaginationMetadata {
+        total,
+        limit,
+        offset,
+        has_more,
+    };
+    let paginated = shared::PaginatedGames { games, pagination };
+    let stats = api::templates::pages::GameStats::from_games(&all_games);
+    let active_filter = params.status.as_deref().unwrap_or("");
+
+    Html(pages::games_list_page(auth, &paginated, &stats, active_filter))
+}
+
+fn filter_games_by_status(
+    games: &[ListDisplayGame],
+    status: Option<&str>,
+) -> Vec<ListDisplayGame> {
+    match status {
+        Some("running") => games
+            .iter()
+            .filter(|g| g.status == shared::GameStatus::InProgress)
+            .cloned()
+            .collect(),
+        Some("waiting") => games
+            .iter()
+            .filter(|g| g.status == shared::GameStatus::NotStarted)
+            .cloned()
+            .collect(),
+        Some("finished") => games
+            .iter()
+            .filter(|g| g.status == shared::GameStatus::Finished)
+            .cloned()
+            .collect(),
+        Some(_) | None => games.to_vec(),
+    }
 }
 
 // ── Game detail HTMX handlers ─────────────────────────────────────────

--- a/api/src/templates/game_detail.rs
+++ b/api/src/templates/game_detail.rs
@@ -12,52 +12,50 @@ pub fn game_detail_page(auth: AuthState, game: &DisplayGame) -> maud::Markup {
         html! {
             div hx-ext="sse" sse-connect=(format!("/api/games/{}/events", game.identifier)) {
                 // Header section
-                div class="mb-6" {
-                    div class="flex items-center justify-between" {
-                        div {
-                            h1 class="text-2xl font-bold text-amber-400" { (game.name) }
-                            p class="text-sm text-gray-400 mt-1" {
-                                "Day " (game.day.unwrap_or(0))
-                                " · "
-                                span class=(status_color(&game.status.to_string())) { (game.status) }
-                                " · "
-                                span id="living-count" { (game.living_count) } "/" (game.tribute_count) " alive"
-                            }
+                div class="detail-header" {
+                    div {
+                        h1 { (game.name) }
+                        p class="detail-meta" {
+                            "Day " (game.day.unwrap_or(0))
+                            " · "
+                            span class=(status_color(&game.status.to_string())) { (game.status) }
+                            " · "
+                            span id="living-count" class="num" { (game.living_count) } "/" (game.tribute_count) " alive"
                         }
-                        @if game.is_mine {
-                            div class="flex gap-2" {
-                                @if game.status == GameStatus::NotStarted {
-                                    button
-                                        class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded font-semibold relative"
-                                        hx-put=(format!("/api/games/{}/next", game.identifier))
-                                        hx-target="#game-status"
-                                        hx-swap="innerHTML"
-                                        hx-disabled-elt="this"
-                                        hx-indicator="#start-spinner" {
-                                        "Start Game"
-                                        span id="start-spinner" class="htmx-indicator ml-2" {
-                                            (spinner_icon())
-                                        }
+                    }
+                    @if game.is_mine {
+                        div class="detail-actions" {
+                            @if game.status == GameStatus::NotStarted {
+                                button
+                                    class="btn btn-primary btn-sm"
+                                    hx-put=(format!("/api/games/{}/next", game.identifier))
+                                    hx-target="#game-status"
+                                    hx-swap="innerHTML"
+                                    hx-disabled-elt="this"
+                                    hx-indicator="#start-spinner" {
+                                    "Start Game"
+                                    span id="start-spinner" class="htmx-indicator" {
+                                        (spinner_icon())
                                     }
-                                } @else if game.status == GameStatus::InProgress {
-                                    button
-                                        class="bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded font-semibold relative"
-                                        hx-put=(format!("/api/games/{}/next", game.identifier))
-                                        hx-target="#game-status"
-                                        hx-swap="innerHTML"
-                                        hx-disabled-elt="this"
-                                        hx-indicator="#play-spinner" {
-                                        "Play Day " (game.day.unwrap_or(0))
-                                        span id="play-spinner" class="htmx-indicator ml-2" {
-                                            (spinner_icon())
-                                        }
+                                }
+                            } @else if game.status == GameStatus::InProgress {
+                                button
+                                    class="btn btn-ghost btn-sm"
+                                    hx-put=(format!("/api/games/{}/next", game.identifier))
+                                    hx-target="#game-status"
+                                    hx-swap="innerHTML"
+                                    hx-disabled-elt="this"
+                                    hx-indicator="#play-spinner" {
+                                    "Play Day " (game.day.unwrap_or(0))
+                                    span id="play-spinner" class="htmx-indicator" {
+                                        (spinner_icon())
                                     }
                                 }
                             }
-                        } @else {
-                            p class="text-sm text-gray-500" {
-                                "By " (game.created_by.username)
-                            }
+                        }
+                    } @else {
+                        p class="detail-meta" {
+                            "By " (game.created_by.username)
                         }
                     }
                 }
@@ -66,35 +64,33 @@ pub fn game_detail_page(auth: AuthState, game: &DisplayGame) -> maud::Markup {
                 div id="game-status" {
                     @if game.status == GameStatus::Finished {
                         @if let Some(winner) = &game.winner {
-                            div class="mb-4 p-3 bg-amber-900/30 border border-amber-700 rounded-lg" {
-                                p class="text-amber-300 font-semibold" {
-                                    (icon("trophy"))
-                                    " Winner: " (winner.name)
-                                }
+                            div class="winner-banner" {
+                                (icon("trophy"))
+                                span { "Winner: " (winner.name) }
                             }
                         }
                     }
                 }
 
                 // Navigation tabs
-                nav class="flex gap-4 border-b border-gray-800 mb-6" {
+                nav class="detail-tabs" {
                     a href=(format!("/games/{}/tributes", game.identifier))
-                        class="pb-2 px-1 text-sm font-medium text-gray-400 hover:text-white border-b-2 border-transparent hover:border-amber-500" {
+                        class="detail-tab" {
                         "Tributes"
                     }
                     a href=(format!("/games/{}/areas", game.identifier))
-                        class="pb-2 px-1 text-sm font-medium text-gray-400 hover:text-white border-b-2 border-transparent hover:border-amber-500" {
+                        class="detail-tab" {
                         "Areas"
                     }
                     a href=(format!("/games/{}/log", game.identifier))
-                        class="pb-2 px-1 text-sm font-medium text-gray-400 hover:text-white border-b-2 border-transparent hover:border-amber-500" {
+                        class="detail-tab" {
                         "Log"
                     }
                 }
 
                 // Content area — sub-pages load here via HTMX
                 div id="detail-content" {
-                    p class="text-gray-500" { "Select a tab above" }
+                    p class="empty-state" { "Select a tab above" }
                 }
             }
         },
@@ -111,16 +107,16 @@ pub fn tributes_page(
         "Tributes",
         auth,
         html! {
-            div {
+            div class="container" style="padding-block:var(--gap-lg);" {
                 a href=(format!("/games/{}", game_id))
-                    class="text-sm text-gray-400 hover:text-white mb-4 inline-block" {
+                    class="back-link" {
                     (icon("arrow-left"))
                     " Back to Game"
                 }
-                h2 class="text-xl font-bold text-amber-400 mb-4" { "Tributes" }
+                h2 style="font-family:var(--font-display);font-size:var(--fs-h3);font-weight:600;margin:0 0 var(--gap-md);" { "Tributes" }
 
                 @if tributes.is_empty() {
-                    p class="text-gray-500" { "No tributes yet." }
+                    p class="empty-state" { "No tributes yet." }
                 } @else {
                     // Group by district
                     @for district_num in 1..=12 {
@@ -128,11 +124,11 @@ pub fn tributes_page(
                             .filter(|t| t.district == district_num)
                             .collect();
                         @if !district_tributes.is_empty() {
-                            div class="mb-6" {
-                                h3 class="text-sm font-semibold text-gray-300 mb-2" {
+                            div {
+                                h3 class="section-header" {
                                     "District " (district_num)
                                 }
-                                div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" {
+                                div class="card-grid" {
                                     @for tribute in &district_tributes {
                                         (tribute_card(tribute))
                                     }
@@ -149,50 +145,46 @@ pub fn tributes_page(
 /// Single tribute card with stats strip.
 fn tribute_card(tribute: &game::tributes::Tribute) -> maud::Markup {
     let is_alive = tribute.is_alive();
-    let status_class = if is_alive {
-        "text-green-400"
-    } else {
-        "text-red-400"
-    };
+    let status_class = if is_alive { "alive" } else { "dead" };
     let status_icon = if is_alive { "check-circle" } else { "x-circle" };
 
     html! {
-        div class="bg-gray-900 border border-gray-800 rounded-lg p-3" {
-            div class="flex items-center justify-between mb-2" {
-                span class="font-semibold text-white text-sm" { (tribute.name) }
-                span class=(status_class) { (icon(status_icon)) }
+        div class="tribute-card" {
+            div class="card-top" {
+                span class="card-name" { (tribute.name) }
+                span class=(format!("card-status {}", status_class)) { (icon(status_icon)) }
             }
 
             // Stats strip
-            div class="space-y-1 text-xs" {
+            div class="card-stats" {
                 // Health
-                div class="flex items-center gap-1" {
+                div {
                     (icon("heart"))
-                    span class="text-gray-400" { "HP" }
-                    span class="text-gray-200 ml-auto" { (tribute.attributes.health) }
+                    " HP "
+                    span class="stat-val" { (tribute.attributes.health) }
                 }
                 // Sanity
-                div class="flex items-center gap-1" {
+                div {
                     (icon("brain"))
-                    span class="text-gray-400" { "SAN" }
-                    span class="text-gray-200 ml-auto" { (tribute.attributes.sanity) }
+                    " SAN "
+                    span class="stat-val" { (tribute.attributes.sanity) }
                 }
                 // Movement
-                div class="flex items-center gap-1" {
+                div {
                     (icon("zap"))
-                    span class="text-gray-400" { "MOV" }
-                    span class="text-gray-200 ml-auto" { (tribute.attributes.movement) }
+                    " MOV "
+                    span class="stat-val" { (tribute.attributes.movement) }
                 }
                 // Strength
-                div class="flex items-center gap-1" {
+                div {
                     (icon("sword"))
-                    span class="text-gray-400" { "STR" }
-                    span class="text-gray-200 ml-auto" { (tribute.attributes.strength) }
+                    " STR "
+                    span class="stat-val" { (tribute.attributes.strength) }
                 }
             }
 
             // Survival bands
-            div class="mt-2 pt-2 border-t border-gray-800 flex gap-2 text-xs" {
+            div class="card-bands" {
                 span class=(hunger_color(tribute.hunger)) { "H: " (hunger_label(tribute.hunger)) }
                 span class=(thirst_color(tribute.thirst)) { "T: " (thirst_label(tribute.thirst)) }
                 span class=(stamina_color(tribute.stamina, tribute.max_stamina)) {
@@ -201,21 +193,18 @@ fn tribute_card(tribute: &game::tributes::Tribute) -> maud::Markup {
             }
 
             // Area location
-            div class="mt-1 text-xs text-gray-500" {
+            div class="card-location" {
                 (icon("map-pin"))
                 " " (tribute.area)
             }
 
             // Inventory
             @if !tribute.items.is_empty() {
-                div class="mt-2 pt-2 border-t border-gray-800" {
-                    p class="text-xs text-gray-500 mb-1" { "Items:" }
-                    div class="flex flex-wrap gap-1" {
-                        @for item in &tribute.items {
-                            span class="text-xs bg-gray-800 text-gray-300 px-1.5 py-0.5 rounded" {
-                                (icon("backpack"))
-                                " " (item.name)
-                            }
+                div class="card-items" {
+                    @for item in &tribute.items {
+                        span class="item-tag" {
+                            (icon("backpack"))
+                            " " (item.name)
                         }
                     }
                 }
@@ -234,18 +223,18 @@ pub fn areas_page(
         "Areas",
         auth,
         html! {
-            div {
+            div class="container" style="padding-block:var(--gap-lg);" {
                 a href=(format!("/games/{}", game_id))
-                    class="text-sm text-gray-400 hover:text-white mb-4 inline-block" {
+                    class="back-link" {
                     (icon("arrow-left"))
                     " Back to Game"
                 }
-                h2 class="text-xl font-bold text-amber-400 mb-4" { "Areas" }
+                h2 style="font-family:var(--font-display);font-size:var(--fs-h3);font-weight:600;margin:0 0 var(--gap-md);" { "Areas" }
 
                 @if areas.is_empty() {
-                    p class="text-gray-500" { "No areas yet." }
+                    p class="empty-state" { "No areas yet." }
                 } @else {
-                    div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" {
+                    div class="card-grid" {
                         @for area in areas {
                             (area_card(area))
                         }
@@ -260,20 +249,16 @@ pub fn areas_page(
 fn area_card(area: &game::areas::AreaDetails) -> maud::Markup {
     let is_open = area.events.is_empty();
     let status_text = if is_open { "Open" } else { "Active Events" };
-    let status_class = if is_open {
-        "text-green-400"
-    } else {
-        "text-orange-400"
-    };
+    let status_class = if is_open { "open" } else { "active" };
 
     html! {
-        div class="bg-gray-900 border border-gray-800 rounded-lg p-3" {
-            div class="flex items-center justify-between mb-2" {
-                h3 class="font-semibold text-white text-sm" {
+        div class="area-card" {
+            div class="card-top" {
+                h3 class="card-name" {
                     (icon("map-pin"))
                     " " (area.name)
                 }
-                span class=(status_class) {
+                span class=(format!("card-status {}", status_class)) {
                     @if is_open {
                         (icon("unlock"))
                     } @else {
@@ -285,14 +270,11 @@ fn area_card(area: &game::areas::AreaDetails) -> maud::Markup {
 
             // Items
             @if !area.items.is_empty() {
-                div class="mt-2" {
-                    p class="text-xs text-gray-500 mb-1" { "Items:" }
-                    div class="flex flex-wrap gap-1" {
-                        @for item in &area.items {
-                            span class="text-xs bg-gray-800 text-gray-300 px-1.5 py-0.5 rounded" {
-                                (icon("backpack"))
-                                " " (item.name)
-                            }
+                div class="card-items" {
+                    @for item in &area.items {
+                        span class="item-tag" {
+                            (icon("backpack"))
+                            " " (item.name)
                         }
                     }
                 }
@@ -300,9 +282,9 @@ fn area_card(area: &game::areas::AreaDetails) -> maud::Markup {
 
             // Events
             @if !area.events.is_empty() {
-                div class="mt-2 pt-2 border-t border-gray-800" {
-                    p class="text-xs text-gray-500 mb-1" { "Events:" }
-                    ul class="text-xs text-gray-400 space-y-0.5" {
+                div class="card-events" {
+                    p style="font-weight:600;margin-bottom:4px;" { "Events:" }
+                    ul style="list-style:none;padding:0;" {
                         @for event in &area.events {
                             li { (narrative_icon("event")) " " (event) }
                         }
@@ -337,19 +319,19 @@ pub fn log_page(
         "Log",
         auth,
         html! {
-            div hx-ext="sse" sse-connect=(format!("/api/games/{}/events", game_id)) {
+            div class="container" style="padding-block:var(--gap-lg);" hx-ext="sse" sse-connect=(format!("/api/games/{}/events", game_id)) {
                 a href=(format!("/games/{}", game_id))
-                    class="text-sm text-gray-400 hover:text-white mb-4 inline-block" {
+                    class="back-link" {
                     (icon("arrow-left"))
                     " Back to Game"
                 }
-                h2 class="text-xl font-bold text-amber-400 mb-4" { "Game Log" }
+                h2 style="font-family:var(--font-display);font-size:var(--fs-h3);font-weight:600;margin:0 0 var(--gap-md);" { "Game Log" }
 
                 @if messages.is_empty() {
-                    p class="text-gray-500" { "No messages yet." }
+                    p class="empty-state" { "No messages yet." }
                 } @else {
                     div id="log-entries"
-                        class="max-h-[70vh] overflow-y-auto space-y-2 pr-2"
+                        class="log-container"
                         hx-trigger=(format!("sse:{}", sse_events))
                         hx-get=(format!("/games/{}/log", game_id))
                         hx-target="#log-entries"
@@ -372,8 +354,8 @@ fn log_entry(msg: &shared::messages::GameMessage) -> maud::Markup {
     let kind_clr = kind_color(&msg.payload);
 
     html! {
-        div class="bg-gray-900 border border-gray-800 rounded p-3" {
-            div class="flex items-center gap-2 text-xs text-gray-500 mb-1" {
+        div class="log-entry" {
+            div class="log-meta" {
                 span { "Day " (msg.game_day) }
                 span { "·" }
                 span class="capitalize" { (phase_label) }
@@ -381,9 +363,9 @@ fn log_entry(msg: &shared::messages::GameMessage) -> maud::Markup {
                 (kind_icon)
                 span class=(kind_clr) { (kind_label) }
             }
-            p class="text-sm text-gray-200" { (msg.content) }
+            p class="log-content" { (msg.content) }
             @if !msg.subject.is_empty() {
-                p class="text-xs text-gray-500 mt-1" { (msg.subject) }
+                p class="log-subject" { (msg.subject) }
             }
         }
     }
@@ -452,12 +434,12 @@ fn message_kind_icon(payload: &shared::messages::MessagePayload) -> maud::Markup
 fn kind_color(payload: &shared::messages::MessagePayload) -> &'static str {
     use shared::messages::MessageKind;
     match payload.kind() {
-        MessageKind::Death => "text-red-400",
-        MessageKind::Combat | MessageKind::CombatSwing => "text-orange-400",
-        MessageKind::Alliance => "text-blue-400",
-        MessageKind::Movement => "text-purple-400",
-        MessageKind::Item | MessageKind::SponsorGift => "text-yellow-400",
-        MessageKind::State | MessageKind::Trauma => "text-gray-400",
+        MessageKind::Death => "kind-death",
+        MessageKind::Combat | MessageKind::CombatSwing => "kind-combat",
+        MessageKind::Alliance => "kind-alliance",
+        MessageKind::Movement => "kind-movement",
+        MessageKind::Item | MessageKind::SponsorGift => "kind-item",
+        MessageKind::State | MessageKind::Trauma => "kind-state",
     }
 }
 
@@ -466,9 +448,9 @@ fn kind_color(payload: &shared::messages::MessagePayload) -> &'static str {
 /// Inline SVG spinner for HTMX loading indicators.
 fn spinner_icon() -> maud::Markup {
     maud::html! {
-        svg class="inline w-4 h-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" {
-            circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" {}
-            path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" {}
+        svg class="spinner" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" {
+            circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" stroke-opacity="0.25" {}
+            path fill="currentColor" fill-opacity="0.75" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" {}
         }
     }
 }
@@ -486,10 +468,10 @@ fn hunger_label(hunger: u8) -> &'static str {
 
 fn hunger_color(hunger: u8) -> &'static str {
     match hunger {
-        0 => "text-green-400",
-        1..=2 => "text-yellow-400",
-        3..=4 => "text-orange-400",
-        _ => "text-red-400",
+        0 => "band-good",
+        1..=2 => "band-warn",
+        3..=4 => "band-warn",
+        _ => "band-danger",
     }
 }
 
@@ -504,10 +486,10 @@ fn thirst_label(thirst: u8) -> &'static str {
 
 fn thirst_color(thirst: u8) -> &'static str {
     match thirst {
-        0 => "text-green-400",
-        1..=2 => "text-yellow-400",
-        3..=4 => "text-orange-400",
-        _ => "text-red-400",
+        0 => "band-good",
+        1..=2 => "band-warn",
+        3..=4 => "band-warn",
+        _ => "band-danger",
     }
 }
 
@@ -527,14 +509,14 @@ fn stamina_label(stamina: u32, max_stamina: u32) -> &'static str {
 
 fn stamina_color(stamina: u32, max_stamina: u32) -> &'static str {
     if max_stamina == 0 {
-        return "text-gray-500";
+        return "band-none";
     }
     let ratio = stamina as f64 / max_stamina as f64;
     if ratio > 0.66 {
-        "text-green-400"
+        "band-good"
     } else if ratio > 0.33 {
-        "text-yellow-400"
+        "band-warn"
     } else {
-        "text-red-400"
+        "band-danger"
     }
 }

--- a/api/src/templates/mod.rs
+++ b/api/src/templates/mod.rs
@@ -35,41 +35,55 @@ pub fn base_layout(title: &str, auth: AuthState, content: Markup) -> Markup {
             head {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
-                title { (title) " — Hangrier Games" }
+                title { (title) " — Hangry Games" }
+                link rel="preconnect" href="https://fonts.googleapis.com";
+                link rel="preconnect" href="https://fonts.gstatic.com" crossorigin;
+                link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,16..72,200..800;1,16..72,200..800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet";
                 link rel="stylesheet" href="/assets/main.css";
                 script src="https://unpkg.com/htmx.org@2.0.4" {}
                 script src="https://unpkg.com/htmx-ext-sse@2.2.3" {}
             }
-            body class="bg-gray-950 text-gray-100 min-h-screen" {
-                // SVG sprites served as static files — browser caches after first load
+            body {
+                // SVG sprites served as static files
                 (PreEscaped(r#"<svg xmlns="http://www.w3.org/2000/svg" style="display:none"><use href="/icons/sprite-ui.svg"/></svg>"#))
                 (PreEscaped(r#"<svg xmlns="http://www.w3.org/2000/svg" style="display:none"><use href="/icons/sprite-narrative.svg"/></svg>"#))
-                nav class="bg-gray-900 border-b border-gray-800 px-4 py-3" {
-                    div class="max-w-6xl mx-auto flex items-center justify-between" {
-                        a href="/" class="text-lg font-bold text-amber-400" { "Hangrier Games" }
-                        (nav_links(&auth))
+                header class="topnav" {
+                    div class="container topnav-inner" {
+                        div class="logo" {
+                            "Hangry "
+                            span { "Games" }
+                        }
+                        nav {
+                            a href="/games" class="active" { "Broadcast" }
+                            a href="#" { "Tributes" }
+                            a href="#" { "Arena" }
+                            a href="#" { "Odds" }
+                        }
+                        (auth_links(&auth))
                     }
                 }
-                main class="max-w-6xl mx-auto px-4 py-6" {
+                main {
                     (content)
+                }
+                footer class="pagefoot" {
+                    div class="container row-between" {
+                        span { "© Hangry Games" }
+                        span class="num" { "Server v0.1.15" }
+                    }
                 }
             }
         }
     }
 }
 
-/// Render navigation links based on authentication state.
-pub fn nav_links(auth: &AuthState) -> Markup {
+/// Render auth links based on authentication state.
+fn auth_links(auth: &AuthState) -> Markup {
     html! {
-        div class="flex items-center gap-4" {
-            a href="/games" class="text-sm text-gray-300 hover:text-white" { "Games" }
+        div class="auth-links" {
             @if auth.is_authenticated {
-                a href="/account" class="text-sm text-gray-300 hover:text-white" {
-                    (icon("user"))
-                    " " (auth.username.as_deref().unwrap_or("Account"))
-                }
+                a href="/account" { (auth.username.as_deref().unwrap_or("Account")) }
             } @else {
-                a href="/login" class="text-sm text-gray-300 hover:text-white" { "Login" }
+                a href="/login" { "Login" }
             }
         }
     }
@@ -77,7 +91,7 @@ pub fn nav_links(auth: &AuthState) -> Markup {
 
 pub fn icon(name: &str) -> Markup {
     html! {
-        svg class="inline w-4 h-4" {
+        svg class="icon" {
             use href=(format!("#icon_ui_{}", name)) {}
         }
     }
@@ -85,7 +99,7 @@ pub fn icon(name: &str) -> Markup {
 
 pub fn narrative_icon(name: &str) -> Markup {
     html! {
-        svg class="inline w-4 h-4" {
+        svg class="icon" {
             use href=(format!("#icon_narrative_{}", name)) {}
         }
     }

--- a/api/src/templates/pages.rs
+++ b/api/src/templates/pages.rs
@@ -1,7 +1,36 @@
 use maud::html;
-use shared::{ListDisplayGame, PaginatedGames};
+use shared::{GameStatus, ListDisplayGame, PaginatedGames};
 
 use super::{AuthState, base_layout};
+
+/// Aggregated game statistics for the dashboard.
+pub struct GameStats {
+    pub running: u32,
+    pub waiting: u32,
+    pub finished: u32,
+    pub total: u32,
+}
+
+impl GameStats {
+    pub fn from_games(games: &[ListDisplayGame]) -> Self {
+        let mut running = 0;
+        let mut waiting = 0;
+        let mut finished = 0;
+        for g in games {
+            match g.status {
+                GameStatus::InProgress => running += 1,
+                GameStatus::NotStarted => waiting += 1,
+                GameStatus::Finished => finished += 1,
+            }
+        }
+        Self {
+            running,
+            waiting,
+            finished,
+            total: games.len() as u32,
+        }
+    }
+}
 
 pub fn home_page(auth: AuthState) -> maud::Markup {
     base_layout(
@@ -19,31 +48,124 @@ pub fn home_page(auth: AuthState) -> maud::Markup {
     )
 }
 
-pub fn games_list_page(auth: AuthState, paginated: &PaginatedGames) -> maud::Markup {
+pub fn games_list_page(
+    auth: AuthState,
+    paginated: &PaginatedGames,
+    stats: &GameStats,
+    active_filter: &str,
+) -> maud::Markup {
     base_layout(
         "Games",
         auth,
         html! {
-            h1 class="text-2xl font-bold text-amber-400 mb-6" { "Games" }
-            @if paginated.games.is_empty() {
-                p class="text-gray-400" { "No games yet." }
-            } @else {
-                div class="space-y-4" {
-                    @for game in &paginated.games {
-                        (game_card(game))
+            // Page header
+            section class="page-header" {
+                div class="container" {
+                    h1 { "Games" }
+                    p class="deck" { "All simulations — past, present, and waiting to begin." }
+                }
+            }
+
+            // Action row
+            div class="container" {
+                div class="action-row" {
+                    // Left: launch block
+                    div class="launch-block" {
+                        // Quickstart form
+                        form method="POST" action="/games/new" {
+                            input type="hidden" name="csrf_token" value="";
+                            input type="hidden" name="name" value="Quick Game";
+                            button.quickstart-btn type="submit" { "⚡ Quickstart — New 24-Tribute Game" }
+                        }
+                        div class="or-divider" { "or" }
+                        // Create form
+                        div class="create-form" {
+                            h3 { "Create a Game" }
+                            form method="POST" action="/games/new" {
+                                input type="hidden" name="csrf_token" value="";
+                                input type="text" name="name" placeholder="Game name";
+                                button class="btn btn-primary btn-sm" type="submit" { "Create" }
+                            }
+                        }
+                    }
+                    // Right: stats column
+                    div class="stats-col" {
+                        (summary_card("Running", stats.running, "running"))
+                        (summary_card("Waiting", stats.waiting, "waiting"))
+                        (summary_card("Finished", stats.finished, "finished"))
+                        (summary_card("Total Games", stats.total, ""))
                     }
                 }
-                @if paginated.pagination.has_more {
-                    div class="mt-6 text-center" {
-                        button
-                            class="bg-gray-800 hover:bg-gray-700 text-gray-300 px-4 py-2 rounded"
-                            hx-get=(format!("/games?offset={}&limit={}",
-                                paginated.pagination.offset + paginated.pagination.limit,
-                                paginated.pagination.limit))
-                            hx-target="#games-list"
-                            hx-swap="beforeend"
-                            hx-disabled-elt="this" {
-                            "Load More"
+            }
+
+            // Game list section
+            section class="game-list" {
+                div class="container" {
+                    div class="game-list-header" {
+                        h2 { "All Games" }
+                        div class="filter-pills" {
+                            (filter_pill("All", "", active_filter))
+                            (filter_pill("Running", "running", active_filter))
+                            (filter_pill("Waiting", "waiting", active_filter))
+                            (filter_pill("Finished", "finished", active_filter))
+                        }
+                    }
+
+                    div id="games-list-content" {
+                        @if paginated.games.is_empty() {
+                            div class="empty-state" {
+                                p { "No games yet" }
+                                p { "Create a game to get started" }
+                            }
+                        } @else {
+                            @let running_games: Vec<_> = paginated.games.iter()
+                                .filter(|g| g.status == GameStatus::InProgress)
+                                .collect();
+                            @let waiting_games: Vec<_> = paginated.games.iter()
+                                .filter(|g| g.status == GameStatus::NotStarted)
+                                .collect();
+                            @let finished_games: Vec<_> = paginated.games.iter()
+                                .filter(|g| g.status == GameStatus::Finished)
+                                .collect();
+
+                            // Featured running cards (first 2)
+                            @for (idx, game) in running_games.iter().enumerate() {
+                                @if idx < 2 {
+                                    (featured_running_card(game))
+                                } @else {
+                                    (running_card(game))
+                                }
+                            }
+
+                            // Waiting cards
+                            @for game in &waiting_games {
+                                (waiting_card(game))
+                            }
+
+                            // Finished heading + grid
+                            @if !finished_games.is_empty() {
+                                h3 style="font-family:var(--font-display);font-size:var(--fs-h3);font-weight:600;margin:var(--gap-lg) 0 var(--gap-md);" { "Finished" }
+                                div class="finished-grid" {
+                                    @for game in &finished_games {
+                                        (finished_card(game))
+                                    }
+                                }
+                            }
+
+                            // Load more
+                            @if paginated.pagination.has_more {
+                                div class="text-center" style="margin-top:var(--gap-lg);" {
+                                    button class="btn btn-ghost"
+                                        hx-get=(format!("/games?offset={}&limit={}",
+                                            paginated.pagination.offset + paginated.pagination.limit,
+                                            paginated.pagination.limit))
+                                        hx-target="#games-list-content"
+                                        hx-swap="innerHTML"
+                                        hx-disabled-elt="this" {
+                                        "Load More"
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -52,33 +174,173 @@ pub fn games_list_page(auth: AuthState, paginated: &PaginatedGames) -> maud::Mar
     )
 }
 
-fn game_card(game: &ListDisplayGame) -> maud::Markup {
+fn summary_card(label: &str, value: u32, modifier: &str) -> maud::Markup {
+    let classes = format!("summary-card {}", modifier);
     html! {
-        a href=(format!("/games/{}", game.identifier))
-            class="block bg-gray-900 hover:bg-gray-800 border border-gray-800 rounded-lg p-4 transition-colors" {
-            div class="flex items-center justify-between" {
-                div {
-                    h2 class="text-lg font-semibold text-white" { (game.name) }
-                    p class="text-sm text-gray-400" {
-                        "Day " (game.day.unwrap_or(0))
-                        " · "
-                        span class=(status_color(&game.status.to_string())) { (game.status) }
+        div class=(classes) {
+            div class="s-val num" { (value) }
+            div class="s-label" { (label) }
+        }
+    }
+}
+
+fn filter_pill(label: &str, status: &str, active: &str) -> maud::Markup {
+    let is_active = if status.is_empty() {
+        active.is_empty() || active == "all"
+    } else {
+        active == status
+    };
+    let classes = if is_active {
+        "filter-pill active"
+    } else {
+        "filter-pill"
+    };
+    let href = if status.is_empty() {
+        "/games".to_string()
+    } else {
+        format!("/games?status={}", status)
+    };
+    html! {
+        a href=(href) class=(classes) { (label) }
+    }
+}
+
+fn featured_running_card(game: &ListDisplayGame) -> maud::Markup {
+    let progress = compute_progress(game.day);
+    html! {
+        div class="game-card featured running" data-status="running" {
+            div class="game-info" {
+                div class="live-pulse" { "Live" }
+                h3 class="game-name" {
+                    a href=(format!("/games/{}", game.identifier)) { (game.name) }
+                }
+                div class="game-meta" {
+                    span { span class="num" { (game.tribute_count) } " tributes" }
+                    span { span class="num" { (game.living_count) } " alive" }
+                    @if let Some(day) = game.day {
+                        span { span class="num" { "Day " (day) } }
                     }
                 }
-                @if game.private {
-                    span class="text-xs text-gray-500 bg-gray-800 px-2 py-1 rounded" { "Private" }
+                div class="progress-bar" {
+                    div class="fill" style=(format!("width:{}%", progress)) {}
                 }
+                div class="progress-label" {
+                    @if let Some(day) = game.day {
+                        span class="num" { "Day " (day) } " · "
+                    }
+                    span class="num" { (game.living_count) } " tributes alive"
+                }
+                div class="reveal-actions" {
+                    a href=(format!("/games/{}", game.identifier)) class="reveal-btn" { "Broadcast" }
+                    a href=(format!("/games/{}/tributes", game.identifier)) class="reveal-btn" { "Tributes" }
+                    a href=(format!("/games/{}/areas", game.identifier)) class="reveal-btn" { "Arena Map" }
+                    a href=(format!("/games/{}/odds", game.identifier)) class="reveal-btn" { "Odds" }
+                }
+            }
+            div class="game-status" {
+                span class="status-pill running" { "Running" }
             }
         }
     }
 }
 
+fn running_card(game: &ListDisplayGame) -> maud::Markup {
+    let progress = compute_progress(game.day);
+    html! {
+        div class="game-card running" data-status="running" {
+            div class="game-info" {
+                h3 class="game-name" {
+                    a href=(format!("/games/{}", game.identifier)) { (game.name) }
+                }
+                div class="game-meta" {
+                    span { span class="num" { (game.tribute_count) } " tributes" }
+                    span { span class="num" { (game.living_count) } " alive" }
+                    @if let Some(day) = game.day {
+                        span { span class="num" { "Day " (day) } }
+                    }
+                }
+                div class="progress-bar" {
+                    div class="fill" style=(format!("width:{}%", progress)) {}
+                }
+                div class="progress-label" {
+                    @if let Some(day) = game.day {
+                        span class="num" { "Day " (day) } " · "
+                    }
+                    span class="num" { (game.living_count) } " tributes alive"
+                }
+                div class="reveal-actions" {
+                    a href=(format!("/games/{}", game.identifier)) class="reveal-btn" { "Broadcast" }
+                    a href=(format!("/games/{}/tributes", game.identifier)) class="reveal-btn" { "Tributes" }
+                    a href=(format!("/games/{}/areas", game.identifier)) class="reveal-btn" { "Arena Map" }
+                }
+            }
+            div class="game-status" {
+                span class="status-pill running" { "Running" }
+            }
+        }
+    }
+}
+
+fn waiting_card(game: &ListDisplayGame) -> maud::Markup {
+    html! {
+        div class="game-card waiting" data-status="waiting" {
+            div class="game-info" {
+                h3 class="game-name" {
+                    a href=(format!("/games/{}", game.identifier)) { (game.name) }
+                }
+                div class="game-meta" {
+                    span { span class="num" { (game.tribute_count) } " tributes" }
+                }
+                div class="reveal-actions" {
+                    a href=(format!("/games/{}/launch", game.identifier)) class="reveal-btn" { "Launch" }
+                    a href=(format!("/games/{}/configure", game.identifier)) class="reveal-btn" { "Configure" }
+                    button class="reveal-btn" type="button" { "Delete" }
+                }
+            }
+            div class="game-status" {
+                span class="status-pill waiting" { "Waiting" }
+            }
+        }
+    }
+}
+
+fn finished_card(game: &ListDisplayGame) -> maud::Markup {
+    html! {
+        div class="game-card finished" data-status="finished" {
+            div class="game-info" {
+                h3 class="game-name" {
+                    a href=(format!("/games/{}", game.identifier)) { (game.name) }
+                }
+                div class="game-meta" {
+                    span { span class="num" { (game.tribute_count) } " tributes" }
+                    @if let Some(day) = game.day {
+                        span { span class="num" { (day) } " days" }
+                    }
+                }
+                div class="reveal-actions" {
+                    a href=(format!("/games/{}/recap", game.identifier)) class="reveal-btn" { "Recap" }
+                    a href=(format!("/games/{}/tributes", game.identifier)) class="reveal-btn" { "Tributes" }
+                    a href=(format!("/games/{}/areas", game.identifier)) class="reveal-btn" { "Arena" }
+                }
+            }
+            div class="game-status" {
+                span class="status-pill finished" { "Finished" }
+            }
+        }
+    }
+}
+
+fn compute_progress(day: Option<u32>) -> f64 {
+    let d = day.unwrap_or(1) as f64;
+    (d / 10.0 * 100.0).min(100.0)
+}
+
 pub fn status_color(status: &str) -> &'static str {
     match status {
-        "NotStarted" => "text-gray-400",
-        "InProgress" => "text-green-400",
-        "Finished" => "text-amber-400",
-        _ => "text-gray-500",
+        "NotStarted" => "band-warn",
+        "InProgress" => "band-good",
+        "Finished" => "band-none",
+        _ => "band-none",
     }
 }
 


### PR DESCRIPTION
## Summary
Migrate game detail page and all sub-pages (tributes, areas, log) from dark Tailwind theme to the new light theme using OKLCH CSS custom properties.

## Changes
- api/assets/src/main.css: Added ~200 lines for detail components
- api/src/templates/game_detail.rs: Complete rebuild of 4 page templates
- api/src/templates/pages.rs: Updated status_color() to return semantic CSS classes
- api/src/templates/mod.rs: Migrated icon helpers to .icon CSS class

## Verification
- All HTMX attributes preserved
- All ID targets preserved
- No Tailwind color classes remain in detail templates