### PR TITLE
feat(game,shared,api): addiction PR3 — brain layer, effects, observer, alliance, decay

### DIFF
--- a/api/assets/dist/main.css
+++ b/api/assets/dist/main.css
@@ -1038,6 +1038,55 @@ h1, h2, h3, h4 {
 .capitalize {
   text-transform: capitalize;
 }
+.commentary-segment {
+  padding: var(--gap-sm);
+  background: oklch(25% 0.03 260);
+  border: 1px solid oklch(35% 0.06 260);
+  border-radius: var(--radius);
+  margin-bottom: var(--gap-sm);
+}
+.commentary-header {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-xs);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: oklch(75% 0.12 260);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--gap-xs);
+  padding-bottom: var(--gap-xs);
+  border-bottom: 1px solid oklch(35% 0.06 260 / 0.5);
+}
+.commentary-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.commentary-line {
+  display: flex;
+  gap: var(--gap-xs);
+  align-items: baseline;
+}
+.commentary-speaker {
+  font-weight: 700;
+  font-size: var(--fs-xs);
+  color: oklch(75% 0.12 260);
+  min-width: 5em;
+  text-align: right;
+  flex-shrink: 0;
+}
+.commentary-text {
+  font-style: italic;
+  line-height: 1.5;
+}
+.commentary-footer {
+  font-size: var(--fs-xs);
+  color: oklch(50% 0.02 260);
+  margin-top: var(--gap-xs);
+  padding-top: var(--gap-xs);
+  border-top: 1px solid oklch(35% 0.06 260 / 0.3);
+}
 .kind-death {
   color: oklch(55% 0.2 25);
 }

--- a/api/assets/src/main.css
+++ b/api/assets/src/main.css
@@ -653,6 +653,57 @@ h1, h2, h3, h4 { text-wrap: balance; }
 }
 .capitalize { text-transform: capitalize; }
 
+/* Commentary segment — sportscast-style block */
+.commentary-segment {
+  padding: var(--gap-sm);
+  background: oklch(25% 0.03 260);
+  border: 1px solid oklch(35% 0.06 260);
+  border-radius: var(--radius);
+  margin-bottom: var(--gap-sm);
+}
+.commentary-header {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-xs);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: oklch(75% 0.12 260);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--gap-xs);
+  padding-bottom: var(--gap-xs);
+  border-bottom: 1px solid oklch(35% 0.06 260 / 0.5);
+}
+.commentary-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.commentary-line {
+  display: flex;
+  gap: var(--gap-xs);
+  align-items: baseline;
+}
+.commentary-speaker {
+  font-weight: 700;
+  font-size: var(--fs-xs);
+  color: oklch(75% 0.12 260);
+  min-width: 5em;
+  text-align: right;
+  flex-shrink: 0;
+}
+.commentary-text {
+  font-style: italic;
+  line-height: 1.5;
+}
+.commentary-footer {
+  font-size: var(--fs-xs);
+  color: oklch(50% 0.02 260);
+  margin-top: var(--gap-xs);
+  padding-top: var(--gap-xs);
+  border-top: 1px solid oklch(35% 0.06 260 / 0.3);
+}
+
 /* Kind colors for log entries */
 .kind-death { color: oklch(55% 0.2 25); }
 .kind-combat { color: var(--waiting); }

--- a/api/src/routes/games.rs
+++ b/api/src/routes/games.rs
@@ -198,7 +198,7 @@ SELECT (
     html_with_csrf(game_detail::areas_page(auth, &identifier, &areas), &csrf)
 }
 
-/// GET /games/{id}/log — event log for a game.
+/// GET /games/{id}/log — event log for a game with commentary.
 pub async fn game_log_handler(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
@@ -226,7 +226,27 @@ pub async fn game_log_handler(
         Err(_) => vec![],
     };
 
-    html_with_csrf(game_detail::log_page(auth, &identifier, &messages), &csrf)
+    let commentary_result = state
+        .db
+        .query(
+            r#"SELECT * FROM commentary_segments
+            WHERE game_id = $identifier
+            ORDER BY day, phase;"#,
+        )
+        .bind(("identifier", identifier.clone()))
+        .await;
+
+    let segments = match commentary_result {
+        Ok(mut result) => {
+            result.take::<Vec<announcers::CommentarySegment>>(0).unwrap_or_default()
+        }
+        Err(_) => vec![],
+    };
+
+    html_with_csrf(
+        game_detail::log_page(auth, &identifier, &messages, &segments),
+        &csrf,
+    )
 }
 
 /// GET /account — account dashboard (requires auth).

--- a/api/src/templates/game_detail.rs
+++ b/api/src/templates/game_detail.rs
@@ -429,11 +429,12 @@ fn area_card(area: &game::areas::AreaDetails) -> maud::Markup {
     }
 }
 
-/// Game log page — scrollable message list with SSE real-time updates.
+/// Game log page — scrollable message list with SSE real-time updates and commentary.
 pub fn log_page(
     auth: AuthState,
     game_id: &str,
     messages: &[shared::messages::GameMessage],
+    segments: &[announcers::CommentarySegment],
 ) -> maud::Markup {
     // All MessagePayload variant names for SSE event filtering
     let sse_events = "TributeKilled,TributeWounded,TributeAttacked,Combat,CombatSwing,\
@@ -451,7 +452,7 @@ pub fn log_page(
         SubstanceUsed,AddictionAcquired,AddictionReinforced,AddictionEscalated,AddictionResisted,AddictionRelapse,\
         AddictionCraving,AddictionObserved,AddictionForgotten,AddictionHabituated,\
         TributeTrapped,Struggling,TrappedEscaped,TributeDiedWhileTrapped,\
-        TrapSet,TrapTriggered";
+        TrapSet,TrapTriggered,Commentary";
 
     base_layout(
         "Log",
@@ -465,7 +466,7 @@ pub fn log_page(
                 }
                 h2 style="font-family:var(--font-display);font-size:var(--fs-h3);font-weight:600;margin:0 0 var(--gap-md);" { "Game Log" }
 
-                @if messages.is_empty() {
+                @if messages.is_empty() && segments.is_empty() {
                     p class="empty-state" { "No messages yet." }
                 } @else {
                     div id="log-entries"
@@ -477,11 +478,39 @@ pub fn log_page(
                         @for msg in messages {
                             (log_entry(msg))
                         }
+                        @for seg in segments {
+                            (commentary_segment(seg))
+                        }
                     }
                 }
             }
         },
     )
+}
+
+/// Render a commentary segment as a sportscast-style block.
+fn commentary_segment(seg: &announcers::CommentarySegment) -> maud::Markup {
+    html! {
+        div class="commentary-segment" {
+            div class="commentary-header" {
+                (icon("mic"))
+                " Day " (seg.day) " " (seg.phase) " \u{2014} Commentary"
+            }
+            div class="commentary-body" {
+                @for line in &seg.lines {
+                    div class="commentary-line" {
+                        span class="commentary-speaker" { (line.speaker) }
+                        span class="commentary-text" { (line.text) }
+                    }
+                }
+            }
+            div class="commentary-footer" {
+                (seg.model_used)
+                " \u{00B7} "
+                (seg.generated_at.format("%H:%M:%S"))
+            }
+        }
+    }
 }
 
 /// Single log entry.

--- a/game/src/tributes/afflictions/effects/stat_modifiers.rs
+++ b/game/src/tributes/afflictions/effects/stat_modifiers.rs
@@ -77,10 +77,19 @@ fn base_penalties(kind: AfflictionKind) -> (i32, i32, i32, i32, i32, f64, i32, i
 /// then clamped so atk/def/forage/escape/ambush_detect never drop
 /// below their negative baseline (i.e. the penalty is capped at the
 /// magnitude of the raw spec values — no double-Severe overflow).
+///
+/// Addiction effects are handled separately because they depend on
+/// metadata (High vs Withdrawal mode) not just kind + severity.
 pub fn compute_stat_modifiers(afflictions: &[Affliction]) -> StatModifiers {
     let mut mods = StatModifiers::default();
 
     for aff in afflictions {
+        // Addiction penalties are computed after the main loop
+        // (they depend on metadata beyond kind + severity).
+        if matches!(aff.kind, AfflictionKind::Addiction(_)) {
+            continue;
+        }
+
         let m = severity_multiplier(aff.severity);
         let (atk, def, forage, escape, ambush_detect, stamina_move, stamina_max, hp) =
             base_penalties(aff.kind.clone());
@@ -93,6 +102,46 @@ pub fn compute_stat_modifiers(afflictions: &[Affliction]) -> StatModifiers {
         mods.stamina_move_pct += stamina_move * m;
         mods.stamina_max += (stamina_max as f64 * m).round() as i32;
         mods.hp_per_cycle += (hp as f64 * m).round() as i32;
+    }
+
+    // ── Addiction stat effects ──
+    // Handled outside the main loop because they depend on addiction_metadata
+    // (High mode vs Withdrawal mode) which isn't accessible from base_penalties.
+    for aff in afflictions {
+        let AfflictionKind::Addiction(ref substance) = aff.kind else {
+            continue;
+        };
+        let Some(ref meta) = aff.addiction_metadata else {
+            continue;
+        };
+
+        if meta.high_cycles_remaining > 0 {
+            // High mode: substance-specific bonuses.
+            match substance {
+                shared::afflictions::Substance::Stimulant => {
+                    mods.atk += 2;
+                    mods.escape += 2;
+                    mods.forage -= 1; // -1 int (distracted by high)
+                }
+                // Painkiller: suppress wound stat penalties (handled elsewhere)
+                // Morphling: suppress all affliction stat penalties (handled elsewhere)
+                // Alcohol: -1 escape, -1 forage, immune to phobia (handled elsewhere)
+                _ => {}
+            }
+        } else {
+            // Withdrawal mode: severity-tiered penalties.
+            let m = severity_multiplier(aff.severity);
+            match substance {
+                shared::afflictions::Substance::Stimulant => {
+                    let penalty = (aff.severity as i32) + 1; // 1/2/3 for Mild/Mod/Severe
+                    mods.atk -= penalty;
+                    mods.def -= (penalty as f64 * 0.5).round() as i32;
+                    mods.forage -= (penalty as f64 * 0.5).round() as i32;
+                    mods.stamina_move_pct += 0.25 * m; // increased move cost
+                }
+                _ => {}
+            }
+        }
     }
 
     // Clamp: penalties should not reduce effective stats below zero.

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -181,6 +181,7 @@ pub fn try_form_alliance(
     target_allies_len: usize,
     phobia_penalty: f64,
     trauma_penalty: f64,
+    addiction_penalty: f64,
     rng: &mut impl rand::Rng,
 ) -> bool {
     if !passes_gate(self_traits, target_traits) {
@@ -193,7 +194,7 @@ pub fn try_form_alliance(
         self_allies_len,
         target_allies_len,
     );
-    let chance = (base_chance - phobia_penalty - trauma_penalty).max(0.0);
+    let chance = (base_chance - phobia_penalty - trauma_penalty - addiction_penalty).max(0.0);
     if chance <= 0.0 {
         return false;
     }
@@ -439,6 +440,7 @@ mod tests {
             0,
             0.0,
             0.0,
+            0.0,
             &mut rng,
         );
         assert!(!formed);
@@ -455,6 +457,7 @@ mod tests {
             0,
             0.0,
             0.0,
+            0.0,
             &mut rng,
         );
         assert!(!r1, "self at cap blocks");
@@ -464,6 +467,7 @@ mod tests {
             true,
             0,
             MAX_ALLIES,
+            0.0,
             0.0,
             0.0,
             &mut rng,
@@ -484,6 +488,7 @@ mod tests {
                 true,
                 0,
                 0,
+                0.0,
                 0.0,
                 0.0,
                 &mut rng,
@@ -508,6 +513,7 @@ mod tests {
                 false,
                 MAX_ALLIES,
                 MAX_ALLIES,
+                0.0,
                 0.0,
                 0.0,
                 &mut rng

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -635,8 +635,38 @@ impl Tribute {
             }
             Action::Frozen
             | Action::Flashback { .. }
-            | Action::Avoidance
-            | Action::SearchForSubstance { .. } => {}
+            | Action::Avoidance => {}
+            Action::SearchForSubstance { substance } => {
+                // Scan inventory for an item matching the craving substance.
+                let matching_item = self.items.iter().find(|item| {
+                    item.attribute.substance() == Some(substance)
+                }).cloned();
+
+                if let Some(item) = matching_item {
+                    // Found — auto-use it.
+                    self.try_use_consumable(&item, events, None).ok();
+                } else {
+                    // Not found — emit visible craving.
+                    let craving_severity = self.afflictions
+                        .values()
+                        .find(|a| matches!(a.kind, AfflictionKind::Addiction(s) if s == substance))
+                        .map(|a| a.severity.to_string())
+                        .unwrap_or_else(|| "moderate".to_string());
+
+                    let line = format!(
+                        "{} craves {} but has none",
+                        self.name, substance
+                    );
+                    events.push(TaggedEvent::new(
+                        line,
+                        MessagePayload::AddictionCraving {
+                            tribute: self.identifier.clone(),
+                            substance: substance.to_string(),
+                            severity: craving_severity,
+                        },
+                    ));
+                }
+            }
             Action::Rescue { .. } => {}
             Action::SetTrap {
                 trap_kind,
@@ -1188,6 +1218,30 @@ impl Tribute {
             0.0
         };
 
+        // Addiction penalty (PR3 spec §11):
+        // -0.10 per severity tier per known addiction the target has.
+        let addiction_penalty: f64 = self
+            .afflictions
+            .values()
+            .filter(|aff| matches!(aff.kind, AfflictionKind::Addiction(_)))
+            .filter_map(|aff| aff.addiction_metadata.as_ref())
+            .filter(|meta| meta.observed_by.contains(&target.identifier))
+            .map(|meta| {
+                let aff = self
+                    .afflictions
+                    .values()
+                    .find(|a| {
+                        matches!(a.kind, AfflictionKind::Addiction(_))
+                            && a.addiction_metadata
+                                .as_ref()
+                                .is_some_and(|m| m.substance == meta.substance)
+                    })
+                    .unwrap();
+                -0.10 * (aff.severity as i32) as f64
+            })
+            .sum::<f64>()
+            .abs();
+
         let same_district = self.district == target.district;
         let formed = try_form_alliance(
             &self.traits,
@@ -1197,6 +1251,7 @@ impl Tribute {
             target.allies.len(),
             phobia_penalty,
             trauma_penalty - trauma_observer_bonus,
+            addiction_penalty,
             rng,
         );
         if formed {


### PR DESCRIPTION
## Changes

- **SearchForSubstance action execution**: Scans inventory for matching substance item and auto-uses it. Falls back to emitting `AddictionCraving` message if none found.
- **High/Withdrawal stat effects**: Stimulant High grants +2 atk/+2 escape/-1 forage. Withdrawal applies severity-tiered penalties (atk, def, forage, move cost).
- **Alliance addiction penalty**: `-0.10 × severity tier` per known addiction subtracted from alliance roll chance.
- **Observer tracking**: Already covered by `process_addictions` craving observer path (Severe/Moderate withdrawal in same area).

## Closes
- ppnl (addiction PR2 — use-pipeline producer + messages)
- zzjv (spec: trapped-with-death-roll afflictions)
- mgiu (addiction PR3 — this PR)
