### PR TITLE
fix(api): consolidate create_game_handler auth check, avoid double JWT parse

### DIFF
--- a/api/src/routes/games.rs
+++ b/api/src/routes/games.rs
@@ -264,13 +264,10 @@ pub async fn account_handler(
 }
 
 /// GET /games/new — create game form (requires auth).
-pub async fn create_game_handler(
-    State(state): State<AppState>,
-    headers: axum::http::HeaderMap,
-) -> Response {
+pub async fn create_game_handler(headers: axum::http::HeaderMap) -> Response {
     let (auth, csrf) = extract_auth(&headers);
-    if require_auth(&state, &headers).await.is_err() {
-        return Redirect::to("/auth").into_response();
+    if !auth.is_authenticated() {
+        return Redirect::to("/auth?tab=login").into_response();
     }
 
     let body = api::templates::auth::create_game_page_with_csrf(auth, &csrf);


### PR DESCRIPTION
Summary: create_game_handler was calling both extract_auth and require_auth, each parsing the JWT independently. Since the result of require_auth is only used for access gating (not for a DB session), replace with auth.is_authenticated() on the already-parsed AuthState. Also removed unused State(state) parameter.\n\nChanges:\n- Replace require_auth(is_err()) gate with auth.is_authenticated()\n- Remove unused State(state) param\n- Redirect to /auth?tab=login instead of /auth\n\nVerification: cargo check --package api passes\n\nFollow-ups: Similar pattern exists in account_handler but that one needs the UserSession for DB queries, so it's a different case.