### PR TITLE
fix(dev): remove duplicate Mailpit install in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,9 +25,4 @@ RUN curl -sSfL https://github.com/axllent/mailpit/releases/download/v1.30.0/mail
 USER vscode
 RUN rustup component add clippy rustfmt rust-src
 
-# Install Mailpit for email testing in development
-RUN curl -sSfL https://github.com/axllent/mailpit/releases/download/v1.30.0/mailpit-linux-amd64.tar.gz \
-    | tar xz -C /usr/local/bin mailpit \
-    && mailpit version
-
 USER root


### PR DESCRIPTION
## Summary

Devcontainer build fails with 'tar: File exists' because the Dockerfile has two Mailpit install blocks. PR #300 moved one before USER vscode but didn't delete the original.

## Change
- Delete the old Mailpit RUN block (lines 28-31) that was left behind after PR #300

## Verification
- Single Mailpit install at lines 19-22, before USER vscode (runs as root correctly)
- docker compose -f .devcontainer/docker-compose.yml build dev should succeed