### PR TITLE
feat(game): addiction PR3 — brain layer, effects, observer, alliance, decay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "serial_test",
  "shared",
  "strum 0.28.0",
  "strum_macros 0.28.0",
@@ -5167,6 +5168,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -24,6 +24,7 @@ criterion = "0.8"
 insta = { version = "1.40", features = ["yaml"] }
 proptest = "1.5"
 rstest = "0.26"
+serial_test = "3"
 tokio = { version = "1.52.1", features = ["macros", "rt"] }
 
 [[bench]]

--- a/game/src/games/tests.rs
+++ b/game/src/games/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::tributes::Attributes;
+use serial_test::serial;
 
 fn create_test_game_with_tributes(tributes: Vec<Tribute>) -> Game {
     Game {
@@ -1385,6 +1386,7 @@ fn survival_tick_routes_dehydration_death_through_tribute_killed() {
 // ---- Sleep tick (PR2c.1, bd-9sjj) ----
 
 #[test]
+#[serial]
 fn sleeping_tribute_naturally_wakes_after_duration_emits_tribute_woke() {
     use crate::messages::{MessagePayload, Phase};
     let mut t = create_tribute("Sleeper", true);
@@ -1416,6 +1418,7 @@ fn sleeping_tribute_naturally_wakes_after_duration_emits_tribute_woke() {
 }
 
 #[test]
+#[serial]
 fn sleeping_tribute_regenerates_stamina_each_phase() {
     use crate::messages::Phase;
     let mut t = create_tribute("Sleeper", true);
@@ -1437,6 +1440,7 @@ fn sleeping_tribute_regenerates_stamina_each_phase() {
 }
 
 #[test]
+#[serial]
 fn sleeping_wounded_tribute_does_not_regen_hp() {
     use crate::messages::Phase;
     use shared::afflictions::{Affliction, AfflictionKind, AfflictionSource, Severity};
@@ -1475,6 +1479,7 @@ fn sleeping_wounded_tribute_does_not_regen_hp() {
 }
 
 #[test]
+#[serial]
 fn cycles_awake_does_not_increment_while_sleeping() {
     use crate::messages::Phase;
     let mut t = create_tribute("Sleeper", true);

--- a/game/src/tributes/afflictions/effects/stat_modifiers.rs
+++ b/game/src/tributes/afflictions/effects/stat_modifiers.rs
@@ -77,10 +77,19 @@ fn base_penalties(kind: AfflictionKind) -> (i32, i32, i32, i32, i32, f64, i32, i
 /// then clamped so atk/def/forage/escape/ambush_detect never drop
 /// below their negative baseline (i.e. the penalty is capped at the
 /// magnitude of the raw spec values — no double-Severe overflow).
+///
+/// Addiction effects are handled separately because they depend on
+/// metadata (High vs Withdrawal mode) not just kind + severity.
 pub fn compute_stat_modifiers(afflictions: &[Affliction]) -> StatModifiers {
     let mut mods = StatModifiers::default();
 
     for aff in afflictions {
+        // Addiction penalties are computed after the main loop
+        // (they depend on metadata beyond kind + severity).
+        if matches!(aff.kind, AfflictionKind::Addiction(_)) {
+            continue;
+        }
+
         let m = severity_multiplier(aff.severity);
         let (atk, def, forage, escape, ambush_detect, stamina_move, stamina_max, hp) =
             base_penalties(aff.kind.clone());
@@ -93,6 +102,40 @@ pub fn compute_stat_modifiers(afflictions: &[Affliction]) -> StatModifiers {
         mods.stamina_move_pct += stamina_move * m;
         mods.stamina_max += (stamina_max as f64 * m).round() as i32;
         mods.hp_per_cycle += (hp as f64 * m).round() as i32;
+    }
+
+    // ── Addiction stat effects ──
+    // Handled outside the main loop because they depend on addiction_metadata
+    // (High mode vs Withdrawal mode) which isn't accessible from base_penalties.
+    for aff in afflictions {
+        let AfflictionKind::Addiction(ref substance) = aff.kind else {
+            continue;
+        };
+        let Some(ref meta) = aff.addiction_metadata else {
+            continue;
+        };
+
+        if meta.high_cycles_remaining > 0 {
+            // High mode: substance-specific bonuses.
+            if *substance == shared::afflictions::Substance::Stimulant {
+                mods.atk += 2;
+                mods.escape += 2;
+                mods.forage -= 1; // -1 int (distracted by high)
+            }
+            // Painkiller: suppress wound stat penalties (handled elsewhere)
+            // Morphling: suppress all affliction stat penalties (handled elsewhere)
+            // Alcohol: -1 escape, -1 forage, immune to phobia (handled elsewhere)
+        } else {
+            // Withdrawal mode: severity-tiered penalties.
+            let m = severity_multiplier(aff.severity);
+            if *substance == shared::afflictions::Substance::Stimulant {
+                let penalty = (aff.severity as i32) + 1; // 1/2/3 for Mild/Mod/Severe
+                mods.atk -= penalty;
+                mods.def -= (penalty as f64 * 0.5).round() as i32;
+                mods.forage -= (penalty as f64 * 0.5).round() as i32;
+                mods.stamina_move_pct += 0.25 * m; // increased move cost
+            }
+        }
     }
 
     // Clamp: penalties should not reduce effective stats below zero.

--- a/game/src/tributes/alliances.rs
+++ b/game/src/tributes/alliances.rs
@@ -181,6 +181,7 @@ pub fn try_form_alliance(
     target_allies_len: usize,
     phobia_penalty: f64,
     trauma_penalty: f64,
+    addiction_penalty: f64,
     rng: &mut impl rand::Rng,
 ) -> bool {
     if !passes_gate(self_traits, target_traits) {
@@ -193,7 +194,7 @@ pub fn try_form_alliance(
         self_allies_len,
         target_allies_len,
     );
-    let chance = (base_chance - phobia_penalty - trauma_penalty).max(0.0);
+    let chance = (base_chance - phobia_penalty - trauma_penalty - addiction_penalty).max(0.0);
     if chance <= 0.0 {
         return false;
     }
@@ -439,6 +440,7 @@ mod tests {
             0,
             0.0,
             0.0,
+            0.0,
             &mut rng,
         );
         assert!(!formed);
@@ -455,6 +457,7 @@ mod tests {
             0,
             0.0,
             0.0,
+            0.0,
             &mut rng,
         );
         assert!(!r1, "self at cap blocks");
@@ -464,6 +467,7 @@ mod tests {
             true,
             0,
             MAX_ALLIES,
+            0.0,
             0.0,
             0.0,
             &mut rng,
@@ -484,6 +488,7 @@ mod tests {
                 true,
                 0,
                 0,
+                0.0,
                 0.0,
                 0.0,
                 &mut rng,
@@ -508,6 +513,7 @@ mod tests {
                 false,
                 MAX_ALLIES,
                 MAX_ALLIES,
+                0.0,
                 0.0,
                 0.0,
                 &mut rng

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -633,10 +633,38 @@ impl Tribute {
             Action::Sleep { duration_phases } => {
                 self.act_sleep(duration_phases, environment_details.phase, events);
             }
-            Action::Frozen
-            | Action::Flashback { .. }
-            | Action::Avoidance
-            | Action::SearchForSubstance { .. } => {}
+            Action::Frozen | Action::Flashback { .. } | Action::Avoidance => {}
+            Action::SearchForSubstance { substance } => {
+                // Scan inventory for an item matching the craving substance.
+                let matching_item = self
+                    .items
+                    .iter()
+                    .find(|item| item.attribute.substance() == Some(substance))
+                    .cloned();
+
+                if let Some(item) = matching_item {
+                    // Found — auto-use it.
+                    self.try_use_consumable(&item, events, None).ok();
+                } else {
+                    // Not found — emit visible craving.
+                    let craving_severity = self
+                        .afflictions
+                        .values()
+                        .find(|a| matches!(a.kind, AfflictionKind::Addiction(s) if s == substance))
+                        .map(|a| a.severity.to_string())
+                        .unwrap_or_else(|| "moderate".to_string());
+
+                    let line = format!("{} craves {} but has none", self.name, substance);
+                    events.push(TaggedEvent::new(
+                        line,
+                        MessagePayload::AddictionCraving {
+                            tribute: self.identifier.clone(),
+                            substance: substance.to_string(),
+                            severity: craving_severity,
+                        },
+                    ));
+                }
+            }
             Action::Rescue { .. } => {}
             Action::SetTrap {
                 trap_kind,
@@ -1188,6 +1216,30 @@ impl Tribute {
             0.0
         };
 
+        // Addiction penalty (PR3 spec §11):
+        // -0.10 per severity tier per known addiction the target has.
+        let addiction_penalty: f64 = self
+            .afflictions
+            .values()
+            .filter(|aff| matches!(aff.kind, AfflictionKind::Addiction(_)))
+            .filter_map(|aff| aff.addiction_metadata.as_ref())
+            .filter(|meta| meta.observed_by.contains(&target.identifier))
+            .map(|meta| {
+                let aff = self
+                    .afflictions
+                    .values()
+                    .find(|a| {
+                        matches!(a.kind, AfflictionKind::Addiction(_))
+                            && a.addiction_metadata
+                                .as_ref()
+                                .is_some_and(|m| m.substance == meta.substance)
+                    })
+                    .unwrap();
+                -0.10 * (aff.severity as i32) as f64
+            })
+            .sum::<f64>()
+            .abs();
+
         let same_district = self.district == target.district;
         let formed = try_form_alliance(
             &self.traits,
@@ -1197,6 +1249,7 @@ impl Tribute {
             target.allies.len(),
             phobia_penalty,
             trauma_penalty - trauma_observer_bonus,
+            addiction_penalty,
             rng,
         );
         if formed {

--- a/game/tests/ai_terrain_behavior_test.rs
+++ b/game/tests/ai_terrain_behavior_test.rs
@@ -5,6 +5,7 @@ use game::tributes::Tribute;
 use game::tributes::brains::Brain;
 use rand::prelude::*;
 use rstest::{fixture, rstest};
+use serial_test::serial;
 
 #[fixture]
 fn small_rng() -> SmallRng {
@@ -113,6 +114,7 @@ fn test_concealed_terrain_boosts_hiding(mut small_rng: SmallRng) {
 
 /// Test that resource-scarce terrain boosts search behavior
 #[rstest]
+#[serial]
 fn test_resource_scarce_terrain_boosts_search(mut small_rng: SmallRng) {
     let brain = Brain::default();
     let mut tribute = Tribute::new("Foxface".to_string(), Some(5), None);


### PR DESCRIPTION
## Changes

- **SearchForSubstance action execution**: Scans inventory for matching substance item and auto-uses it. Falls back to emitting `AddictionCraving` message if none found.
- **High/Withdrawal stat effects**: Stimulant High grants +2 atk/+2 escape/-1 forage. Withdrawal applies severity-tiered penalties (atk, def, forage, move cost).
- **Alliance addiction penalty**: `-0.10 × severity tier` per known addiction subtracted from alliance roll chance.
- **Observer tracking**: Already covered by `process_addictions` craving observer path (Severe/Moderate withdrawal in same area).

## Closes
- ppnl (addiction PR2 — use-pipeline producer + messages)
- zzjv (spec: trapped-with-death-roll afflictions)
- mgiu (addiction PR3 — this PR)
