### PR TITLE
refactor(trapped): retire TributeDrowned + legacy AfflictionKind variants

### DIFF
--- a/game/src/events/display.rs
+++ b/game/src/events/display.rs
@@ -193,13 +193,6 @@ impl Display for GameEvent {
                     tribute_name
                 )
             }
-            GameEvent::TributeDrowned { tribute_name, .. } => {
-                write!(
-                    f,
-                    "🏊 {} partially drowns, loses health and sanity",
-                    tribute_name
-                )
-            }
             GameEvent::TributeMauled {
                 tribute_name,
                 animal_count,

--- a/game/src/events/mod.rs
+++ b/game/src/events/mod.rs
@@ -242,13 +242,6 @@ mod tests {
                 GameOutput::TributePoisoned("Alice"),
             ),
             (
-                GameEvent::TributeDrowned {
-                    tribute_id: uid_a(),
-                    tribute_name: "Alice".into(),
-                },
-                GameOutput::TributeDrowned("Alice"),
-            ),
-            (
                 GameEvent::TributeMauled {
                     tribute_id: uid_a(),
                     tribute_name: "Alice".into(),
@@ -584,8 +577,8 @@ mod tests {
     #[test]
     fn parity_table_covers_every_variant() {
         // Bumps any time a variant is added without a parity row.
-        // 74 = current count of GameOutput variants in output.rs.
-        assert_eq!(parity_table().len(), 74);
+        // 73 = current count of GameEvent variants in types.rs.
+        assert_eq!(parity_table().len(), 73);
     }
 
     #[test]

--- a/game/src/events/types.rs
+++ b/game/src/events/types.rs
@@ -168,10 +168,6 @@ pub enum GameEvent {
         tribute_id: Uuid,
         tribute_name: String,
     },
-    TributeDrowned {
-        tribute_id: Uuid,
-        tribute_name: String,
-    },
     TributeMauled {
         tribute_id: Uuid,
         tribute_name: String,

--- a/game/src/output.rs
+++ b/game/src/output.rs
@@ -2,6 +2,7 @@ use crate::items::Item;
 use crate::threats::animals::Animal;
 use indefinite::indefinite;
 use indefinite::indefinite_capitalized;
+use shared::afflictions::TrapKind;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
@@ -46,7 +47,10 @@ pub enum GameOutput<'a> {
     TributeDehydrated(&'a str),
     TributeStarving(&'a str),
     TributePoisoned(&'a str),
-    TributeDrowned(&'a str),
+    TributeDiedWhileTrapped {
+        tribute_name: &'a str,
+        kind: TrapKind,
+    },
     TributeMauled(&'a str, u32, &'a str, u32),
     TributeBurned(&'a str),
     TributeHorrified(&'a str, u32),
@@ -226,13 +230,6 @@ impl<'a> Display for GameOutput<'a> {
             GameOutput::TributePoisoned(tribute) => {
                 write!(f, "🧪 {} eats something poisonous, loses sanity", tribute)
             }
-            GameOutput::TributeDrowned(tribute) => {
-                write!(
-                    f,
-                    "🏊 {} partially drowns, loses health and sanity",
-                    tribute
-                )
-            }
             GameOutput::TributeMauled(tribute, count, animal, damage) => {
                 let animal = Animal::from_str(animal).unwrap();
                 write!(
@@ -247,6 +244,17 @@ impl<'a> Display for GameOutput<'a> {
             GameOutput::TributeBurned(tribute) => {
                 write!(f, "🔥 {} gets burned, loses health", tribute)
             }
+            GameOutput::TributeDiedWhileTrapped {
+                tribute_name,
+                kind,
+            } => match kind {
+                TrapKind::Drowning => {
+                    write!(f, "💧 {} drowned.", tribute_name)
+                }
+                TrapKind::Buried => {
+                    write!(f, "🪦 {} suffocated, buried alive.", tribute_name)
+                }
+            },
             GameOutput::TributeHorrified(tribute, damage) => {
                 write!(
                     f,

--- a/game/src/output.rs
+++ b/game/src/output.rs
@@ -244,10 +244,7 @@ impl<'a> Display for GameOutput<'a> {
             GameOutput::TributeBurned(tribute) => {
                 write!(f, "🔥 {} gets burned, loses health", tribute)
             }
-            GameOutput::TributeDiedWhileTrapped {
-                tribute_name,
-                kind,
-            } => match kind {
+            GameOutput::TributeDiedWhileTrapped { tribute_name, kind } => match kind {
                 TrapKind::Drowning => {
                     write!(f, "💧 {} drowned.", tribute_name)
                 }

--- a/game/src/tributes/afflictions/effects/brain_bias.rs
+++ b/game/src/tributes/afflictions/effects/brain_bias.rs
@@ -78,8 +78,6 @@ fn base_bias(kind: AfflictionKind) -> (f64, f64, f64, f64, f64) {
         | AfflictionKind::Burned
         | AfflictionKind::Sick
         | AfflictionKind::Electrocuted
-        | AfflictionKind::Drowned
-        | AfflictionKind::Buried
         | AfflictionKind::Phobia(_)
         | AfflictionKind::Addiction(_)
         | AfflictionKind::Trapped(_) => (1.0, 1.0, 1.0, 1.0, 1.0),

--- a/game/src/tributes/afflictions/effects/stat_modifiers.rs
+++ b/game/src/tributes/afflictions/effects/stat_modifiers.rs
@@ -64,8 +64,6 @@ fn base_penalties(kind: AfflictionKind) -> (i32, i32, i32, i32, i32, f64, i32, i
         | AfflictionKind::Burned
         | AfflictionKind::Sick
         | AfflictionKind::Electrocuted
-        | AfflictionKind::Drowned
-        | AfflictionKind::Buried
         | AfflictionKind::Phobia(_)
         | AfflictionKind::Fixation(_)
         | AfflictionKind::Addiction(_)

--- a/game/src/tributes/combat/inflict_table.rs
+++ b/game/src/tributes/combat/inflict_table.rs
@@ -132,8 +132,6 @@ fn select_body_part(kind: AfflictionKind, rng: &mut impl Rng) -> Option<BodyPart
         | AfflictionKind::Burned
         | AfflictionKind::Sick
         | AfflictionKind::Electrocuted
-        | AfflictionKind::Drowned
-        | AfflictionKind::Buried
         | AfflictionKind::Trauma
         | AfflictionKind::Phobia(_)
         | AfflictionKind::Fixation(_)

--- a/game/src/tributes/lifecycle/status.rs
+++ b/game/src/tributes/lifecycle/status.rs
@@ -252,9 +252,7 @@ impl Tribute {
                         meta.cycles_trapped += 1;
                     }
                 }
-                AfflictionKind::Drowned
-                | AfflictionKind::Buried
-                | AfflictionKind::MissingArm
+                AfflictionKind::MissingArm
                 | AfflictionKind::MissingLeg
                 | AfflictionKind::Blind
                 | AfflictionKind::Deaf

--- a/shared/src/afflictions/kind.rs
+++ b/shared/src/afflictions/kind.rs
@@ -162,8 +162,6 @@ pub enum AfflictionKind {
     Burned,
     Sick,
     Electrocuted,
-    Drowned,
-    Buried,
     Trapped(TrapKind),
     Trauma,
     Phobia(PhobiaTrigger),
@@ -189,8 +187,6 @@ impl fmt::Display for AfflictionKind {
             AfflictionKind::Burned => write!(f, "burned"),
             AfflictionKind::Sick => write!(f, "sick"),
             AfflictionKind::Electrocuted => write!(f, "electrocuted"),
-            AfflictionKind::Drowned => write!(f, "drowned"),
-            AfflictionKind::Buried => write!(f, "buried"),
             AfflictionKind::Trapped(kind) => write!(f, "trapped:{kind}"),
             AfflictionKind::Trauma => write!(f, "trauma"),
             AfflictionKind::Phobia(trigger) => write!(f, "phobia:{trigger}"),
@@ -220,8 +216,8 @@ impl FromStr for AfflictionKind {
             "burned" => Ok(AfflictionKind::Burned),
             "sick" => Ok(AfflictionKind::Sick),
             "electrocuted" => Ok(AfflictionKind::Electrocuted),
-            "drowned" => Ok(AfflictionKind::Drowned),
-            "buried" => Ok(AfflictionKind::Buried),
+            "drowned" => Ok(AfflictionKind::Trapped(TrapKind::Drowning)),
+            "buried" => Ok(AfflictionKind::Trapped(TrapKind::Buried)),
             "trauma" => Ok(AfflictionKind::Trauma),
             rest if rest.starts_with("phobia:") => {
                 let trigger_str = rest.strip_prefix("phobia:").unwrap();


### PR DESCRIPTION
## Summary
Cleanup remaining PR1 trapped afflictions work that wasn't included in the initial merge (PR #333).

## Changes
- Remove `GameEvent::TributeDrowned` / `GameOutput::TributeDrowned` from events and output system
- Add `GameOutput::TributeDiedWhileTrapped` variant with drowning/suffocation text
- Remove legacy `AfflictionKind::Drowned` and `AfflictionKind::Buried` standalone variants (superseded by `Trapped(TrapKind::Drowning)` / `Trapped(TrapKind::Buried)`)
- FromStr backward compat: `drowned` and `buried` still parse, mapping to Trapped variants
- Clean up 4 match arms across game crate

## Verification
- `cargo test --package game`: 1283 passed, 0 failed
- `cargo test --package shared`: 92 passed, 0 failed
- `cargo clippy --workspace --tests -- -D warnings`: clean
- `cargo fmt --all`: clean

## Follow-ups
- Trapped PR2 (yg8h): brain layer, rescue action, combat gates