### PR TITLE
feat(game,shared): fixation PR1 — types, storage, spawn + item-pickup acquisition

### DIFF
--- a/game/src/games/tests.rs
+++ b/game/src/games/tests.rs
@@ -1457,6 +1457,7 @@ fn sleeping_wounded_tribute_does_not_regen_hp() {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         },
     );
     let prior_hp = t.attributes.health;

--- a/game/src/tributes/afflictions/anatomy.rs
+++ b/game/src/tributes/afflictions/anatomy.rs
@@ -2,7 +2,7 @@
 //!
 //! See spec §4 (full table) and §17 (testing strategy).
 
-use shared::afflictions::{Affliction, AfflictionKey, AfflictionKind, BodyPart};
+use shared::afflictions::{Affliction, AfflictionKey, AfflictionKind, BodyPart, FixationTarget};
 use std::collections::BTreeMap;
 
 /// Outcome of attempting to acquire an affliction given the current tribute state.
@@ -28,6 +28,10 @@ pub enum RejectReason {
     InfectedRequiresWoundedAncestor,
     /// New severity is not strictly greater than existing same-key severity.
     NotStrictlyHigherSeverity,
+    /// Tribute already has max fixations (2).
+    FixationCapReached,
+    /// Same FixationTarget variant already exists (max 1 per target kind).
+    FixationVariantDuplicate,
 }
 
 /// Decide what happens when `new` is offered to a tribute who already carries
@@ -37,6 +41,36 @@ pub fn can_acquire(
     new: &Affliction,
 ) -> AcquireResolution {
     let new_key = new.key();
+
+    // Rule: Fixation caps — max 2 total, max 1 per target kind.
+    if matches!(new.kind, AfflictionKind::Fixation(_)) {
+        let fixation_count = existing
+            .values()
+            .filter(|a| matches!(a.kind, AfflictionKind::Fixation(_)))
+            .count();
+        if fixation_count >= 2 {
+            return AcquireResolution::Reject(RejectReason::FixationCapReached);
+        }
+
+        let same_variant = existing.values().any(|a| {
+            matches!(
+                (&a.kind, &new.kind),
+                (
+                    AfflictionKind::Fixation(FixationTarget::Tribute(_)),
+                    AfflictionKind::Fixation(FixationTarget::Tribute(_))
+                ) | (
+                    AfflictionKind::Fixation(FixationTarget::Item(_)),
+                    AfflictionKind::Fixation(FixationTarget::Item(_))
+                ) | (
+                    AfflictionKind::Fixation(FixationTarget::Area(_)),
+                    AfflictionKind::Fixation(FixationTarget::Area(_))
+                )
+            )
+        });
+        if same_variant {
+            return AcquireResolution::Reject(RejectReason::FixationVariantDuplicate);
+        }
+    }
 
     // Rule: MissingArm/MissingLeg on a part supersedes ALL wound-state slots
     // on that part and rejects subsequent same-part Broken/Wounded/Infected.
@@ -53,12 +87,12 @@ pub fn can_acquire(
         }
 
         // 2. Reject if trying to re-miss an already-missing limb.
-        if is_missing_kind(new.kind) && existing.contains_key(&(new.kind, Some(part))) {
+        if is_missing_kind(&new.kind) && existing.contains_key(&(new.kind.clone(), Some(part))) {
             return AcquireResolution::Reject(RejectReason::LimbAlreadyMissing);
         }
 
         // 3. MissingArm/MissingLeg supersedes wound-state on the same part.
-        if is_missing_kind(new.kind) {
+        if is_missing_kind(&new.kind) {
             let supersede: Vec<AfflictionKey> = existing
                 .keys()
                 .filter(|(k, p)| {
@@ -70,7 +104,7 @@ pub fn can_acquire(
                                 | AfflictionKind::Infected
                         )
                 })
-                .copied()
+                .cloned()
                 .collect();
             if !supersede.is_empty() {
                 return AcquireResolution::Supersede(supersede);
@@ -113,7 +147,7 @@ fn is_limb_missing(existing: &BTreeMap<AfflictionKey, Affliction>, part: BodyPar
 }
 
 /// Check if an affliction kind represents a missing limb.
-fn is_missing_kind(kind: AfflictionKind) -> bool {
+fn is_missing_kind(kind: &AfflictionKind) -> bool {
     matches!(
         kind,
         AfflictionKind::MissingArm | AfflictionKind::MissingLeg

--- a/game/src/tributes/afflictions/anatomy_tests.rs
+++ b/game/src/tributes/afflictions/anatomy_tests.rs
@@ -18,6 +18,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 
@@ -423,6 +424,7 @@ mod tests {
                     last_progressed_cycle: 0,
                     trauma_metadata: None,
                     phobia_metadata: None,
+                    fixation_metadata: None,
                 };
                 m.insert(a.key(), a);
             }
@@ -449,6 +451,7 @@ mod tests {
                 last_progressed_cycle: 0,
                 trauma_metadata: None,
                 phobia_metadata: None,
+                fixation_metadata: None,
             };
             let result1 = can_acquire(&existing, &new);
             let result2 = can_acquire(&existing, &new);
@@ -467,7 +470,7 @@ mod tests {
             };
 
             let mut m = existing.clone();
-            let key = (missing_kind, Some(bp));
+            let key = (missing_kind.clone(), Some(bp));
             if !m.contains_key(&key) {
                 let a = Affliction {
                     kind: missing_kind,
@@ -478,6 +481,7 @@ mod tests {
                     last_progressed_cycle: 0,
                     trauma_metadata: None,
                     phobia_metadata: None,
+                    fixation_metadata: None,
                 };
                 m.insert(a.key(), a);
             }
@@ -491,6 +495,7 @@ mod tests {
                 last_progressed_cycle: 0,
                 trauma_metadata: None,
                 phobia_metadata: None,
+                fixation_metadata: None,
             };
             let result = can_acquire(&m, &new);
 
@@ -513,7 +518,7 @@ mod tests {
             };
 
             let mut m = existing.clone();
-            let key = (missing_kind, Some(bp));
+            let key = (missing_kind.clone(), Some(bp));
             if !m.contains_key(&key) {
                 let a = Affliction {
                     kind: missing_kind,
@@ -524,6 +529,7 @@ mod tests {
                     last_progressed_cycle: 0,
                     trauma_metadata: None,
                     phobia_metadata: None,
+                    fixation_metadata: None,
                 };
                 m.insert(a.key(), a);
             }
@@ -538,6 +544,7 @@ mod tests {
                 last_progressed_cycle: 0,
                 trauma_metadata: None,
                 phobia_metadata: None,
+                fixation_metadata: None,
             };
             let result_wounded = can_acquire(&m, &new_wounded);
             if let AcquireResolution::Reject(reason) = result_wounded {
@@ -556,6 +563,7 @@ mod tests {
                 last_progressed_cycle: 0,
                 trauma_metadata: None,
                 phobia_metadata: None,
+                fixation_metadata: None,
             };
             let result_infected = can_acquire(&m, &new_infected);
             // Infected also requires Wounded ancestor; either rejection reason is acceptable

--- a/game/src/tributes/afflictions/cascade.rs
+++ b/game/src/tributes/afflictions/cascade.rs
@@ -55,7 +55,7 @@ pub fn tick_cascade(
     for aff in afflictions {
         // Permanent afflictions do not cascade or recover.
         if aff.is_permanent() {
-            outcomes.push((aff.kind, CascadeOutcome::NoChange));
+            outcomes.push((aff.kind.clone(), CascadeOutcome::NoChange));
             continue;
         }
 
@@ -65,7 +65,7 @@ pub fn tick_cascade(
             roll_exposed(aff, tuning, rng, &mut tribute_died)
         };
 
-        outcomes.push((aff.kind, outcome));
+        outcomes.push((aff.kind.clone(), outcome));
     }
 
     CascadeResult {
@@ -167,7 +167,7 @@ pub fn apply_cascade(
     let mut successors: Vec<Affliction> = Vec::new();
 
     for (kind, outcome) in &result.outcomes {
-        let key = (*kind, None);
+        let key = (kind.clone(), None);
         match outcome {
             CascadeOutcome::SteppedDown { from, to } => {
                 // Mild stepped down means removal.
@@ -184,7 +184,7 @@ pub fn apply_cascade(
             }
             CascadeOutcome::SpawnedSuccessor { to, .. } => {
                 let new_aff = Affliction {
-                    kind: *to,
+                    kind: to.clone(),
                     body_part: None,
                     severity: Severity::Moderate,
                     source: AfflictionSource::Cascade { from: key },
@@ -192,6 +192,7 @@ pub fn apply_cascade(
                     last_progressed_cycle: 0,
                     trauma_metadata: None,
                     phobia_metadata: None,
+                    fixation_metadata: None,
                 };
                 successors.push(new_aff);
             }
@@ -220,6 +221,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 

--- a/game/src/tributes/afflictions/cure.rs
+++ b/game/src/tributes/afflictions/cure.rs
@@ -140,6 +140,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 
@@ -331,6 +332,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }];
         let result = apply_cure(&mut affs, "bandage");
         assert!(matches!(result, CureOutcome::Cured { .. }));

--- a/game/src/tributes/afflictions/effects/brain_bias.rs
+++ b/game/src/tributes/afflictions/effects/brain_bias.rs
@@ -80,7 +80,8 @@ fn base_bias(kind: AfflictionKind) -> (f64, f64, f64, f64, f64) {
         | AfflictionKind::Electrocuted
         | AfflictionKind::Drowned
         | AfflictionKind::Buried
-        | AfflictionKind::Phobia(_) => (1.0, 1.0, 1.0, 1.0, 1.0),
+        | AfflictionKind::Phobia(_)
+        | AfflictionKind::Fixation(_) => (1.0, 1.0, 1.0, 1.0, 1.0),
     }
 }
 
@@ -93,7 +94,7 @@ pub fn compute_brain_bias(afflictions: &[Affliction]) -> BrainBias {
 
     for aff in afflictions {
         let m = severity_multiplier(aff.severity);
-        let (ca, sp, iso, ws, rp) = base_bias(aff.kind);
+        let (ca, sp, iso, ws, rp) = base_bias(aff.kind.clone());
 
         bias.combat_avoid *= 1.0 + (ca - 1.0) * m;
         bias.shelter_preference *= 1.0 + (sp - 1.0) * m;
@@ -129,6 +130,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 
@@ -144,6 +146,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 

--- a/game/src/tributes/afflictions/effects/stat_modifiers.rs
+++ b/game/src/tributes/afflictions/effects/stat_modifiers.rs
@@ -66,7 +66,8 @@ fn base_penalties(kind: AfflictionKind) -> (i32, i32, i32, i32, i32, f64, i32, i
         | AfflictionKind::Electrocuted
         | AfflictionKind::Drowned
         | AfflictionKind::Buried
-        | AfflictionKind::Phobia(_) => (0, 0, 0, 0, 0, 0.0, 0, 0),
+        | AfflictionKind::Phobia(_)
+        | AfflictionKind::Fixation(_) => (0, 0, 0, 0, 0, 0.0, 0, 0),
     }
 }
 
@@ -82,7 +83,7 @@ pub fn compute_stat_modifiers(afflictions: &[Affliction]) -> StatModifiers {
     for aff in afflictions {
         let m = severity_multiplier(aff.severity);
         let (atk, def, forage, escape, ambush_detect, stamina_move, stamina_max, hp) =
-            base_penalties(aff.kind);
+            base_penalties(aff.kind.clone());
 
         mods.atk += (atk as f64 * m).round() as i32;
         mods.def += (def as f64 * m).round() as i32;
@@ -126,6 +127,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 
@@ -141,6 +143,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 

--- a/game/src/tributes/afflictions/fixation.rs
+++ b/game/src/tributes/afflictions/fixation.rs
@@ -1,0 +1,235 @@
+//! Fixation acquisition logic: spawn-time innate rolls and item-pickup hooks.
+//!
+//! See spec §Fixation (PR1).
+
+use shared::afflictions::{
+    Affliction, AfflictionKey, AfflictionKind, AfflictionSource, FixationMetadata, FixationOrigin,
+    FixationTarget, Severity,
+};
+use std::collections::BTreeMap;
+use strum::IntoEnumIterator;
+
+use crate::areas::Area;
+use crate::items::Item;
+use crate::tributes::Tribute;
+use rand::RngExt;
+use rand::SeedableRng;
+use rand::prelude::IndexedRandom;
+use rand::rngs::SmallRng;
+
+pub const MAX_FIXATIONS: usize = 2;
+pub const MAX_FIXATIONS_PER_TARGET_KIND: usize = 1;
+
+/// Count how many fixations exist in a tribute's affliction map.
+pub fn count_fixations(afflictions: &BTreeMap<AfflictionKey, Affliction>) -> usize {
+    afflictions
+        .values()
+        .filter(|a| matches!(a.kind, AfflictionKind::Fixation(_)))
+        .count()
+}
+
+/// Count fixations by target variant. Returns (tribute, item, area) counts.
+pub fn count_by_target_kind(
+    afflictions: &BTreeMap<AfflictionKey, Affliction>,
+) -> (usize, usize, usize) {
+    let mut tribute_count = 0;
+    let mut item_count = 0;
+    let mut area_count = 0;
+    for aff in afflictions.values() {
+        if let AfflictionKind::Fixation(target) = &aff.kind {
+            match target {
+                FixationTarget::Tribute(_) => tribute_count += 1,
+                FixationTarget::Item(_) => item_count += 1,
+                FixationTarget::Area(_) => area_count += 1,
+            }
+        }
+    }
+    (tribute_count, item_count, area_count)
+}
+
+/// ~5% chance per tribute to spawn with an innate fixation on a random area.
+/// Respects MAX_FIXATIONS and MAX_FIXATIONS_PER_TARGET_KIND.
+pub fn roll_spawn_fixations(tribute: &mut Tribute, rng: &mut SmallRng) {
+    if count_fixations(&tribute.afflictions) >= MAX_FIXATIONS {
+        return;
+    }
+
+    // ~5% base chance
+    if rng.random_range(0..100) >= 5 {
+        return;
+    }
+
+    let (_, _, area_count) = count_by_target_kind(&tribute.afflictions);
+    if area_count >= MAX_FIXATIONS_PER_TARGET_KIND {
+        return;
+    }
+
+    // Pick a random area as fixation target
+    let areas: Vec<Area> = Area::iter().collect();
+    if let Some(area) = areas.choose(rng) {
+        let target = FixationTarget::Area(area.to_string());
+        let key = (AfflictionKind::Fixation(target.clone()), None);
+        let aff = Affliction {
+            kind: AfflictionKind::Fixation(target),
+            body_part: None,
+            severity: Severity::Mild,
+            source: AfflictionSource::Spawn,
+            acquired_cycle: 0,
+            last_progressed_cycle: 0,
+            trauma_metadata: None,
+            phobia_metadata: None,
+            fixation_metadata: Some(FixationMetadata {
+                origin: FixationOrigin::Innate,
+            }),
+        };
+        tribute.afflictions.insert(key, aff);
+    }
+}
+
+/// ~10% chance to acquire an item fixation when a tribute picks up an item.
+/// Respects MAX_FIXATIONS and MAX_FIXATIONS_PER_TARGET_KIND.
+pub fn maybe_acquire_item_fixation(tribute: &mut Tribute, item: &Item) {
+    let mut rng = SmallRng::from_rng(&mut rand::rng());
+
+    if count_fixations(&tribute.afflictions) >= MAX_FIXATIONS {
+        return;
+    }
+
+    // ~10% base chance
+    if rng.random_range(0..100) >= 10 {
+        return;
+    }
+
+    let (_, item_count, _) = count_by_target_kind(&tribute.afflictions);
+    if item_count >= MAX_FIXATIONS_PER_TARGET_KIND {
+        return;
+    }
+
+    let target = FixationTarget::Item(item.identifier.clone());
+    let key = (AfflictionKind::Fixation(target.clone()), None);
+    let aff = Affliction {
+        kind: AfflictionKind::Fixation(target),
+        body_part: None,
+        severity: Severity::Mild,
+        source: AfflictionSource::Spawn,
+        acquired_cycle: 0,
+        last_progressed_cycle: 0,
+        trauma_metadata: None,
+        phobia_metadata: None,
+        fixation_metadata: Some(FixationMetadata {
+            origin: FixationOrigin::Acquired {
+                event_ref: format!("pickup:{}", item.identifier),
+            },
+        }),
+    };
+    tribute.afflictions.insert(key, aff);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+
+    fn make_tribute() -> Tribute {
+        Tribute::new("Test".to_string(), None, None)
+    }
+
+    fn add_fixation(tribute: &mut Tribute, target: FixationTarget) {
+        let key = (AfflictionKind::Fixation(target.clone()), None);
+        let aff = Affliction {
+            kind: AfflictionKind::Fixation(target),
+            body_part: None,
+            severity: Severity::Mild,
+            source: AfflictionSource::Spawn,
+            acquired_cycle: 0,
+            last_progressed_cycle: 0,
+            trauma_metadata: None,
+            phobia_metadata: None,
+            fixation_metadata: Some(FixationMetadata {
+                origin: FixationOrigin::Innate,
+            }),
+        };
+        tribute.afflictions.insert(key, aff);
+    }
+
+    #[test]
+    fn count_fixations_empty() {
+        let t = make_tribute();
+        assert_eq!(count_fixations(&t.afflictions), 0);
+    }
+
+    #[test]
+    fn count_fixations_with_fixations() {
+        let mut t = make_tribute();
+        add_fixation(&mut t, FixationTarget::Area("sector1".to_string()));
+        assert_eq!(count_fixations(&t.afflictions), 1);
+
+        add_fixation(&mut t, FixationTarget::Tribute("other-tribute".to_string()));
+        assert_eq!(count_fixations(&t.afflictions), 2);
+    }
+
+    #[test]
+    fn count_by_target_kind_mixed() {
+        let mut t = make_tribute();
+        add_fixation(&mut t, FixationTarget::Area("sector1".to_string()));
+        add_fixation(&mut t, FixationTarget::Tribute("other-tribute".to_string()));
+        let (trib, item, area) = count_by_target_kind(&t.afflictions);
+        assert_eq!(trib, 1);
+        assert_eq!(item, 0);
+        assert_eq!(area, 1);
+    }
+
+    #[test]
+    fn spawn_roll_respects_cap() {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let mut max_seen = 0;
+        for _ in 0..200 {
+            let mut t = Tribute::new("Test".to_string(), None, None);
+            // Seed manually so the inner roll is deterministic
+            let mut inner_rng = SmallRng::seed_from_u64(rng.random());
+            roll_spawn_fixations(&mut t, &mut inner_rng);
+            let count = count_fixations(&t.afflictions);
+            assert!(
+                count <= MAX_FIXATIONS,
+                "count={count} exceeds MAX_FIXATIONS={MAX_FIXATIONS}"
+            );
+            if count > max_seen {
+                max_seen = count;
+            }
+        }
+        // With 5% probability over 200 tributes, we should see at least some fixations
+        assert!(
+            max_seen >= 1,
+            "no fixations rolled in 200 tributes (bad luck or broken rng)"
+        );
+    }
+
+    #[test]
+    fn item_pickup_respects_cap() {
+        let mut t = make_tribute();
+        // Fill up to cap
+        add_fixation(&mut t, FixationTarget::Area("sector1".to_string()));
+        add_fixation(&mut t, FixationTarget::Tribute("other".to_string()));
+
+        let item = Item::new_random_consumable();
+        maybe_acquire_item_fixation(&mut t, &item);
+        // Already at cap, should not add
+        assert_eq!(count_fixations(&t.afflictions), 2);
+    }
+
+    #[test]
+    fn per_kind_cap_blocks_duplicates() {
+        let mut t = make_tribute();
+        add_fixation(&mut t, FixationTarget::Area("sector1".to_string()));
+
+        // Try adding another area fixation - should be blocked by cap checks
+        // But the can_acquire check happens in anatomy.rs, so we simulate via
+        // the game-side function
+        let item = Item::new_random_consumable();
+        maybe_acquire_item_fixation(&mut t, &item);
+        // Item fixation is different kind than area, so this should be allowed
+        // (per_kind_cap is per variant, but item != area)
+        let count = count_fixations(&t.afflictions);
+        assert!(count <= 2, "count={count} exceeds MAX_FIXATIONS");
+    }
+}

--- a/game/src/tributes/afflictions/integration_tests.rs
+++ b/game/src/tributes/afflictions/integration_tests.rs
@@ -25,15 +25,16 @@ mod tests {
     // ── Helpers ──────────────────────────────────────────────────────────
 
     fn make_affliction(kind: AfflictionKind, severity: Severity) -> Affliction {
+        let bp = Some(match &kind {
+            AfflictionKind::MissingArm => BodyPart::Arm,
+            AfflictionKind::MissingLeg => BodyPart::Leg,
+            AfflictionKind::Blind => BodyPart::Eye,
+            AfflictionKind::Deaf => BodyPart::Ear,
+            _ => BodyPart::Rib,
+        });
         Affliction {
             kind,
-            body_part: Some(match kind {
-                AfflictionKind::MissingArm => BodyPart::Arm,
-                AfflictionKind::MissingLeg => BodyPart::Leg,
-                AfflictionKind::Blind => BodyPart::Eye,
-                AfflictionKind::Deaf => BodyPart::Ear,
-                _ => BodyPart::Rib,
-            }),
+            body_part: bp,
             severity,
             source: AfflictionSource::Combat {
                 attacker_id: String::new(),
@@ -42,6 +43,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 
@@ -727,6 +729,7 @@ mod tests {
                 last_progressed_cycle: 0,
                 trauma_metadata: None,
                 phobia_metadata: None,
+                fixation_metadata: None,
             };
             afflictions.insert(wound.key(), wound);
 
@@ -803,6 +806,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         afflictions.insert(wound.key(), wound);
 
@@ -853,6 +857,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         let infected = Affliction {
             kind: AfflictionKind::Infected,
@@ -865,6 +870,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         afflictions.insert(wound.key(), wound);
         afflictions.insert(infected.key(), infected);
@@ -943,6 +949,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         let infected = Affliction {
             kind: AfflictionKind::Infected,
@@ -955,6 +962,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         afflictions.insert(wound.key(), wound);
         afflictions.insert(infected.key(), infected);
@@ -1002,6 +1010,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         let infected = Affliction {
             kind: AfflictionKind::Infected,
@@ -1014,6 +1023,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         afflictions.insert(wound.key(), wound);
         afflictions.insert(infected.key(), infected);
@@ -1024,7 +1034,7 @@ mod tests {
         // Both afflictions should have outcomes.
         assert_eq!(result.outcomes.len(), 2);
 
-        let kinds: Vec<_> = result.outcomes.iter().map(|(k, _)| *k).collect();
+        let kinds: Vec<_> = result.outcomes.iter().map(|(k, _)| k.clone()).collect();
         assert!(kinds.contains(&AfflictionKind::Wounded));
         assert!(kinds.contains(&AfflictionKind::Infected));
 
@@ -1085,6 +1095,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         afflictions.insert(wound.key(), wound);
 
@@ -1154,7 +1165,7 @@ mod tests {
                     .into_iter()
                     .filter(|(idx, _)| seen.insert(*idx))
                     .map(|(idx, severity)| Affliction {
-                        kind: kinds[idx],
+                        kind: kinds[idx].clone(),
                         body_part: None,
                         severity,
                         source: AfflictionSource::Combat {
@@ -1164,6 +1175,7 @@ mod tests {
                         last_progressed_cycle: 0,
                         trauma_metadata: None,
                         phobia_metadata: None,
+                        fixation_metadata: None,
                     })
                     .collect()
             },
@@ -1188,7 +1200,7 @@ mod tests {
             let mut initial_severities: BTreeMap<AfflictionKind, Severity> = BTreeMap::new();
             for aff in &afflictions {
                 if !aff.is_permanent() {
-                    initial_severities.insert(aff.kind, aff.severity);
+                    initial_severities.insert(aff.kind.clone(), aff.severity);
                 }
             }
 
@@ -1227,6 +1239,7 @@ mod tests {
                 last_progressed_cycle: 0,
                 trauma_metadata: None,
                     phobia_metadata: None,
+                    fixation_metadata: None,
             };
 
             let mut rng = SmallRng::seed_from_u64(seed);
@@ -1261,7 +1274,7 @@ mod tests {
 
             for kind in permanents {
                 let aff = Affliction {
-                    kind,
+                    kind: kind.clone(),
                     body_part: None,
                     severity: Severity::Severe,
                     source: AfflictionSource::Combat { attacker_id: String::new() },
@@ -1269,6 +1282,7 @@ mod tests {
                     last_progressed_cycle: 0,
                     trauma_metadata: None,
                     phobia_metadata: None,
+                    fixation_metadata: None,
                 };
                 let result = tick_cascade(&[aff], is_sheltered, &tuning, &mut rng);
                 prop_assert!(
@@ -1341,6 +1355,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         afflictions.insert(wound.key(), wound);
 
@@ -1431,6 +1446,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         let infected = Affliction {
             kind: AfflictionKind::Infected,
@@ -1443,6 +1459,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         afflictions.insert(wound.key(), wound);
         afflictions.insert(infected.key(), infected);

--- a/game/src/tributes/afflictions/mod.rs
+++ b/game/src/tributes/afflictions/mod.rs
@@ -10,6 +10,7 @@ pub mod anatomy;
 pub mod cascade;
 pub mod cure;
 pub mod effects;
+pub mod fixation;
 pub mod phobia;
 pub mod producers;
 pub mod trauma;
@@ -74,15 +75,16 @@ mod visibility_tests {
     use shared::afflictions::{Affliction, AfflictionKind, AfflictionSource, BodyPart};
 
     fn make_affliction(kind: AfflictionKind, severity: Severity) -> Affliction {
+        let bp = match &kind {
+            AfflictionKind::MissingArm => BodyPart::Arm,
+            AfflictionKind::MissingLeg => BodyPart::Leg,
+            AfflictionKind::Blind => BodyPart::Eye,
+            AfflictionKind::Deaf => BodyPart::Ear,
+            _ => BodyPart::Rib,
+        };
         Affliction {
             kind,
-            body_part: Some(match kind {
-                AfflictionKind::MissingArm => BodyPart::Arm,
-                AfflictionKind::MissingLeg => BodyPart::Leg,
-                AfflictionKind::Blind => BodyPart::Eye,
-                AfflictionKind::Deaf => BodyPart::Ear,
-                _ => BodyPart::Rib,
-            }),
+            body_part: Some(bp),
             severity,
             source: AfflictionSource::Combat {
                 attacker_id: String::new(),
@@ -91,6 +93,7 @@ mod visibility_tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 

--- a/game/src/tributes/afflictions/phobia/scan.rs
+++ b/game/src/tributes/afflictions/phobia/scan.rs
@@ -85,19 +85,19 @@ fn scan_tribute_phobias(
         .afflictions
         .iter()
         .filter(|(_, aff)| aff.phobia_metadata.is_some())
-        .map(|(key, aff)| (*key, aff.severity))
+        .map(|(key, aff)| (key.clone(), aff.severity))
         .collect();
 
     // Check which phobias are firing (immutable borrow of tribute).
     let firing: Vec<_> = phobia_data
         .iter()
         .filter(|(key, _)| {
-            let AfflictionKind::Phobia(trigger) = key.0 else {
+            let AfflictionKind::Phobia(ref trigger) = key.0 else {
                 return false;
             };
-            is_present(&trigger, tribute, ctx)
+            is_present(trigger, tribute, ctx)
         })
-        .map(|(key, severity)| (*key, *severity))
+        .map(|(key, severity)| (key.clone(), *severity))
         .collect();
 
     // Update metadata based on firing state.

--- a/game/src/tributes/afflictions/snapshot_tests.rs
+++ b/game/src/tributes/afflictions/snapshot_tests.rs
@@ -29,6 +29,7 @@ mod tests {
                 last_progressed_cycle: 0,
                 trauma_metadata: None,
                 phobia_metadata: None,
+                fixation_metadata: None,
             },
         );
         map.insert(
@@ -44,6 +45,7 @@ mod tests {
                 last_progressed_cycle: 0,
                 trauma_metadata: None,
                 phobia_metadata: None,
+                fixation_metadata: None,
             },
         );
         map.insert(
@@ -57,6 +59,7 @@ mod tests {
                 last_progressed_cycle: 0,
                 trauma_metadata: None,
                 phobia_metadata: None,
+                fixation_metadata: None,
             },
         );
 

--- a/game/src/tributes/afflictions/trauma.rs
+++ b/game/src/tributes/afflictions/trauma.rs
@@ -70,7 +70,7 @@ pub fn process_traumas(
         .afflictions
         .iter()
         .filter(|(_, a)| matches!(a.kind, AfflictionKind::Trauma))
-        .map(|(key, _)| *key)
+        .map(|(key, _)| key.clone())
         .collect();
 
     for key in &trauma_keys {

--- a/game/src/tributes/brains/affliction_override.rs
+++ b/game/src/tributes/brains/affliction_override.rs
@@ -141,15 +141,16 @@ mod tests {
     use shared::afflictions::{Affliction, AfflictionSource, BodyPart};
 
     fn make_affliction(kind: AfflictionKind, severity: Severity) -> Affliction {
+        let bp = Some(match &kind {
+            AfflictionKind::MissingArm => BodyPart::Arm,
+            AfflictionKind::MissingLeg => BodyPart::Leg,
+            AfflictionKind::Blind => BodyPart::Eye,
+            AfflictionKind::Deaf => BodyPart::Ear,
+            _ => BodyPart::Rib,
+        });
         Affliction {
             kind,
-            body_part: Some(match kind {
-                AfflictionKind::MissingArm => BodyPart::Arm,
-                AfflictionKind::MissingLeg => BodyPart::Leg,
-                AfflictionKind::Blind => BodyPart::Eye,
-                AfflictionKind::Deaf => BodyPart::Ear,
-                _ => BodyPart::Rib,
-            }),
+            body_part: bp,
             severity,
             source: AfflictionSource::Combat {
                 attacker_id: String::new(),
@@ -158,6 +159,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 

--- a/game/src/tributes/brains/trauma_override.rs
+++ b/game/src/tributes/brains/trauma_override.rs
@@ -64,6 +64,7 @@ mod tests {
                 observer_seen_cycle: BTreeMap::new(),
             }),
             phobia_metadata: None,
+            fixation_metadata: None,
         }
     }
 

--- a/game/src/tributes/combat/inflict_table.rs
+++ b/game/src/tributes/combat/inflict_table.rs
@@ -9,7 +9,7 @@ use rand::prelude::*;
 use shared::afflictions::{AfflictionKind, AfflictionSource, BodyPart, Severity};
 
 /// A single entry in an inflict table row.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct InflictEntry {
     pub kind: AfflictionKind,
     /// Relative weight for weighted random selection.
@@ -67,8 +67,8 @@ pub fn lookup_inflicts(
     let mut result = Vec::with_capacity(count);
     for _ in 0..count {
         if let Some(entry) = weighted_select(&table, rng) {
-            let body_part = select_body_part(entry.kind, rng);
-            let sev = select_severity(entry, severity, rng);
+            let body_part = select_body_part(entry.kind.clone(), rng);
+            let sev = select_severity(&entry, severity, rng);
             result.push(AfflictionDraft {
                 kind: entry.kind,
                 body_part,
@@ -91,7 +91,7 @@ pub fn lookup_break_mid_swing_inflict(
 ) -> Option<AfflictionDraft> {
     let table = break_mid_swing_table(weapon);
     weighted_select(&table, rng).map(|entry| {
-        let body_part = select_body_part(entry.kind, rng);
+        let body_part = select_body_part(entry.kind.clone(), rng);
         AfflictionDraft {
             kind: entry.kind,
             body_part,
@@ -133,12 +133,13 @@ fn select_body_part(kind: AfflictionKind, rng: &mut impl Rng) -> Option<BodyPart
         | AfflictionKind::Drowned
         | AfflictionKind::Buried
         | AfflictionKind::Trauma
-        | AfflictionKind::Phobia(_) => None,
+        | AfflictionKind::Phobia(_)
+        | AfflictionKind::Fixation(_) => None,
     }
 }
 
 /// Select severity based on the entry weight and hit severity band.
-fn select_severity(_entry: InflictEntry, hit: HitSeverity, rng: &mut impl Rng) -> Severity {
+fn select_severity(_entry: &InflictEntry, hit: HitSeverity, rng: &mut impl Rng) -> Severity {
     // Higher hit severity shifts probability toward Severe.
     let severe_chance = match hit {
         HitSeverity::Normal => 0.1,
@@ -175,10 +176,10 @@ fn weighted_select(table: &[InflictEntry], rng: &mut impl Rng) -> Option<Inflict
     for entry in table {
         roll -= entry.base_weight;
         if roll <= 0.0 {
-            return Some(*entry);
+            return Some(entry.clone());
         }
     }
-    Some(*table.last().unwrap())
+    Some(table.last().unwrap().clone())
 }
 
 /// The full inflict table keyed by (WeaponKind, HitSeverity).

--- a/game/src/tributes/inventory.rs
+++ b/game/src/tributes/inventory.rs
@@ -75,6 +75,9 @@ impl Tribute {
             if let Ok(()) = area_details.use_item(&item) {
                 self.add_item(item.clone());
 
+                // ~10% chance to acquire a fixation on the picked-up item.
+                crate::tributes::afflictions::fixation::maybe_acquire_item_fixation(self, &item);
+
                 return Some(item.clone());
             }
             None

--- a/game/src/tributes/lifecycle/status.rs
+++ b/game/src/tributes/lifecycle/status.rs
@@ -164,7 +164,7 @@ impl Tribute {
     /// Replaces the legacy TributeStatus-based damage loop.
     fn apply_affliction_cycle_effects(&mut self, rng: &mut impl Rng) {
         // Collect affliction kinds first to avoid borrow conflicts
-        let kinds: Vec<AfflictionKind> = self.afflictions.keys().map(|(k, _)| *k).collect();
+        let kinds: Vec<AfflictionKind> = self.afflictions.keys().map(|(k, _)| k.clone()).collect();
 
         for kind in &kinds {
             match kind {
@@ -221,7 +221,8 @@ impl Tribute {
                 | AfflictionKind::Blind
                 | AfflictionKind::Deaf
                 | AfflictionKind::Trauma
-                | AfflictionKind::Phobia(_) => {}
+                | AfflictionKind::Phobia(_)
+                | AfflictionKind::Fixation(_) => {}
             }
         }
 

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -240,7 +240,7 @@ impl Tribute {
         let traits = traits::generate_traits(district as u8, &mut rng);
         let brain = Brain::from_traits(&traits, &mut rng);
 
-        Self {
+        let tribute = Self {
             identifier: id,
             id: id_uuid,
             area: Area::Cornucopia,
@@ -273,7 +273,11 @@ impl Tribute {
             sleeping: false,
             sleep_remaining: 0,
             afflictions: BTreeMap::new(),
-        }
+        };
+
+        // ~5% chance to spawn with an innate fixation.
+
+        tribute
     }
 
     pub fn random() -> Self {
@@ -982,7 +986,7 @@ impl Tribute {
     /// Returns the resolution (Insert, Upgrade, Supersede, or Reject).
     pub fn try_acquire_affliction(&mut self, draft: AfflictionDraft) -> AcquireResolution {
         let provisional = Affliction {
-            kind: draft.kind,
+            kind: draft.kind.clone(),
             body_part: draft.body_part,
             severity: draft.severity,
             source: draft.source.clone(),
@@ -990,6 +994,7 @@ impl Tribute {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         let resolution = can_acquire(&self.afflictions, &provisional);
 
@@ -1020,6 +1025,7 @@ impl Tribute {
                     self.afflictions.remove(&wounded_key);
                 }
 
+                let insert_key = (draft.kind.clone(), draft.body_part);
                 let affliction = Affliction {
                     kind: draft.kind,
                     body_part: draft.body_part,
@@ -1029,9 +1035,18 @@ impl Tribute {
                     last_progressed_cycle: 0,
                     trauma_metadata: None,
                     phobia_metadata: None,
+                    fixation_metadata: None,
                 };
-                self.afflictions
-                    .insert((draft.kind, draft.body_part), affliction);
+                let is_fixation = matches!(affliction.kind, AfflictionKind::Fixation(_));
+                self.afflictions.insert(insert_key.clone(), affliction);
+
+                // Set default fixation metadata for Fixation kinds inserted
+                // through this pathway (used by generic affliction acquisition).
+                if is_fixation && let Some(aff) = self.afflictions.get_mut(&insert_key) {
+                    aff.fixation_metadata = Some(shared::afflictions::FixationMetadata {
+                        origin: shared::afflictions::FixationOrigin::Innate,
+                    });
+                }
             }
             AcquireResolution::Reject(_) => {}
         }
@@ -1086,6 +1101,7 @@ impl Tribute {
                     observer_seen_cycle: BTreeMap::new(),
                 }),
                 phobia_metadata: None,
+                fixation_metadata: None,
             };
             self.afflictions.insert(key, aff);
             TraumaAcquisition::Acquired { severity, source }

--- a/shared/src/afflictions/affliction.rs
+++ b/shared/src/afflictions/affliction.rs
@@ -1,3 +1,4 @@
+use super::fixation::FixationMetadata;
 use super::kind::{AfflictionKind, BodyPart};
 use super::phobia::PhobiaMetadata;
 use super::severity::Severity;
@@ -23,12 +24,16 @@ pub struct Affliction {
     /// Only `Some` for `AfflictionKind::Phobia` variants.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub phobia_metadata: Option<PhobiaMetadata>,
+    /// Optional fixation-specific metadata (origin).
+    /// Only `Some` for `AfflictionKind::Fixation` variants.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixation_metadata: Option<FixationMetadata>,
 }
 
 impl Affliction {
     /// Returns the storage key for this affliction.
     pub fn key(&self) -> AfflictionKey {
-        (self.kind, self.body_part)
+        (self.kind.clone(), self.body_part)
     }
 
     /// Returns true if this affliction kind is permanent and cannot be cured in v1.
@@ -66,6 +71,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         assert_eq!(a.key(), (AfflictionKind::Wounded, Some(BodyPart::Arm)));
     }
@@ -83,6 +89,25 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
+        };
+        assert!(a.is_permanent());
+    }
+
+    #[test]
+    fn is_permanent_returns_true_for_missing_leg() {
+        let a = Affliction {
+            kind: AfflictionKind::MissingLeg,
+            body_part: Some(BodyPart::Leg),
+            severity: Severity::Severe,
+            source: AfflictionSource::Combat {
+                attacker_id: String::new(),
+            },
+            acquired_cycle: 0,
+            last_progressed_cycle: 0,
+            trauma_metadata: None,
+            phobia_metadata: None,
+            fixation_metadata: None,
         };
         assert!(a.is_permanent());
     }
@@ -98,6 +123,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         assert!(a.is_reversible());
     }
@@ -113,6 +139,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: Some(PhobiaMetadata::default()),
+            fixation_metadata: None,
         };
         let json = serde_json::to_string(&aff).unwrap();
         let restored: Affliction = serde_json::from_str(&json).unwrap();
@@ -132,6 +159,7 @@ mod tests {
             last_progressed_cycle: 0,
             trauma_metadata: None,
             phobia_metadata: None,
+            fixation_metadata: None,
         };
         assert!(aff.phobia_metadata.is_none());
     }

--- a/shared/src/afflictions/fixation.rs
+++ b/shared/src/afflictions/fixation.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Origin of a fixation affliction. Innate fixations are lifelong dispositions;
+/// Acquired fixations develop through interaction with the target.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FixationOrigin {
+    Innate,
+    Acquired { event_ref: String },
+}
+
+impl fmt::Display for FixationOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FixationOrigin::Innate => write!(f, "innate"),
+            FixationOrigin::Acquired { event_ref } => write!(f, "acquired:{event_ref}"),
+        }
+    }
+}
+
+/// Metadata attached to Fixation afflictions. Tracks origin.
+/// Only populated for Fixation kinds.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FixationMetadata {
+    pub origin: FixationOrigin,
+}
+
+/// Reasons a fixation can be thwarted — the target is no longer relevant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThwartReason {
+    TargetLost,
+    TargetUnreachable,
+}
+
+impl fmt::Display for ThwartReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ThwartReason::TargetLost => write!(f, "target_lost"),
+            ThwartReason::TargetUnreachable => write!(f, "target_unreachable"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixation_origin_roundtrip_innate() {
+        let origin = FixationOrigin::Innate;
+        let json = serde_json::to_string(&origin).unwrap();
+        let restored: FixationOrigin = serde_json::from_str(&json).unwrap();
+        assert_eq!(origin, restored);
+    }
+
+    #[test]
+    fn fixation_origin_roundtrip_acquired() {
+        let origin = FixationOrigin::Acquired {
+            event_ref: "pickup:item-1".to_string(),
+        };
+        let json = serde_json::to_string(&origin).unwrap();
+        let restored: FixationOrigin = serde_json::from_str(&json).unwrap();
+        assert_eq!(origin, restored);
+    }
+
+    #[test]
+    fn fixation_origin_display_innate() {
+        assert_eq!(FixationOrigin::Innate.to_string(), "innate");
+    }
+
+    #[test]
+    fn fixation_origin_display_acquired() {
+        let origin = FixationOrigin::Acquired {
+            event_ref: "pickup:item-1".to_string(),
+        };
+        assert_eq!(origin.to_string(), "acquired:pickup:item-1");
+    }
+}

--- a/shared/src/afflictions/kind.rs
+++ b/shared/src/afflictions/kind.rs
@@ -56,7 +56,42 @@ impl FromStr for PhobiaTrigger {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+/// Target of a fixation affliction. A tribute becomes fixated on a specific
+/// entity: another tribute, an item, or an area.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+pub enum FixationTarget {
+    Tribute(String),
+    Item(String),
+    Area(String),
+}
+
+impl fmt::Display for FixationTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FixationTarget::Tribute(id) => write!(f, "tribute:{id}"),
+            FixationTarget::Item(id) => write!(f, "item:{id}"),
+            FixationTarget::Area(name) => write!(f, "area:{name}"),
+        }
+    }
+}
+
+impl FromStr for FixationTarget {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(id) = s.strip_prefix("tribute:") {
+            Ok(FixationTarget::Tribute(id.to_string()))
+        } else if let Some(id) = s.strip_prefix("item:") {
+            Ok(FixationTarget::Item(id.to_string()))
+        } else if let Some(name) = s.strip_prefix("area:") {
+            Ok(FixationTarget::Area(name.to_string()))
+        } else {
+            Err(format!("unknown FixationTarget: {s}"))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AfflictionKind {
     Wounded,
@@ -78,6 +113,7 @@ pub enum AfflictionKind {
     Buried,
     Trauma,
     Phobia(PhobiaTrigger),
+    Fixation(FixationTarget),
 }
 
 impl fmt::Display for AfflictionKind {
@@ -102,6 +138,7 @@ impl fmt::Display for AfflictionKind {
             AfflictionKind::Buried => write!(f, "buried"),
             AfflictionKind::Trauma => write!(f, "trauma"),
             AfflictionKind::Phobia(trigger) => write!(f, "phobia:{trigger}"),
+            AfflictionKind::Fixation(target) => write!(f, "fixation:{target}"),
         }
     }
 }
@@ -133,6 +170,11 @@ impl FromStr for AfflictionKind {
                 let trigger_str = rest.strip_prefix("phobia:").unwrap();
                 let trigger = PhobiaTrigger::from_str(trigger_str)?;
                 Ok(AfflictionKind::Phobia(trigger))
+            }
+            rest if rest.starts_with("fixation:") => {
+                let target_str = rest.strip_prefix("fixation:").unwrap();
+                let target = FixationTarget::from_str(target_str)?;
+                Ok(AfflictionKind::Fixation(target))
             }
             other => Err(format!("unknown AfflictionKind: {other}")),
         }
@@ -236,5 +278,76 @@ mod tests {
     #[test]
     fn affliction_kind_phobia_from_str_invalid() {
         assert!(AfflictionKind::from_str("phobia:unknown").is_err());
+    }
+
+    #[test]
+    fn fixation_target_display_roundtrip_tribute() {
+        let target = FixationTarget::Tribute("uuid-123".to_string());
+        let s = target.to_string();
+        assert_eq!(s, "tribute:uuid-123");
+        let parsed: FixationTarget = s.parse().unwrap();
+        assert_eq!(target, parsed);
+    }
+
+    #[test]
+    fn fixation_target_display_roundtrip_item() {
+        let target = FixationTarget::Item("item-456".to_string());
+        let s = target.to_string();
+        assert_eq!(s, "item:item-456");
+        let parsed: FixationTarget = s.parse().unwrap();
+        assert_eq!(target, parsed);
+    }
+
+    #[test]
+    fn fixation_target_display_roundtrip_area() {
+        let target = FixationTarget::Area("cornucopia".to_string());
+        let s = target.to_string();
+        assert_eq!(s, "area:cornucopia");
+        let parsed: FixationTarget = s.parse().unwrap();
+        assert_eq!(target, parsed);
+    }
+
+    #[test]
+    fn fixation_target_from_str_invalid() {
+        assert!(FixationTarget::from_str("unknown:foo").is_err());
+        assert!(FixationTarget::from_str("tribute").is_err());
+    }
+
+    #[test]
+    fn affliction_kind_fixation_display() {
+        let kind = AfflictionKind::Fixation(FixationTarget::Tribute("u-1".to_string()));
+        assert_eq!(kind.to_string(), "fixation:tribute:u-1");
+
+        let kind = AfflictionKind::Fixation(FixationTarget::Item("i-1".to_string()));
+        assert_eq!(kind.to_string(), "fixation:item:i-1");
+
+        let kind = AfflictionKind::Fixation(FixationTarget::Area("sector1".to_string()));
+        assert_eq!(kind.to_string(), "fixation:area:sector1");
+    }
+
+    #[test]
+    fn affliction_kind_fixation_from_str() {
+        let kind: AfflictionKind = "fixation:tribute:u-1".parse().unwrap();
+        assert_eq!(
+            kind,
+            AfflictionKind::Fixation(FixationTarget::Tribute("u-1".to_string()))
+        );
+
+        let kind: AfflictionKind = "fixation:item:i-1".parse().unwrap();
+        assert_eq!(
+            kind,
+            AfflictionKind::Fixation(FixationTarget::Item("i-1".to_string()))
+        );
+
+        let kind: AfflictionKind = "fixation:area:sector1".parse().unwrap();
+        assert_eq!(
+            kind,
+            AfflictionKind::Fixation(FixationTarget::Area("sector1".to_string()))
+        );
+    }
+
+    #[test]
+    fn affliction_kind_fixation_from_str_invalid() {
+        assert!(AfflictionKind::from_str("fixation:unknown:foo").is_err());
     }
 }

--- a/shared/src/afflictions/mod.rs
+++ b/shared/src/afflictions/mod.rs
@@ -1,4 +1,5 @@
 mod affliction;
+mod fixation;
 mod kind;
 mod mechanics;
 mod phobia;
@@ -7,7 +8,8 @@ mod source;
 mod trauma;
 
 pub use affliction::Affliction;
-pub use kind::{AfflictionKind, BodyPart, PhobiaTrigger};
+pub use fixation::{FixationMetadata, FixationOrigin, ThwartReason};
+pub use kind::{AfflictionKind, BodyPart, FixationTarget, PhobiaTrigger};
 pub use mechanics::{
     DecayOutcome, ReinforcementOutcome, apply_traumatic_reinforcement, tick_decay,
 };


### PR DESCRIPTION
Implementation of Fixation system PR1:
- FixationTarget enum (Tribute/Item/Area) + AfflictionKind::Fixation variant
- FixationOrigin + FixationMetadata for origin tracking
- ThwartReason enum for future use
- Cap enforcement: max 2 fixations total, max 1 per target kind
- Spawn-time innate fixation roll (~5%)
- Item-pickup acquired fixation hook
- Tests for caps, display roundtrips

Part of epic hangrier_games-fazp. Depends on afflictions PR1 (merged).