### PR TITLE
feat(auth): redesign auth pages with tabbed layout and OKLCH theme

### DIFF
--- a/api/src/templates/auth.rs
+++ b/api/src/templates/auth.rs
@@ -2,157 +2,167 @@ use maud::html;
 use shared::{ListDisplayGame, UserSession};
 
 use super::pages::status_color;
-use super::{AuthState, base_layout, icon};
+use super::{AuthState, auth_layout, base_layout, icon};
 
-/// Login form page.
-pub fn login_page(auth: AuthState, error: Option<&str>) -> maud::Markup {
-    base_layout(
-        "Login",
-        auth,
+/// Which tab to activate by default on the auth page.
+#[derive(Clone, Copy, Default)]
+pub enum AuthTab {
+    #[default]
+    Login,
+    Register,
+    Reset,
+}
+
+/// Unified tabbed auth page with login, register, and reset panels.
+pub fn auth_page(error: Option<&str>, default_tab: AuthTab) -> maud::Markup {
+    auth_layout(
+        "Auth",
         html! {
-            div class="max-w-md mx-auto py-12" {
-                h1 class="text-2xl font-bold text-amber-400 mb-6 text-center" { "Login" }
+            @let login_active = matches!(default_tab, AuthTab::Login);
+            @let register_active = matches!(default_tab, AuthTab::Register);
+            @let reset_active = matches!(default_tab, AuthTab::Reset);
+
+            // ── Login tab ──
+            div class=(if login_active { "tab-panel active" } else { "tab-panel" }) id="login" {
+                h2 class="auth-title" { "Welcome back" }
+                p class="auth-subtitle" { "Sign in to your account to continue." }
 
                 @if let Some(err) = error {
-                    div class="mb-4 p-3 bg-red-900/30 border border-red-700 rounded-lg text-red-300 text-sm" {
-                        (err)
-                    }
+                    div class="error-banner" { (err) }
                 }
 
-                form method="POST" action="/login" class="space-y-4" {
+                form method="POST" action="/login" {
                     input type="hidden" name="csrf_token" value=(csrf_placeholder()) {}
 
-                    div {
-                        label for="username" class="block text-sm font-medium text-gray-300 mb-1" {
-                            "Username"
-                        }
-                        input
-                            type="text"
-                            id="username"
-                            name="username"
-                            required
-                            minlength="3"
-                            maxlength="50"
-                            class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white focus:outline-none focus:border-amber-500"
+                    div class="form-group" {
+                        label for="username" { "Username" }
+                        input type="text" id="username" name="username"
+                            required minlength="3" maxlength="50"
                             placeholder="Your username";
                     }
 
-                    div {
-                        label for="password" class="block text-sm font-medium text-gray-300 mb-1" {
-                            "Password"
-                        }
-                        input
-                            type="password"
-                            id="password"
-                            name="password"
-                            required
-                            minlength="8"
-                            maxlength="72"
-                            class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white focus:outline-none focus:border-amber-500"
+                    div class="form-group" {
+                        label for="password" { "Password" }
+                        input type="password" id="password" name="password"
+                            required minlength="8" maxlength="72"
                             placeholder="Your password";
                     }
 
-                    button
-                        type="submit"
-                        class="w-full bg-amber-500 hover:bg-amber-600 text-gray-900 font-semibold px-4 py-2 rounded relative"
+                    div class="form-row" {
+                        label {
+                            input type="checkbox" name="remember" value="true";
+                            " Remember me"
+                        }
+                        a href="#" onclick="switchTab('reset');return false;" {
+                            "Forgot password?"
+                        }
+                    }
+
+                    button type="submit" class="btn btn-primary"
                         hx-indicator="#login-spinner" {
-                        "Login"
-                        span id="login-spinner" class="htmx-indicator absolute right-3 top-1/2 -translate-y-1/2" {
+                        "Sign In"
+                        span id="login-spinner" class="htmx-indicator" {
                             (spinner_icon())
                         }
                     }
                 }
 
-                p class="mt-4 text-center text-sm text-gray-400" {
+                div class="auth-footer" {
                     "Don't have an account? "
-                    a href="/register" class="text-amber-400 hover:text-amber-300" { "Register" }
+                    a href="#" onclick="switchTab('register');return false;" {
+                        "Create one"
+                    }
+                }
+            }
+
+            // ── Register tab ──
+            div class=(if register_active { "tab-panel active" } else { "tab-panel" }) id="register" {
+                h2 class="auth-title" { "Create account" }
+                p class="auth-subtitle" { "Join the broadcast. No credit card required." }
+
+                @if let Some(err) = error {
+                    div class="error-banner" { (err) }
+                }
+
+                form method="POST" action="/register" {
+                    input type="hidden" name="csrf_token" value=(csrf_placeholder()) {}
+
+                    div class="form-group" {
+                        label for="reg-username" { "Username" }
+                        input type="text" id="reg-username" name="username"
+                            required minlength="3" maxlength="50"
+                            placeholder="3-50 characters";
+                    }
+
+                    div class="form-group" {
+                        label for="reg-password" { "Password" }
+                        input type="password" id="reg-password" name="password"
+                            required minlength="8" maxlength="72"
+                            placeholder="8-72 characters";
+                    }
+
+                    div class="form-group" {
+                        label for="reg-confirm" { "Confirm Password" }
+                        input type="password" id="reg-confirm" name="confirm_password"
+                            required minlength="8" maxlength="72"
+                            placeholder="Repeat your password";
+                    }
+
+                    button type="submit" class="btn btn-primary"
+                        hx-indicator="#register-spinner" {
+                        "Create Account"
+                        span id="register-spinner" class="htmx-indicator" {
+                            (spinner_icon())
+                        }
+                    }
+                }
+
+                div class="auth-footer" {
+                    "Already have an account? "
+                    a href="#" onclick="switchTab('login');return false;" {
+                        "Sign in"
+                    }
+                }
+            }
+
+            // ── Reset tab ──
+            div class=(if reset_active { "tab-panel active" } else { "tab-panel" }) id="reset" {
+                h2 class="auth-title" { "Reset password" }
+                p class="auth-subtitle" { "Enter your username and we'll send you a reset link." }
+
+                form method="POST" action="/auth/reset-password" {
+                    input type="hidden" name="csrf_token" value=(csrf_placeholder()) {}
+
+                    div class="form-group" {
+                        label for="reset-username" { "Username" }
+                        input type="text" id="reset-username" name="username"
+                            required placeholder="Your username";
+                    }
+
+                    button type="submit" class="btn btn-primary" {
+                        "Send Reset Link"
+                    }
+                }
+
+                div class="divider" { "or" }
+
+                button type="button" class="btn btn-ghost"
+                    onclick="switchTab('login')" {
+                    "Back to Sign In"
                 }
             }
         },
     )
 }
 
-/// Registration form page.
-pub fn register_page(auth: AuthState, error: Option<&str>) -> maud::Markup {
-    base_layout(
-        "Register",
-        auth,
-        html! {
-            div class="max-w-md mx-auto py-12" {
-                h1 class="text-2xl font-bold text-amber-400 mb-6 text-center" { "Register" }
+/// Login form page — delegates to unified auth_page.
+pub fn login_page(_auth: AuthState, error: Option<&str>) -> maud::Markup {
+    auth_page(error, AuthTab::Login)
+}
 
-                @if let Some(err) = error {
-                    div class="mb-4 p-3 bg-red-900/30 border border-red-700 rounded-lg text-red-300 text-sm" {
-                        (err)
-                    }
-                }
-
-                form method="POST" action="/register" class="space-y-4" {
-                    input type="hidden" name="csrf_token" value=(csrf_placeholder()) {}
-
-                    div {
-                        label for="username" class="block text-sm font-medium text-gray-300 mb-1" {
-                            "Username"
-                        }
-                        input
-                            type="text"
-                            id="username"
-                            name="username"
-                            required
-                            minlength="3"
-                            maxlength="50"
-                            class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white focus:outline-none focus:border-amber-500"
-                            placeholder="3-50 characters";
-                    }
-
-                    div {
-                        label for="password" class="block text-sm font-medium text-gray-300 mb-1" {
-                            "Password"
-                        }
-                        input
-                            type="password"
-                            id="password"
-                            name="password"
-                            required
-                            minlength="8"
-                            maxlength="72"
-                            class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white focus:outline-none focus:border-amber-500"
-                            placeholder="8-72 characters";
-                    }
-
-                    div {
-                        label for="confirm_password" class="block text-sm font-medium text-gray-300 mb-1" {
-                            "Confirm Password"
-                        }
-                        input
-                            type="password"
-                            id="confirm_password"
-                            name="confirm_password"
-                            required
-                            minlength="8"
-                            maxlength="72"
-                            class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white focus:outline-none focus:border-amber-500"
-                            placeholder="Repeat your password";
-                    }
-
-                    button
-                        type="submit"
-                        class="w-full bg-amber-500 hover:bg-amber-600 text-gray-900 font-semibold px-4 py-2 rounded relative"
-                        hx-indicator="#register-spinner" {
-                        "Create Account"
-                        span id="register-spinner" class="htmx-indicator absolute right-3 top-1/2 -translate-y-1/2" {
-                            (spinner_icon())
-                        }
-                    }
-                }
-
-                p class="mt-4 text-center text-sm text-gray-400" {
-                    "Already have an account? "
-                    a href="/login" class="text-amber-400 hover:text-amber-300" { "Login" }
-                }
-            }
-        },
-    )
+/// Registration form page — delegates to unified auth_page.
+pub fn register_page(_auth: AuthState, error: Option<&str>) -> maud::Markup {
+    auth_page(error, AuthTab::Register)
 }
 
 /// Account dashboard page.
@@ -340,19 +350,23 @@ fn spinner_icon() -> maud::Markup {
 /// Placeholder for CSRF token value in templates.
 /// The real token is injected by the handler via a form value override.
 fn csrf_placeholder() -> &'static str {
-    ""
+    "__CSRF_TOKEN__"
 }
 
-/// Login form page with CSRF token injected.
+/// Auth page with CSRF token injected (used by GET /login and GET /register).
+pub fn auth_page_with_csrf(csrf: &str, default_tab: AuthTab) -> String {
+    let markup: String = auth_page(None, default_tab).into();
+    markup.replace(csrf_placeholder(), csrf)
+}
+
+/// Login form page with CSRF token injected — delegates to auth_page_with_csrf.
 pub fn login_page_with_csrf(csrf: &str) -> String {
-    let markup: String = login_page(AuthState::guest(), None).into();
-    markup.replace(csrf_placeholder(), csrf)
+    auth_page_with_csrf(csrf, AuthTab::Login)
 }
 
-/// Registration form page with CSRF token injected.
+/// Registration form page with CSRF token injected — delegates to auth_page_with_csrf.
 pub fn register_page_with_csrf(csrf: &str) -> String {
-    let markup: String = register_page(AuthState::guest(), None).into();
-    markup.replace(csrf_placeholder(), csrf)
+    auth_page_with_csrf(csrf, AuthTab::Register)
 }
 
 /// Create game form page with CSRF token injected.

--- a/api/src/templates/mod.rs
+++ b/api/src/templates/mod.rs
@@ -28,6 +28,217 @@ impl AuthState {
     }
 }
 
+pub fn auth_layout(title: &str, content: Markup) -> Markup {
+    html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) " — Hangry Games" }
+                link rel="preconnect" href="https://fonts.googleapis.com";
+                link rel="preconnect" href="https://fonts.gstatic.com" crossorigin;
+                link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,16..72,200..800;1,16..72,200..800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet";
+                style {
+                    (PreEscaped(r#"
+:root {
+  --bg: oklch(97.5% 0.012 75);
+  --surface: oklch(99.5% 0.004 75);
+  --fg: oklch(18% 0.015 70);
+  --muted: oklch(52% 0.012 70);
+  --border: oklch(88% 0.01 75);
+  --accent: oklch(42% 0.18 285);
+  --accent-soft: color-mix(in oklch, var(--accent) 10%, transparent);
+  --fg-soft: color-mix(in oklch, var(--fg) 5%, transparent);
+  --font-display: 'Newsreader', 'Iowan Old Style', Georgia, serif;
+  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+  --fs-h2: 28px;
+  --fs-body: 15px;
+  --fs-meta: 12px;
+  --fs-xs: 11px;
+  --gap-xs: 6px;
+  --gap-sm: 12px;
+  --gap-md: 20px;
+  --gap-lg: 32px;
+  --container: 440px;
+  --radius-sm: 4px;
+  --radius: 8px;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: oklch(16% 0.02 280);
+    --surface: oklch(20% 0.02 280);
+    --fg: oklch(88% 0.01 75);
+    --muted: oklch(58% 0.015 280);
+    --border: oklch(28% 0.02 280);
+    --accent: oklch(62% 0.22 285);
+    --accent-soft: color-mix(in oklch, var(--accent) 15%, transparent);
+    --fg-soft: color-mix(in oklch, var(--fg) 8%, transparent);
+  }
+}
+[data-theme="dark"] {
+  --bg: oklch(16% 0.02 280);
+  --surface: oklch(20% 0.02 280);
+  --fg: oklch(88% 0.01 75);
+  --muted: oklch(58% 0.015 280);
+  --border: oklch(28% 0.02 280);
+  --accent: oklch(62% 0.22 285);
+  --accent-soft: color-mix(in oklch, var(--accent) 15%, transparent);
+  --fg-soft: color-mix(in oklch, var(--fg) 8%, transparent);
+}
+*, *::before, *::after { box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; }
+body {
+  margin: 0; background: var(--bg); color: var(--fg);
+  font-family: var(--font-body); font-size: var(--fs-body);
+  line-height: 1.6; min-height: 100vh;
+  display: flex; align-items: center; justify-content: center;
+  padding: var(--gap-lg);
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+button { font: inherit; cursor: pointer; }
+.auth-card {
+  width: 100%; max-width: var(--container);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--gap-lg);
+}
+.auth-logo {
+  font-family: var(--font-display);
+  font-size: 22px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  text-align: center; margin-bottom: var(--gap-lg);
+}
+.auth-logo span { color: var(--accent); }
+.auth-title {
+  font-family: var(--font-display);
+  font-size: var(--fs-h2); font-weight: 700;
+  margin: 0 0 4px; letter-spacing: -0.01em;
+}
+.auth-subtitle {
+  font-size: var(--fs-meta); color: var(--muted);
+  margin: 0 0 var(--gap-md);
+}
+.form-group { margin-bottom: var(--gap-sm); }
+.form-group label {
+  display: block; font-size: var(--fs-meta); font-weight: 500;
+  color: var(--fg); margin-bottom: 4px;
+}
+.form-group input {
+  width: 100%; padding: 10px 12px;
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
+  font-family: var(--font-body); font-size: var(--fs-body);
+  background: var(--bg); color: var(--fg); outline: none;
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+.form-group input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.form-row {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: var(--gap-md); font-size: var(--fs-meta);
+}
+.form-row label {
+  display: flex; align-items: center; gap: 6px;
+  color: var(--muted); cursor: pointer;
+}
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 100%; padding: 12px 24px;
+  border-radius: var(--radius-sm); border: none;
+  font-size: 15px; font-weight: 600;
+  cursor: pointer; transition: opacity 0.15s;
+}
+.btn:hover { opacity: 0.85; }
+.btn-primary { background: var(--accent); color: #fff; }
+.btn-ghost { background: transparent; color: var(--fg); border: 1px solid var(--border); }
+.auth-footer {
+  text-align: center; margin-top: var(--gap-md);
+  font-size: var(--fs-meta); color: var(--muted);
+}
+.divider {
+  display: flex; align-items: center; gap: var(--gap-sm);
+  margin: var(--gap-md) 0;
+  font-size: var(--fs-xs); color: var(--muted);
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+.divider::before, .divider::after {
+  content: ''; flex: 1; height: 1px; background: var(--border);
+}
+.tab-bar {
+  display: flex; gap: 2px; margin-bottom: var(--gap-lg);
+  background: var(--bg); border-radius: var(--radius-sm); padding: 2px;
+}
+.tab-btn {
+  flex: 1; padding: 8px; border: none; background: transparent;
+  font-size: var(--fs-meta); font-weight: 500; color: var(--muted);
+  border-radius: var(--radius-sm); cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.tab-btn.active {
+  background: var(--surface); color: var(--fg);
+  box-shadow: 0 1px 3px color-mix(in oklch, var(--fg) 8%, transparent);
+}
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+.error-banner {
+  margin-bottom: var(--gap-md); padding: 10px 12px;
+  border: 1px solid oklch(60% 0.22 25); border-radius: var(--radius-sm);
+  background: oklch(60% 0.22 25 / 0.1); color: oklch(60% 0.22 25);
+  font-size: var(--fs-meta);
+}
+.theme-toggle-btn {
+  position: fixed; top: 12px; right: 12px;
+  background: transparent; border: 1px solid var(--border); border-radius: var(--radius-sm);
+  padding: 4px 8px; font-size: 14px; cursor: pointer; color: var(--muted);
+  transition: background 0.12s, color 0.12s;
+}
+.theme-toggle-btn:hover { background: var(--fg-soft); color: var(--fg); }
+                    "#))
+                }
+            }
+            body {
+                button class="theme-toggle-btn" aria-label="Toggle theme" { "🌙" }
+                div class="auth-card" {
+                    div class="auth-logo" { "Hangry " span { "Games" } }
+                    div class="tab-bar" {
+                        button class="tab-btn active" data-tab="login" { "Sign In" }
+                        button class="tab-btn" data-tab="register" { "Register" }
+                        button class="tab-btn" data-tab="reset" { "Reset Password" }
+                    }
+                    (content)
+                }
+                script {
+                    (PreEscaped(r#"
+function switchTab(id) {
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+  document.querySelector('[data-tab="'+id+'"]').classList.add('active');
+  document.getElementById(id).classList.add('active');
+}
+document.querySelectorAll('.tab-btn').forEach(btn => {
+  btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+});
+const themeBtn = document.querySelector('.theme-toggle-btn');
+if (themeBtn) {
+  themeBtn.addEventListener('click', () => {
+    const root = document.documentElement;
+    const isDark = root.getAttribute('data-theme') === 'dark';
+    root.setAttribute('data-theme', isDark ? 'light' : 'dark');
+    themeBtn.textContent = isDark ? '🌙' : '☀️';
+  });
+}
+                    "#))
+                }
+            }
+        }
+    }
+}
+
 pub fn base_layout(title: &str, auth: AuthState, content: Markup) -> Markup {
     html! {
         (DOCTYPE)


### PR DESCRIPTION
## Summary

Redesigned auth pages (login/register/reset) as a unified tabbed interface matching the reference design.

## Changes

- **mod.rs**: Added `auth_layout()` — standalone layout with OKLCH CSS vars, Newsreader/Inter fonts, centered card, tab bar, theme toggle
- **auth.rs**: Unified `auth_page()` with 3 tabs (Login, Register, Reset Password), preserved all backend integration (CSRF, form actions, HTMX spinners)
- **auth.rs**: Fixed `csrf_placeholder()` regression (was reverted to empty string)

## Verification

- cargo check: PASS
- CSRF placeholder: `"__CSRF_TOKEN__"` (not empty string)

## Follow-ups

- account_page, create_game_page still use Tailwind classes — future migration opportunity