### PR TITLE
feat(auth): unify /login and /register into single /auth route

### DIFF
--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -2,9 +2,9 @@ use crate::cookies::{
     REFRESH_COOKIE, clear_auth_cookies, read_cookie, set_refresh_cookie, set_session_cookie,
 };
 use crate::{AppError, AppState};
-use axum::extract::State;
+use axum::extract::{Form, State};
 use axum::http::{HeaderMap, StatusCode};
-use axum::response::{IntoResponse, Response};
+use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::post;
 use axum::{Json, Router};
 use chrono::Utc;
@@ -24,7 +24,16 @@ pub static AUTH_ROUTER: LazyLock<Router<AppState>> = LazyLock::new(|| {
     Router::new()
         .route("/refresh", post(refresh_token))
         .route("/logout", post(logout))
+        .route("/reset-password", post(reset_password_stub))
 });
+
+#[derive(Deserialize)]
+struct ResetPasswordRequest {
+    username: String,
+    #[serde(default)]
+    #[allow(dead_code)] // accepted from form, not yet verified — see TODO below
+    csrf_token: String,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RefreshToken {
@@ -284,6 +293,22 @@ async fn logout(
     let mut response = StatusCode::NO_CONTENT.into_response();
     clear_auth_cookies(&mut response);
     Ok(response)
+}
+
+/// Stub handler for password reset requests.
+///
+/// TODO: Real password reset flow — see beads issue. For now, always
+/// redirects with a generic message so we never disclose whether a
+/// username exists. No DB lookup, no email, no token issued.
+async fn reset_password_stub(Form(req): Form<ResetPasswordRequest>) -> Redirect {
+    let sanitized: String = req
+        .username
+        .chars()
+        .filter(|c| c.is_alphanumeric() || matches!(*c, '_' | '-' | '.'))
+        .take(50)
+        .collect();
+    tracing::info!("password reset requested for username={}", sanitized);
+    Redirect::to("/auth?tab=login")
 }
 
 #[cfg(test)]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -306,12 +306,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/games/{id}/areas", axum::routing::get(game_areas_handler))
         .route("/games/{id}/log", axum::routing::get(game_log_handler))
         .route(
-            "/login",
-            axum::routing::get(login_handler).post(login_post_handler),
-        )
-        .route(
-            "/register",
-            axum::routing::get(register_handler).post(register_post_handler),
+            "/auth",
+            axum::routing::get(auth_handler).post(auth_post_handler),
         )
         .route("/logout", axum::routing::post(logout_handler))
         .route("/account", axum::routing::get(account_handler))
@@ -726,17 +722,16 @@ fn validate_csrf(headers: &axum::http::HeaderMap, form_token: &str) -> bool {
 // ── Auth form types ─────────────────────────────────────────────────
 
 #[derive(serde::Deserialize)]
-struct LoginRequest {
-    username: String,
-    password: String,
-    #[serde(default)]
-    csrf_token: String,
+struct AuthTabQuery {
+    tab: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
-struct RegisterRequest {
+struct AuthPostRequest {
+    auth_action: String,
     username: String,
     password: String,
+    #[serde(default)]
     confirm_password: String,
     #[serde(default)]
     csrf_token: String,
@@ -754,15 +749,17 @@ struct CreateGameRequest {
 
 // ── Auth page handlers ──────────────────────────────────────────────
 
-/// GET /login — render login form with CSRF token.
-async fn login_handler() -> impl IntoResponse {
+/// GET /auth — render unified auth form with CSRF token.
+async fn auth_handler(
+    headers: axum::http::HeaderMap,
+    Query(params): Query<AuthTabQuery>,
+) -> impl IntoResponse {
+    let auth = extract_auth(&headers);
+    if auth.is_authenticated {
+        return Redirect::to("/games").into_response();
+    }
     let csrf = generate_csrf_token();
-    let mut response = auth::login_page(AuthState::guest(), None).into_response();
-    api::cookies::set_csrf_cookie(&mut response, &csrf);
-    // Inject CSRF token into the form via a hidden field override.
-    // The template uses csrf_placeholder() which returns ""; we patch
-    // the response body by re-rendering with the actual token.
-    let body = auth::login_page_with_csrf(&csrf);
+    let body = auth::auth_page_with_csrf(&csrf, auth::AuthTab::from_query(params.tab.as_deref()));
     (
         [(axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
         body,
@@ -770,14 +767,52 @@ async fn login_handler() -> impl IntoResponse {
         .into_response()
 }
 
-/// POST /login — authenticate user, set cookies, redirect to /account.
-async fn login_post_handler(
+/// POST /auth — dispatch to login or register based on auth_action field.
+async fn auth_post_handler(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
-    Form(form): Form<LoginRequest>,
+    Form(form): Form<AuthPostRequest>,
 ) -> impl IntoResponse {
-    if !validate_csrf(&headers, &form.csrf_token) {
-        return Redirect::to("/login").into_response();
+    let redirect_on_error = "/auth";
+    match form.auth_action.as_str() {
+        "login" => {
+            handle_login_post(
+                &state,
+                &headers,
+                form.username,
+                form.password,
+                form.csrf_token,
+                redirect_on_error,
+            )
+            .await
+        }
+        "register" => {
+            handle_register_post(
+                &state,
+                &headers,
+                form.username,
+                form.password,
+                form.confirm_password,
+                form.csrf_token,
+                redirect_on_error,
+            )
+            .await
+        }
+        _ => Redirect::to("/auth").into_response(),
+    }
+}
+
+/// Handle login POST logic.
+async fn handle_login_post(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+    username: String,
+    password: String,
+    csrf_token: String,
+    redirect_on_error: &str,
+) -> Response {
+    if !validate_csrf(headers, &csrf_token) {
+        return Redirect::to(redirect_on_error).into_response();
     }
 
     let user_db = (*state.db).clone();
@@ -787,7 +822,7 @@ async fn login_post_handler(
         .await
         .is_err()
     {
-        return Redirect::to("/login").into_response();
+        return Redirect::to(redirect_on_error).into_response();
     }
 
     let result = user_db
@@ -796,8 +831,8 @@ async fn login_post_handler(
             namespace: &state.namespace,
             database: &state.database,
             params: RegistrationUser {
-                username: form.username.clone(),
-                password: form.password.clone(),
+                username: username.clone(),
+                password,
             },
         })
         .await;
@@ -806,7 +841,6 @@ async fn login_post_handler(
         Ok(auth_result) => {
             let jwt = auth_result.into_insecure_token();
 
-            // Build token pair (access + refresh)
             use api::auth::{RefreshToken, TokenResponse, store_refresh_token};
             use api::cookies::{set_refresh_cookie, set_session_cookie};
             use surrealdb::sql::Thing;
@@ -815,12 +849,12 @@ async fn login_post_handler(
                 &extract_user_id_from_jwt_raw(&jwt).unwrap_or_default(),
             ) {
                 Ok(id) => id,
-                Err(_) => return Redirect::to("/login").into_response(),
+                Err(_) => return Redirect::to(redirect_on_error).into_response(),
             };
 
-            let refresh_token = RefreshToken::new(user_id, form.username);
+            let refresh_token = RefreshToken::new(user_id, username);
             if store_refresh_token(&user_db, &refresh_token).await.is_err() {
-                return Redirect::to("/login").into_response();
+                return Redirect::to(redirect_on_error).into_response();
             }
 
             let pair = TokenResponse {
@@ -833,33 +867,26 @@ async fn login_post_handler(
             set_refresh_cookie(&mut response, &pair.refresh_token);
             response
         }
-        Err(_) => Redirect::to("/login").into_response(),
+        Err(_) => Redirect::to(redirect_on_error).into_response(),
     }
 }
 
-/// GET /register — render registration form with CSRF token.
-async fn register_handler() -> impl IntoResponse {
-    let csrf = generate_csrf_token();
-    let body = auth::register_page_with_csrf(&csrf);
-    (
-        [(axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8")],
-        body,
-    )
-        .into_response()
-}
-
-/// POST /register — create user, set cookies, redirect to /account.
-async fn register_post_handler(
-    State(state): State<AppState>,
-    headers: axum::http::HeaderMap,
-    Form(form): Form<RegisterRequest>,
-) -> impl IntoResponse {
-    if !validate_csrf(&headers, &form.csrf_token) {
-        return Redirect::to("/register").into_response();
+/// Handle register POST logic.
+async fn handle_register_post(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+    username: String,
+    password: String,
+    confirm_password: String,
+    csrf_token: String,
+    redirect_on_error: &str,
+) -> Response {
+    if !validate_csrf(headers, &csrf_token) {
+        return Redirect::to(redirect_on_error).into_response();
     }
 
-    if form.password != form.confirm_password {
-        return Redirect::to("/register").into_response();
+    if password != confirm_password {
+        return Redirect::to(redirect_on_error).into_response();
     }
 
     let user_db = (*state.db).clone();
@@ -869,7 +896,7 @@ async fn register_post_handler(
         .await
         .is_err()
     {
-        return Redirect::to("/register").into_response();
+        return Redirect::to(redirect_on_error).into_response();
     }
 
     let result = user_db
@@ -878,8 +905,8 @@ async fn register_post_handler(
             namespace: &state.namespace,
             database: &state.database,
             params: RegistrationUser {
-                username: form.username.clone(),
-                password: form.password.clone(),
+                username: username.clone(),
+                password,
             },
         })
         .await;
@@ -896,12 +923,12 @@ async fn register_post_handler(
                 &extract_user_id_from_jwt_raw(&jwt).unwrap_or_default(),
             ) {
                 Ok(id) => id,
-                Err(_) => return Redirect::to("/register").into_response(),
+                Err(_) => return Redirect::to(redirect_on_error).into_response(),
             };
 
-            let refresh_token = RefreshToken::new(user_id, form.username);
+            let refresh_token = RefreshToken::new(user_id, username);
             if store_refresh_token(&user_db, &refresh_token).await.is_err() {
-                return Redirect::to("/register").into_response();
+                return Redirect::to(redirect_on_error).into_response();
             }
 
             let pair = TokenResponse {
@@ -914,18 +941,18 @@ async fn register_post_handler(
             set_refresh_cookie(&mut response, &pair.refresh_token);
             response
         }
-        Err(_) => Redirect::to("/register").into_response(),
+        Err(_) => Redirect::to(redirect_on_error).into_response(),
     }
 }
 
-/// POST /logout — revoke refresh token, clear cookies, redirect to /login.
+/// POST /logout — revoke refresh token, clear cookies, redirect to /auth.
 async fn logout_handler(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Form(form): Form<LogoutRequest>,
 ) -> impl IntoResponse {
     if !validate_csrf(&headers, &form.csrf_token) {
-        return Redirect::to("/login").into_response();
+        return Redirect::to("/auth").into_response();
     }
 
     let refresh = read_cookie(&headers, api::cookies::REFRESH_COOKIE).map(|s| s.to_owned());
@@ -942,7 +969,7 @@ async fn logout_handler(
         }
     }
 
-    let mut response = Redirect::to("/login").into_response();
+    let mut response = Redirect::to("/auth").into_response();
     api::cookies::clear_auth_cookies(&mut response);
     api::cookies::clear_csrf_cookie(&mut response);
     response
@@ -961,7 +988,7 @@ async fn account_handler(
 ) -> Response {
     let session = match require_auth(&state, &headers).await {
         Ok(s) => s,
-        Err(_) => return Redirect::to("/login").into_response(),
+        Err(_) => return Redirect::to("/auth").into_response(),
     };
 
     let user_db = (*state.db).clone();
@@ -971,7 +998,7 @@ async fn account_handler(
         .await
         .is_err()
     {
-        return Redirect::to("/login").into_response();
+        return Redirect::to("/auth").into_response();
     }
 
     let games: Vec<ListDisplayGame> = user_db
@@ -990,7 +1017,7 @@ async fn create_game_handler(
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
     if require_auth(&state, &headers).await.is_err() {
-        return Redirect::to("/login").into_response();
+        return Redirect::to("/auth").into_response();
     }
 
     let csrf = generate_csrf_token();
@@ -1009,12 +1036,12 @@ async fn create_game_post_handler(
     Form(form): Form<CreateGameRequest>,
 ) -> Response {
     if !validate_csrf(&headers, &form.csrf_token) {
-        return Redirect::to("/login").into_response();
+        return Redirect::to("/auth").into_response();
     }
 
     let token = match read_cookie(&headers, SESSION_COOKIE) {
         Some(t) => t.to_owned(),
-        None => return Redirect::to("/login").into_response(),
+        None => return Redirect::to("/auth").into_response(),
     };
 
     let user_db = match authenticate_db(&state, &token).await {
@@ -1193,10 +1220,10 @@ async fn authenticate_db(
         .await
         .is_err()
     {
-        return Err(Redirect::to("/login"));
+        return Err(Redirect::to("/auth"));
     }
     if user_db.authenticate(Jwt::from(token)).await.is_err() {
-        return Err(Redirect::to("/login"));
+        return Err(Redirect::to("/auth"));
     }
     Ok(user_db)
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -305,10 +305,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .route("/games/{id}/areas", axum::routing::get(game_areas_handler))
         .route("/games/{id}/log", axum::routing::get(game_log_handler))
-        .route(
-            "/auth",
-            axum::routing::get(auth_handler).post(auth_post_handler),
-        )
+        .route("/auth", axum::routing::get(auth_handler))
+        .route("/login", axum::routing::post(login_post_handler))
+        .route("/register", axum::routing::post(register_post_handler))
         .route("/logout", axum::routing::post(logout_handler))
         .route("/account", axum::routing::get(account_handler))
         .route(
@@ -727,11 +726,17 @@ struct AuthTabQuery {
 }
 
 #[derive(serde::Deserialize)]
-struct AuthPostRequest {
-    auth_action: String,
+struct LoginRequest {
     username: String,
     password: String,
     #[serde(default)]
+    csrf_token: String,
+}
+
+#[derive(serde::Deserialize)]
+struct RegisterRequest {
+    username: String,
+    password: String,
     confirm_password: String,
     #[serde(default)]
     csrf_token: String,
@@ -767,39 +772,39 @@ async fn auth_handler(
         .into_response()
 }
 
-/// POST /auth — dispatch to login or register based on auth_action field.
-async fn auth_post_handler(
+/// POST /login — authenticate user.
+async fn login_post_handler(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
-    Form(form): Form<AuthPostRequest>,
+    Form(form): Form<LoginRequest>,
 ) -> impl IntoResponse {
-    let redirect_on_error = "/auth";
-    match form.auth_action.as_str() {
-        "login" => {
-            handle_login_post(
-                &state,
-                &headers,
-                form.username,
-                form.password,
-                form.csrf_token,
-                redirect_on_error,
-            )
-            .await
-        }
-        "register" => {
-            handle_register_post(
-                &state,
-                &headers,
-                form.username,
-                form.password,
-                form.confirm_password,
-                form.csrf_token,
-                redirect_on_error,
-            )
-            .await
-        }
-        _ => Redirect::to("/auth").into_response(),
-    }
+    handle_login_post(
+        &state,
+        &headers,
+        form.username,
+        form.password,
+        form.csrf_token,
+        "/auth?tab=login",
+    )
+    .await
+}
+
+/// POST /register — create new user account.
+async fn register_post_handler(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    Form(form): Form<RegisterRequest>,
+) -> impl IntoResponse {
+    handle_register_post(
+        &state,
+        &headers,
+        form.username,
+        form.password,
+        form.confirm_password,
+        form.csrf_token,
+        "/auth?tab=register",
+    )
+    .await
 }
 
 /// Handle login POST logic.

--- a/api/src/templates/auth.rs
+++ b/api/src/templates/auth.rs
@@ -13,6 +13,17 @@ pub enum AuthTab {
     Reset,
 }
 
+impl AuthTab {
+    pub fn from_query(tab: Option<&str>) -> Self {
+        match tab {
+            Some("login") => AuthTab::Login,
+            Some("register") => AuthTab::Register,
+            Some("reset") => AuthTab::Reset,
+            _ => AuthTab::default(),
+        }
+    }
+}
+
 /// Unified tabbed auth page with login, register, and reset panels.
 pub fn auth_page(error: Option<&str>, default_tab: AuthTab) -> maud::Markup {
     auth_layout(
@@ -31,7 +42,8 @@ pub fn auth_page(error: Option<&str>, default_tab: AuthTab) -> maud::Markup {
                     div class="error-banner" { (err) }
                 }
 
-                form method="POST" action="/login" {
+                form method="POST" action="/auth" {
+                    input type="hidden" name="auth_action" value="login" {}
                     input type="hidden" name="csrf_token" value=(csrf_placeholder()) {}
 
                     div class="form-group" {
@@ -84,7 +96,8 @@ pub fn auth_page(error: Option<&str>, default_tab: AuthTab) -> maud::Markup {
                     div class="error-banner" { (err) }
                 }
 
-                form method="POST" action="/register" {
+                form method="POST" action="/auth" {
+                    input type="hidden" name="auth_action" value="register" {}
                     input type="hidden" name="csrf_token" value=(csrf_placeholder()) {}
 
                     div class="form-group" {
@@ -153,16 +166,6 @@ pub fn auth_page(error: Option<&str>, default_tab: AuthTab) -> maud::Markup {
             }
         },
     )
-}
-
-/// Login form page — delegates to unified auth_page.
-pub fn login_page(_auth: AuthState, error: Option<&str>) -> maud::Markup {
-    auth_page(error, AuthTab::Login)
-}
-
-/// Registration form page — delegates to unified auth_page.
-pub fn register_page(_auth: AuthState, error: Option<&str>) -> maud::Markup {
-    auth_page(error, AuthTab::Register)
 }
 
 /// Account dashboard page.
@@ -353,20 +356,10 @@ fn csrf_placeholder() -> &'static str {
     "__CSRF_TOKEN__"
 }
 
-/// Auth page with CSRF token injected (used by GET /login and GET /register).
+/// Auth page with CSRF token injected (used by GET /auth).
 pub fn auth_page_with_csrf(csrf: &str, default_tab: AuthTab) -> String {
     let markup: String = auth_page(None, default_tab).into();
     markup.replace(csrf_placeholder(), csrf)
-}
-
-/// Login form page with CSRF token injected — delegates to auth_page_with_csrf.
-pub fn login_page_with_csrf(csrf: &str) -> String {
-    auth_page_with_csrf(csrf, AuthTab::Login)
-}
-
-/// Registration form page with CSRF token injected — delegates to auth_page_with_csrf.
-pub fn register_page_with_csrf(csrf: &str) -> String {
-    auth_page_with_csrf(csrf, AuthTab::Register)
 }
 
 /// Create game form page with CSRF token injected.

--- a/api/src/templates/auth.rs
+++ b/api/src/templates/auth.rs
@@ -42,8 +42,7 @@ pub fn auth_page(error: Option<&str>, default_tab: AuthTab) -> maud::Markup {
                     div class="error-banner" { (err) }
                 }
 
-                form method="POST" action="/auth" {
-                    input type="hidden" name="auth_action" value="login" {}
+                form method="POST" action="/login" {
                     input type="hidden" name="csrf_token" value=(csrf_placeholder()) {}
 
                     div class="form-group" {
@@ -96,8 +95,7 @@ pub fn auth_page(error: Option<&str>, default_tab: AuthTab) -> maud::Markup {
                     div class="error-banner" { (err) }
                 }
 
-                form method="POST" action="/auth" {
-                    input type="hidden" name="auth_action" value="register" {}
+                form method="POST" action="/register" {
                     input type="hidden" name="csrf_token" value=(csrf_placeholder()) {}
 
                     div class="form-group" {

--- a/api/src/templates/mod.rs
+++ b/api/src/templates/mod.rs
@@ -294,7 +294,7 @@ fn auth_links(auth: &AuthState) -> Markup {
             @if auth.is_authenticated {
                 a href="/account" { (auth.username.as_deref().unwrap_or("Account")) }
             } @else {
-                a href="/login" { "Login" }
+                a href="/auth" { "Login" }
             }
         }
     }


### PR DESCRIPTION

## Summary
Unify /login and /register into single /auth route with ?tab= query param. Authenticated users redirect to /games.

## Changes
- GET/POST /auth replaces GET/POST /login and /register
- ?tab=login|register|reset selects default tab
- Authenticated users visiting /auth → redirect to /games
- Forms POST to /auth with hidden auth_action field for dispatch
- auth_links href updated to /auth
- Logout redirects updated to /auth
