### PR TITLE
feat(web): addiction PR4 — frontend tribute detail, state strip, icons

### DIFF
--- a/api/src/templates/game_detail.rs
+++ b/api/src/templates/game_detail.rs
@@ -1,4 +1,5 @@
 use maud::html;
+use shared::afflictions::AfflictionKind;
 use shared::{DisplayGame, GameStatus};
 
 use super::pages::status_color;
@@ -204,15 +205,47 @@ fn tribute_card(tribute: &game::tributes::Tribute) -> maud::Markup {
             @if !tribute.afflictions.is_empty() {
                 div class="card-afflictions" {
                     @for (_key, affliction) in &tribute.afflictions {
-                        @let severity_class = match affliction.severity.to_string().as_str() {
-                            "severe" => "severity-severe",
-                            "moderate" => "severity-moderate",
-                            _ => "severity-mild",
+                        @if !matches!(affliction.kind, AfflictionKind::Addiction(_)) {
+                            @let severity_class = match affliction.severity.to_string().as_str() {
+                                "severe" => "severity-severe",
+                                "moderate" => "severity-moderate",
+                                _ => "severity-mild",
+                            };
+                            @let body_part = affliction.body_part.map(|bp| format!(" ({bp})")).unwrap_or_default();
+                            span class=(format!("affliction-badge {}", severity_class)) {
+                                (icon("bandage"))
+                                " " (affliction.kind) (body_part)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Addiction state indicators
+            @let addictions: Vec<_> = tribute.afflictions.values()
+                .filter(|a| matches!(a.kind, AfflictionKind::Addiction(_)))
+                .collect();
+            @if !addictions.is_empty() {
+                div class="card-addiction-state" {
+                    @for affliction in &addictions {
+                        @let substance = match &affliction.kind {
+                            AfflictionKind::Addiction(s) => s,
+                            _ => unreachable!(),
                         };
-                        @let body_part = affliction.body_part.map(|bp| format!(" ({bp})")).unwrap_or_default();
-                        span class=(format!("affliction-badge {}", severity_class)) {
-                            (icon("bandage"))
-                            " " (affliction.kind) (body_part)
+                        @if let Some(meta) = &affliction.addiction_metadata {
+                            @if meta.high_cycles_remaining > 0 {
+                                span class="addiction-state-high" {
+                                    (icon(substance.icon_name()))
+                                    " HIGH"
+                                }
+                            } @else {
+                                @if affliction.severity >= shared::afflictions::Severity::Moderate {
+                                    span class="addiction-state-withdrawal" {
+                                        (icon("withdrawal"))
+                                        " WITHDRAWAL"
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/api/src/templates/tribute_detail.rs
+++ b/api/src/templates/tribute_detail.rs
@@ -71,14 +71,14 @@ pub fn tribute_detail_page(
                     }
                 }
 
-                // Afflictions (non-fixation)
-                @let non_fixation_afflictions: Vec<_> = tribute.afflictions.values()
-                    .filter(|a| !matches!(a.kind, AfflictionKind::Fixation(_)))
+                // Afflictions (non-fixation, non-addiction)
+                @let non_special_afflictions: Vec<_> = tribute.afflictions.values()
+                    .filter(|a| !matches!(a.kind, AfflictionKind::Fixation(_) | AfflictionKind::Addiction(_)))
                     .collect();
-                @if !non_fixation_afflictions.is_empty() {
+                @if !non_special_afflictions.is_empty() {
                     div class="card-afflictions" {
                         h3 { (icon("bandage")) " Afflictions" }
-                        @for affliction in &non_fixation_afflictions {
+                        @for affliction in &non_special_afflictions {
                             @let severity_class = match affliction.severity.to_string().as_str() {
                                 "severe" => "severity-severe",
                                 "moderate" => "severity-moderate",
@@ -88,6 +88,65 @@ pub fn tribute_detail_page(
                             span class=(format!("affliction-badge {}", severity_class)) {
                                 (icon("bandage"))
                                 " " (affliction.kind.to_string()) (body_part)
+                            }
+                        }
+                    }
+                }
+
+                // Addictions section
+                @let addictions: Vec<_> = tribute.afflictions.values()
+                    .filter(|a| matches!(a.kind, AfflictionKind::Addiction(_)))
+                    .collect();
+                @if !addictions.is_empty() {
+                    div class="addictions-section" {
+                        h3 { (icon("activity")) " Addictions" }
+                        @for affliction in &addictions {
+                            @let substance = match &affliction.kind {
+                                AfflictionKind::Addiction(s) => s,
+                                _ => unreachable!(),
+                            };
+                            @let meta = &affliction.addiction_metadata;
+                            @let severity = affliction.severity.to_string();
+                            @let severity_class = match severity.as_str() {
+                                "severe" => "severity-severe",
+                                "moderate" => "severity-moderate",
+                                _ => "severity-mild",
+                            };
+                            @let use_count = tribute.addiction_use_count.get(substance).copied().unwrap_or(0);
+                            @let bar_pct = ((use_count as f64) / 20.0_f64).min(1.0) * 100.0;
+
+                            div class="addiction-card" {
+                                div class="addiction-header" {
+                                    (icon(substance.icon_name()))
+                                    " " (substance.to_string())
+                                    span class=(format!("affliction-badge {}", severity_class)) { (severity) }
+                                }
+                                @if let Some(m) = meta {
+                                    div class="addiction-meta" {
+                                        @if m.high_cycles_remaining > 0 {
+                                            span class="badge-high" {
+                                                "HIGH \u{d7}" (m.high_cycles_remaining)
+                                            }
+                                        } @else {
+                                            span class="badge-withdrawal" {
+                                                (icon("withdrawal"))
+                                                " WITHDRAWAL"
+                                            }
+                                        }
+                                        span { "Cycles since last use: " (m.cycles_since_last_use) }
+                                    }
+                                    div class="addiction-observers" {
+                                        (icon("eye"))
+                                        " Observed by " (m.observed_by.len()) " tribute(s)"
+                                    }
+                                    // Use-count bar
+                                    div class="use-count-bar" {
+                                        span class="use-count-label" { "Total uses: " (use_count) }
+                                        div class="bar-track" {
+                                            div class="bar-fill" style=(format!("width: {:.0}%", bar_pct)) {}
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/shared/src/afflictions/kind.rs
+++ b/shared/src/afflictions/kind.rs
@@ -105,6 +105,18 @@ pub enum Substance {
     Painkiller,
 }
 
+impl Substance {
+    /// Icon name for sprite-ui.svg lookups.
+    pub fn icon_name(&self) -> &'static str {
+        match self {
+            Substance::Stimulant => "stimulant",
+            Substance::Morphling => "morphling",
+            Substance::Alcohol => "alcohol",
+            Substance::Painkiller => "painkiller",
+        }
+    }
+}
+
 impl fmt::Display for Substance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
Summary: Frontend for addiction affliction system per spec §12.

Changes:
- Add substance icons (stimulant, morphling, alcohol, painkiller) + withdrawal icon to sprite-ui.svg
- Add `Substance::icon_name()` method to shared/src/afflictions/kind.rs
- Add dedicated "Addictions" section to tribute detail page (severity badge, mode badge, cycles since last use, observer count, use-count bar chart)
- Add addiction state-strip indicators to tribute card (HIGH/Withdrawal badges)
- Filter addictions out of generic affliction badges in both tribute card and detail page

Verification: `cargo check --package api` + `cargo check --package shared` + `cargo fmt --check` all pass.

Follow-ups: None.