### PR TITLE
feat(ui): display commentary segments inline in game Log page

### DIFF
--- a/api/assets/dist/main.css
+++ b/api/assets/dist/main.css
@@ -1038,6 +1038,55 @@ h1, h2, h3, h4 {
 .capitalize {
   text-transform: capitalize;
 }
+.commentary-segment {
+  padding: var(--gap-sm);
+  background: oklch(25% 0.03 260);
+  border: 1px solid oklch(35% 0.06 260);
+  border-radius: var(--radius);
+  margin-bottom: var(--gap-sm);
+}
+.commentary-header {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-xs);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: oklch(75% 0.12 260);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--gap-xs);
+  padding-bottom: var(--gap-xs);
+  border-bottom: 1px solid oklch(35% 0.06 260 / 0.5);
+}
+.commentary-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.commentary-line {
+  display: flex;
+  gap: var(--gap-xs);
+  align-items: baseline;
+}
+.commentary-speaker {
+  font-weight: 700;
+  font-size: var(--fs-xs);
+  color: oklch(75% 0.12 260);
+  min-width: 5em;
+  text-align: right;
+  flex-shrink: 0;
+}
+.commentary-text {
+  font-style: italic;
+  line-height: 1.5;
+}
+.commentary-footer {
+  font-size: var(--fs-xs);
+  color: oklch(50% 0.02 260);
+  margin-top: var(--gap-xs);
+  padding-top: var(--gap-xs);
+  border-top: 1px solid oklch(35% 0.06 260 / 0.3);
+}
 .kind-death {
   color: oklch(55% 0.2 25);
 }

--- a/api/assets/src/main.css
+++ b/api/assets/src/main.css
@@ -653,6 +653,57 @@ h1, h2, h3, h4 { text-wrap: balance; }
 }
 .capitalize { text-transform: capitalize; }
 
+/* Commentary segment — sportscast-style block */
+.commentary-segment {
+  padding: var(--gap-sm);
+  background: oklch(25% 0.03 260);
+  border: 1px solid oklch(35% 0.06 260);
+  border-radius: var(--radius);
+  margin-bottom: var(--gap-sm);
+}
+.commentary-header {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-xs);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: oklch(75% 0.12 260);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--gap-xs);
+  padding-bottom: var(--gap-xs);
+  border-bottom: 1px solid oklch(35% 0.06 260 / 0.5);
+}
+.commentary-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.commentary-line {
+  display: flex;
+  gap: var(--gap-xs);
+  align-items: baseline;
+}
+.commentary-speaker {
+  font-weight: 700;
+  font-size: var(--fs-xs);
+  color: oklch(75% 0.12 260);
+  min-width: 5em;
+  text-align: right;
+  flex-shrink: 0;
+}
+.commentary-text {
+  font-style: italic;
+  line-height: 1.5;
+}
+.commentary-footer {
+  font-size: var(--fs-xs);
+  color: oklch(50% 0.02 260);
+  margin-top: var(--gap-xs);
+  padding-top: var(--gap-xs);
+  border-top: 1px solid oklch(35% 0.06 260 / 0.3);
+}
+
 /* Kind colors for log entries */
 .kind-death { color: oklch(55% 0.2 25); }
 .kind-combat { color: var(--waiting); }

--- a/api/src/routes/games.rs
+++ b/api/src/routes/games.rs
@@ -198,7 +198,7 @@ SELECT (
     html_with_csrf(game_detail::areas_page(auth, &identifier, &areas), &csrf)
 }
 
-/// GET /games/{id}/log — event log for a game.
+/// GET /games/{id}/log — event log for a game with commentary.
 pub async fn game_log_handler(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
@@ -226,7 +226,27 @@ pub async fn game_log_handler(
         Err(_) => vec![],
     };
 
-    html_with_csrf(game_detail::log_page(auth, &identifier, &messages), &csrf)
+    let commentary_result = state
+        .db
+        .query(
+            r#"SELECT * FROM commentary_segments
+            WHERE game_id = $identifier
+            ORDER BY day, phase;"#,
+        )
+        .bind(("identifier", identifier.clone()))
+        .await;
+
+    let segments = match commentary_result {
+        Ok(mut result) => result
+            .take::<Vec<announcers::CommentarySegment>>(0)
+            .unwrap_or_default(),
+        Err(_) => vec![],
+    };
+
+    html_with_csrf(
+        game_detail::log_page(auth, &identifier, &messages, &segments),
+        &csrf,
+    )
 }
 
 /// GET /account — account dashboard (requires auth).

--- a/api/src/templates/game_detail.rs
+++ b/api/src/templates/game_detail.rs
@@ -429,11 +429,12 @@ fn area_card(area: &game::areas::AreaDetails) -> maud::Markup {
     }
 }
 
-/// Game log page — scrollable message list with SSE real-time updates.
+/// Game log page — scrollable message list with SSE real-time updates and commentary.
 pub fn log_page(
     auth: AuthState,
     game_id: &str,
     messages: &[shared::messages::GameMessage],
+    segments: &[announcers::CommentarySegment],
 ) -> maud::Markup {
     // All MessagePayload variant names for SSE event filtering
     let sse_events = "TributeKilled,TributeWounded,TributeAttacked,Combat,CombatSwing,\
@@ -451,7 +452,7 @@ pub fn log_page(
         SubstanceUsed,AddictionAcquired,AddictionReinforced,AddictionEscalated,AddictionResisted,AddictionRelapse,\
         AddictionCraving,AddictionObserved,AddictionForgotten,AddictionHabituated,\
         TributeTrapped,Struggling,TrappedEscaped,TributeDiedWhileTrapped,\
-        TrapSet,TrapTriggered";
+        TrapSet,TrapTriggered,Commentary";
 
     base_layout(
         "Log",
@@ -465,7 +466,7 @@ pub fn log_page(
                 }
                 h2 style="font-family:var(--font-display);font-size:var(--fs-h3);font-weight:600;margin:0 0 var(--gap-md);" { "Game Log" }
 
-                @if messages.is_empty() {
+                @if messages.is_empty() && segments.is_empty() {
                     p class="empty-state" { "No messages yet." }
                 } @else {
                     div id="log-entries"
@@ -477,11 +478,39 @@ pub fn log_page(
                         @for msg in messages {
                             (log_entry(msg))
                         }
+                        @for seg in segments {
+                            (commentary_segment(seg))
+                        }
                     }
                 }
             }
         },
     )
+}
+
+/// Render a commentary segment as a sportscast-style block.
+fn commentary_segment(seg: &announcers::CommentarySegment) -> maud::Markup {
+    html! {
+        div class="commentary-segment" {
+            div class="commentary-header" {
+                (icon("mic"))
+                " Day " (seg.day) " " (seg.phase) " \u{2014} Commentary"
+            }
+            div class="commentary-body" {
+                @for line in &seg.lines {
+                    div class="commentary-line" {
+                        span class="commentary-speaker" { (line.speaker) }
+                        span class="commentary-text" { (line.text) }
+                    }
+                }
+            }
+            div class="commentary-footer" {
+                (seg.model_used)
+                " \u{00B7} "
+                (seg.generated_at.format("%H:%M:%S"))
+            }
+        }
+    }
 }
 
 /// Single log entry.


### PR DESCRIPTION
## Changes

- Commentary segments rendered as sportscast-style blocks (Verity/Rex dialog) in the game Log page
- SSE trigger listens for \`Commentary\` events to auto-refresh when new commentary arrives
- Dark blue-tinted CSS styling to visually distinguish commentary from raw game events
- Backend: \`game_log_handler\` now fetches \`commentary_segments\` from SurrealDB alongside game messages

## Background

The announcers commentary pipeline was already fully wired (generates segments, persists to SurrealDB, pushes via SSE/WebSocket), but the segments were never displayed in the UI. This PR connects that output to the Log page.