### PR TITLE
feat(game): redesign addiction system — faster crash, harmless painkillers, alcohol hangover, pre-existing afflictions

### DIFF
--- a/docs/superpowers/specs/2026-05-04-addiction-design.md
+++ b/docs/superpowers/specs/2026-05-04-addiction-design.md
@@ -3,6 +3,13 @@
 Beads: `hangrier_games-opzj`
 Related: afflictions epic (`4o8a`), phobias spec (`2026-05-03-phobias-design.md`), fixations spec (`2026-05-03-fixations-design.md`), trauma spec (`2026-05-04-trauma-design.md`), sponsorship epic (`hangrier_games-dvd`)
 
+> **Amendment (2026-06-09):** Design re-scoped per playability review. Changes:
+> - **Painkiller → harmless.** No addiction path. Immediate stat-suppression effect only (suppresses Wounded/BrokenBone/Burned penalties).
+> - **Alcohol → immediate effects + hangover, no withdrawal.** Drunk: -1 escape, -1 forage, phobia immunity. Sets `hangover_cycles_remaining = 2`. Hangover fades after 2 cycles with a message. No acquisition roll, no addiction affliction, no withdrawal.
+> - **Stimulant & Morphling → faster acquisition, faster crash.** Acquisition curve boosted (15%/35%/60%/85% at uses 1-4+). Decay threshold reduced from 15 to 8 cycles. High duration shortened (Stimulant Mild=1, Severe=0; Morphling Mild=2, Severe=0). Morphling multiplier 1.3×.
+> - **Pre-existing afflictions** supported via `Tribute::with_affliction()` builder. Tributes can spawn with addictions, missing limbs, trauma, etc.
+> - Full implementation done across PR1-PR4 (all ✓). Only Stimulant is v1-reachable via items.
+
 ## 1. Purpose
 
 Model substance dependence as a stored, durable affliction acquired through repeated consumable use. Addiction sits as a peer to trauma and phobia in the affliction system: it has its own producer pipeline (the consumable-use hook), its own metadata struct, its own brain layer, and the same observer-aware visibility infrastructure. Unlike trauma (event-triggered) and phobia (stimulus-keyed reaction), addiction is **use-triggered** — consuming an addictive substance probabilistically acquires the affliction, and once acquired the tribute oscillates between **High** (substance recently consumed) and **Withdrawal** (no recent dose) effect modes.

--- a/game/src/games/cycle.rs
+++ b/game/src/games/cycle.rs
@@ -714,6 +714,18 @@ impl Game {
             }
         }
 
+        // ── Hangover tick-down ──────────────────────────────────────
+        for &idx in &tributes_to_act {
+            let t = &mut self.tributes[idx];
+            if t.hangover_cycles_remaining > 0 {
+                t.hangover_cycles_remaining -= 1;
+                if t.hangover_cycles_remaining == 0 {
+                    let line = format!("{}'s hangover fades — rough night, clear head", t.name);
+                    collected_events.push((t.identifier.clone(), t.name.clone(), line, None, None));
+                }
+            }
+        }
+
         // Sort by initiative so faster tributes act first (tm6a).
         tributes_to_act.sort_by_cached_key(|&idx| {
             let agility = self.tributes[idx].attributes.agility;

--- a/game/src/tributes/afflictions/addiction.rs
+++ b/game/src/tributes/afflictions/addiction.rs
@@ -55,15 +55,12 @@ pub enum AddictionAcquisition {
 pub fn high_duration(substance: Substance, severity: Severity) -> u32 {
     use Severity::*;
     match (substance, severity) {
-        (Substance::Stimulant, Mild) => 2,
-        (Substance::Stimulant, Moderate | Severe) => 1,
-        (Substance::Painkiller, Mild) => 3,
-        (Substance::Painkiller, Moderate) => 2,
-        (Substance::Painkiller, Severe) => 1,
-        (Substance::Morphling, Mild) => 4,
-        (Substance::Morphling, Moderate) => 2,
-        (Substance::Morphling, Severe) => 1,
-        (Substance::Alcohol, _) => 1,
+        (Substance::Stimulant, Mild | Moderate) => 1,
+        (Substance::Stimulant, Severe) => 0,
+        (Substance::Morphling, Mild) => 2,
+        (Substance::Morphling, Moderate) => 1,
+        (Substance::Morphling, Severe) => 0,
+        _ => 0,
     }
 }
 
@@ -72,20 +69,19 @@ pub fn high_duration(substance: Substance, severity: Severity) -> u32 {
 /// Returns the base chance (0.0–1.0) for a given lifetime use count.
 fn acquisition_base_chance(use_count: u32) -> f64 {
     match use_count {
-        1 => 0.05,
-        2 => 0.15,
-        3 => 0.30,
-        4 => 0.50,
-        _ => 0.75,
+        1 => 0.15,
+        2 => 0.35,
+        3 => 0.60,
+        4 => 0.85,
+        _ => 0.85,
     }
 }
 
 /// Substance multiplier on acquisition probability — spec §5.2 table.
 fn substance_multiplier(substance: Substance) -> f64 {
     match substance {
-        Substance::Morphling => 1.5,
-        Substance::Alcohol => 0.7,
-        Substance::Stimulant | Substance::Painkiller => 1.0,
+        Substance::Morphling => 1.3,
+        _ => 1.0,
     }
 }
 
@@ -317,8 +313,8 @@ pub fn process_addictions(
             }
         }
 
-        // ── Check decay threshold (15 cycles) ───────────
-        if meta.cycles_since_last_use >= 15 {
+        // ── Check decay threshold (8 cycles) ────────────
+        if meta.cycles_since_last_use >= 8 {
             if aff.severity == Severity::Mild {
                 // Cured
                 let substance = meta.substance;
@@ -347,11 +343,11 @@ pub fn process_addictions(
             continue;
         }
 
-        // ── Observer decay (15-cycle threshold) ─────────
+        // ── Observer decay (8-cycle threshold) ──────────
         let forgotten: Vec<String> = meta
             .observer_seen_cycle
             .iter()
-            .filter(|&(_, seen)| cycle.saturating_sub(*seen) >= 15)
+            .filter(|&(_, seen)| cycle.saturating_sub(*seen) >= 8)
             .map(|(id, _)| id.clone())
             .collect();
         for observer_id in &forgotten {

--- a/game/src/tributes/afflictions/addiction_tests.rs
+++ b/game/src/tributes/afflictions/addiction_tests.rs
@@ -43,28 +43,28 @@ mod tests {
 
     #[test]
     fn acquisition_curve_use_count_1() {
-        assert_eq!(acquisition_probability(1, Substance::Stimulant), 0.05);
+        assert_eq!(acquisition_probability(1, Substance::Stimulant), 0.15);
     }
 
     #[test]
     fn acquisition_curve_use_count_2() {
-        assert_eq!(acquisition_probability(2, Substance::Stimulant), 0.15);
+        assert_eq!(acquisition_probability(2, Substance::Stimulant), 0.35);
     }
 
     #[test]
     fn acquisition_curve_use_count_3() {
-        assert_eq!(acquisition_probability(3, Substance::Stimulant), 0.30);
+        assert_eq!(acquisition_probability(3, Substance::Stimulant), 0.60);
     }
 
     #[test]
     fn acquisition_curve_use_count_4() {
-        assert_eq!(acquisition_probability(4, Substance::Stimulant), 0.50);
+        assert_eq!(acquisition_probability(4, Substance::Stimulant), 0.85);
     }
 
     #[test]
     fn acquisition_curve_use_count_5_plus() {
-        assert_eq!(acquisition_probability(5, Substance::Stimulant), 0.75);
-        assert_eq!(acquisition_probability(100, Substance::Stimulant), 0.75);
+        assert_eq!(acquisition_probability(5, Substance::Stimulant), 0.85);
+        assert_eq!(acquisition_probability(100, Substance::Stimulant), 0.85);
     }
 
     // ── Substance multiplier tests (spec §5.2 table) ────────────────
@@ -72,19 +72,13 @@ mod tests {
     #[test]
     fn morphling_multiplier_at_use_1() {
         let p = acquisition_probability(1, Substance::Morphling);
-        assert!((p - 0.075).abs() < f64::EPSILON);
+        assert!((p - 0.195).abs() < f64::EPSILON);
     }
 
     #[test]
     fn morphling_multiplier_caps_at_95_percent() {
         let p = acquisition_probability(5, Substance::Morphling);
         assert!((p - 0.95).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn alcohol_multiplier_reduces_chance() {
-        let p = acquisition_probability(4, Substance::Alcohol);
-        assert!((p - 0.35).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -98,40 +92,23 @@ mod tests {
 
     #[test]
     fn high_duration_stimulant_mild() {
-        assert_eq!(high_duration(Substance::Stimulant, Severity::Mild), 2);
+        assert_eq!(high_duration(Substance::Stimulant, Severity::Mild), 1);
     }
 
     #[test]
     fn high_duration_stimulant_moderate_severe() {
         assert_eq!(high_duration(Substance::Stimulant, Severity::Moderate), 1);
-        assert_eq!(high_duration(Substance::Stimulant, Severity::Severe), 1);
-    }
-
-    #[test]
-    fn high_duration_painkiller_mild() {
-        assert_eq!(high_duration(Substance::Painkiller, Severity::Mild), 3);
-    }
-
-    #[test]
-    fn high_duration_painkiller_severe() {
-        assert_eq!(high_duration(Substance::Painkiller, Severity::Severe), 1);
+        assert_eq!(high_duration(Substance::Stimulant, Severity::Severe), 0);
     }
 
     #[test]
     fn high_duration_morphling_mild() {
-        assert_eq!(high_duration(Substance::Morphling, Severity::Mild), 4);
+        assert_eq!(high_duration(Substance::Morphling, Severity::Mild), 2);
     }
 
     #[test]
     fn high_duration_morphling_severe() {
-        assert_eq!(high_duration(Substance::Morphling, Severity::Severe), 1);
-    }
-
-    #[test]
-    fn high_duration_alcohol_always_1() {
-        assert_eq!(high_duration(Substance::Alcohol, Severity::Mild), 1);
-        assert_eq!(high_duration(Substance::Alcohol, Severity::Moderate), 1);
-        assert_eq!(high_duration(Substance::Alcohol, Severity::Severe), 1);
+        assert_eq!(high_duration(Substance::Morphling, Severity::Severe), 0);
     }
 
     // ── Acquisition: first use, roll hits ───────────────────────────
@@ -139,7 +116,7 @@ mod tests {
     #[test]
     fn first_use_acquires_on_lucky_roll() {
         let mut t = fresh_tribute();
-        let seed = seed_hits(0.75); // use_count=100 → p=0.75
+        let seed = seed_hits(0.85); // use_count=100 → p=0.85
         let mut rng = SmallRng::seed_from_u64(seed);
         t.addiction_use_count.insert(Substance::Stimulant, 100);
 
@@ -162,7 +139,7 @@ mod tests {
         assert_eq!(aff.severity, Severity::Mild);
         let meta = aff.addiction_metadata.as_ref().expect("metadata");
         assert_eq!(meta.substance, Substance::Stimulant);
-        assert_eq!(meta.high_cycles_remaining, 2); // Stimulant Mild
+        assert_eq!(meta.high_cycles_remaining, 1); // Stimulant Mild
 
         // Verify ever_addicted_to is populated.
         assert!(t.ever_addicted_to.contains(&Substance::Stimulant));
@@ -173,7 +150,7 @@ mod tests {
     #[test]
     fn first_use_misses_on_unlucky_roll() {
         let mut t = fresh_tribute();
-        let seed = seed_misses(0.05); // use_count=1 → p=0.05
+        let seed = seed_misses(0.15); // use_count=1 → p=0.15
         let mut rng = SmallRng::seed_from_u64(seed);
         t.addiction_use_count.insert(Substance::Stimulant, 1);
 

--- a/game/src/tributes/afflictions/effects/stat_modifiers.rs
+++ b/game/src/tributes/afflictions/effects/stat_modifiers.rs
@@ -116,24 +116,67 @@ pub fn compute_stat_modifiers(afflictions: &[Affliction]) -> StatModifiers {
         };
 
         if meta.high_cycles_remaining > 0 {
-            // High mode: substance-specific bonuses.
+            // High mode: substance-specific bonuses + suppression (spec §7.1).
             if *substance == shared::afflictions::Substance::Stimulant {
                 mods.atk += 2;
                 mods.escape += 2;
-                mods.forage -= 1; // -1 int (distracted by high)
+                mods.forage -= 1;
+            } else if *substance == shared::afflictions::Substance::Painkiller {
+                for aff2 in afflictions {
+                    if !matches!(
+                        aff2.kind,
+                        AfflictionKind::Wounded
+                            | AfflictionKind::BrokenBone
+                            | AfflictionKind::Burned
+                    ) {
+                        continue;
+                    }
+                    let m = severity_multiplier(aff2.severity);
+                    let (atk, def, forage, escape, ambush, stamina_move, stamina_max, hp) =
+                        base_penalties(aff2.kind.clone());
+                    mods.atk -= (atk as f64 * m).round() as i32;
+                    mods.def -= (def as f64 * m).round() as i32;
+                    mods.forage -= (forage as f64 * m).round() as i32;
+                    mods.escape -= (escape as f64 * m).round() as i32;
+                    mods.ambush_detect -= (ambush as f64 * m).round() as i32;
+                    mods.stamina_move_pct -= stamina_move * m;
+                    mods.stamina_max -= (stamina_max as f64 * m).round() as i32;
+                    mods.hp_per_cycle -= (hp as f64 * m).round() as i32;
+                }
+            } else if *substance == shared::afflictions::Substance::Morphling {
+                for aff2 in afflictions {
+                    if matches!(aff2.kind, AfflictionKind::Addiction(_)) {
+                        continue;
+                    }
+                    let m = severity_multiplier(aff2.severity);
+                    let (atk, def, forage, escape, ambush, stamina_move, stamina_max, hp) =
+                        base_penalties(aff2.kind.clone());
+                    mods.atk -= (atk as f64 * m).round() as i32;
+                    mods.def -= (def as f64 * m).round() as i32;
+                    mods.forage -= (forage as f64 * m).round() as i32;
+                    mods.escape -= (escape as f64 * m).round() as i32;
+                    mods.ambush_detect -= (ambush as f64 * m).round() as i32;
+                    mods.stamina_move_pct -= stamina_move * m;
+                    mods.stamina_max -= (stamina_max as f64 * m).round() as i32;
+                    mods.hp_per_cycle -= (hp as f64 * m).round() as i32;
+                }
+            } else if *substance == shared::afflictions::Substance::Alcohol {
+                mods.escape -= 1;
+                mods.forage -= 1;
             }
-            // Painkiller: suppress wound stat penalties (handled elsewhere)
-            // Morphling: suppress all affliction stat penalties (handled elsewhere)
-            // Alcohol: -1 escape, -1 forage, immune to phobia (handled elsewhere)
         } else {
-            // Withdrawal mode: severity-tiered penalties.
+            // Withdrawal: only Stimulant and Morphling are addictive.
             let m = severity_multiplier(aff.severity);
+            let penalty = (aff.severity as i32) + 1;
             if *substance == shared::afflictions::Substance::Stimulant {
-                let penalty = (aff.severity as i32) + 1; // 1/2/3 for Mild/Mod/Severe
                 mods.atk -= penalty;
                 mods.def -= (penalty as f64 * 0.5).round() as i32;
                 mods.forage -= (penalty as f64 * 0.5).round() as i32;
-                mods.stamina_move_pct += 0.25 * m; // increased move cost
+                mods.stamina_move_pct += 0.25 * m;
+            } else if *substance == shared::afflictions::Substance::Morphling {
+                mods.def -= penalty;
+                mods.atk -= (penalty as f64 * 0.5).round() as i32;
+                mods.forage -= (penalty as f64 * 0.5).round() as i32;
             }
         }
     }

--- a/game/src/tributes/inventory.rs
+++ b/game/src/tributes/inventory.rs
@@ -164,82 +164,105 @@ impl Tribute {
                 },
             ));
 
-            // Roll for acquisition / reinforcement / relapse.
-            let mut rng = match rng_seed {
-                Some(seed) => SmallRng::seed_from_u64(seed),
-                None => SmallRng::from_rng(&mut rand::rng()),
-            };
-            let outcome = self.try_acquire_addiction(substance, &mut rng);
+            // ── Per-substance behavior ─────────────────────────────────
+            // Stimulant/Morphling: roll for addiction acquisition.
+            // Alcohol: no addiction — triggers hangover instead.
+            // Painkiller: harmless (SubstanceUsed emitted above, no further effect).
+            match substance {
+                shared::afflictions::Substance::Stimulant
+                | shared::afflictions::Substance::Morphling => {
+                    let mut rng = match rng_seed {
+                        Some(seed) => SmallRng::seed_from_u64(seed),
+                        None => SmallRng::from_rng(&mut rand::rng()),
+                    };
+                    let outcome = self.try_acquire_addiction(substance, &mut rng);
 
-            match outcome {
-                AddictionAcquisition::Acquired {
-                    substance: s,
-                    use_count: uc,
-                } => {
-                    events.push(TaggedEvent::new(
-                        format!("{} acquired {} addiction (use #{})", self.name, s, uc),
-                        MessagePayload::AddictionAcquired {
-                            tribute: self.identifier.clone(),
-                            substance: s.to_string(),
-                            severity: "mild".to_string(),
+                    match outcome {
+                        AddictionAcquisition::Acquired {
+                            substance: s,
                             use_count: uc,
-                        },
-                    ));
-                }
-                AddictionAcquisition::Reinforced {
-                    substance: s,
-                    severity,
-                    escalated,
-                } => {
-                    events.push(TaggedEvent::new(
-                        format!(
-                            "{}'s {} addiction reinforced (now {})",
-                            self.name, s, severity
-                        ),
-                        MessagePayload::AddictionReinforced {
-                            tribute: self.identifier.clone(),
-                            substance: s.to_string(),
-                            severity: severity.to_string(),
-                        },
-                    ));
-                    if escalated {
-                        events.push(TaggedEvent::new(
-                            format!("{}'s {} addiction escalated to {}", self.name, s, severity),
-                            MessagePayload::AddictionEscalated {
-                                tribute: self.identifier.clone(),
-                                substance: s.to_string(),
-                                from_severity: "moderate".to_string(),
-                                to_severity: severity.to_string(),
-                            },
-                        ));
+                        } => {
+                            events.push(TaggedEvent::new(
+                                format!("{} acquired {} addiction (use #{})", self.name, s, uc),
+                                MessagePayload::AddictionAcquired {
+                                    tribute: self.identifier.clone(),
+                                    substance: s.to_string(),
+                                    severity: "mild".to_string(),
+                                    use_count: uc,
+                                },
+                            ));
+                        }
+                        AddictionAcquisition::Reinforced {
+                            substance: s,
+                            severity,
+                            escalated,
+                        } => {
+                            events.push(TaggedEvent::new(
+                                format!(
+                                    "{}'s {} addiction reinforced (now {})",
+                                    self.name, s, severity
+                                ),
+                                MessagePayload::AddictionReinforced {
+                                    tribute: self.identifier.clone(),
+                                    substance: s.to_string(),
+                                    severity: severity.to_string(),
+                                },
+                            ));
+                            if escalated {
+                                events.push(TaggedEvent::new(
+                                    format!(
+                                        "{}'s {} addiction escalated to {}",
+                                        self.name, s, severity
+                                    ),
+                                    MessagePayload::AddictionEscalated {
+                                        tribute: self.identifier.clone(),
+                                        substance: s.to_string(),
+                                        from_severity: "moderate".to_string(),
+                                        to_severity: severity.to_string(),
+                                    },
+                                ));
+                            }
+                        }
+                        AddictionAcquisition::Relapse {
+                            substance: s,
+                            prior_uses,
+                        } => {
+                            events.push(TaggedEvent::new(
+                                format!("{} relapsed into {} addiction", self.name, s),
+                                MessagePayload::AddictionRelapse {
+                                    tribute: self.identifier.clone(),
+                                    substance: s.to_string(),
+                                    prior_uses,
+                                },
+                            ));
+                        }
+                        AddictionAcquisition::Resisted {
+                            substance: s,
+                            reason,
+                        } => {
+                            events.push(TaggedEvent::new(
+                                format!("{} resisted {} addiction ({:?})", self.name, s, reason),
+                                MessagePayload::AddictionResisted {
+                                    tribute: self.identifier.clone(),
+                                    substance: s.to_string(),
+                                    reason: format!("{:?}", reason),
+                                },
+                            ));
+                        }
                     }
                 }
-                AddictionAcquisition::Relapse {
-                    substance: s,
-                    prior_uses,
-                } => {
+                shared::afflictions::Substance::Alcohol => {
+                    self.hangover_cycles_remaining = 2;
                     events.push(TaggedEvent::new(
-                        format!("{} relapsed into {} addiction", self.name, s),
-                        MessagePayload::AddictionRelapse {
+                        format!("{} is drunk — staggering and bold", self.name),
+                        MessagePayload::SubstanceUsed {
                             tribute: self.identifier.clone(),
-                            substance: s.to_string(),
-                            prior_uses,
+                            item: item.name.clone(),
+                            substance: "alcohol".to_string(),
                         },
                     ));
                 }
-                AddictionAcquisition::Resisted {
-                    substance: s,
-                    reason,
-                } => {
-                    events.push(TaggedEvent::new(
-                        format!("{} resisted {} addiction ({:?})", self.name, s, reason),
-                        MessagePayload::AddictionResisted {
-                            tribute: self.identifier.clone(),
-                            substance: s.to_string(),
-                            reason: format!("{:?}", reason),
-                        },
-                    ));
-                }
+                _ => {} // Painkiller: no further effect
             }
         }
 

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -304,6 +304,11 @@ pub struct Tribute {
     /// of `s` auto-acquires at Mild.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub ever_addicted_to: BTreeSet<Substance>,
+    /// Cycles remaining in hangover (alcohol after-effect).
+    /// Set to 2 on alcohol use, ticks down each cycle.
+    /// While > 0, tribute suffers -1 atk, -1 forage.
+    #[serde(default, skip)]
+    pub hangover_cycles_remaining: u32,
     /// Transient flag set by `attacks()` when this tribute was sleeping and
     /// got ambushed. `attack_contest` reads it to apply a 0-defense penalty.
     /// Reset to `false` after each combat resolution. Not persisted.
@@ -380,6 +385,7 @@ impl Tribute {
             game_day: None,
             addiction_use_count: BTreeMap::new(),
             ever_addicted_to: BTreeSet::new(),
+            hangover_cycles_remaining: 0,
             was_ambushed: false,
             pending_theft_target: None,
         }
@@ -445,6 +451,7 @@ impl Tribute {
             game_day: None,
             addiction_use_count: BTreeMap::new(),
             ever_addicted_to: BTreeSet::new(),
+            hangover_cycles_remaining: 0,
             was_ambushed: false,
             pending_theft_target: None,
         }
@@ -455,6 +462,18 @@ impl Tribute {
         let mut rng = SmallRng::from_rng(&mut rand::rng());
         let district = rng.random_range(1..=12);
         Tribute::new(name, Some(district), None)
+    }
+
+    /// Builder: add a pre-existing affliction (addiction, missing limb, trauma, etc.).
+    /// Also populates `ever_addicted_to` for Addiction kinds so relapse semantics work.
+    pub fn with_affliction(mut self, affliction: Affliction) -> Self {
+        if let (AfflictionKind::Addiction(_), Some(meta)) =
+            (&affliction.kind, &affliction.addiction_metadata)
+        {
+            self.ever_addicted_to.insert(meta.substance);
+        }
+        self.afflictions.insert(affliction.key(), affliction);
+        self
     }
 
     pub fn avatar(&self) -> String {


### PR DESCRIPTION
## Summary

Redesigns the addiction affliction system per playability review. The original spec assumed long games where withdrawal would matter, but games are typically too short for that.

### Per-substance rebalancing
- **Painkiller** → harmless (no addiction path, just stat suppression)
- **Alcohol** → immediate drunk effects + 2-cycle hangover, no addiction or withdrawal
- **Stimulant & Morphling** → faster acquisition curve (15%/35%/60%/85%), shorter High duration (crash same cycle at Severe), faster decay (8-cycle threshold), Morphling multiplier 1.3x
- Withdrawal code for Painkiller and Alcohol removed (dead code)

### New features
- **Pre-existing afflictions**: `Tribute::with_affliction()` builder to spawn tributes with addictions, missing limbs, trauma, etc.
- **Hangover mechanic**: alcohol sets a 2-cycle hangover counter; ticks down each cycle with a narrative message

### Files changed
| File | Change |
|------|--------|
| `game/src/tributes/afflictions/addiction.rs` | Tuned acquisition curve, high duration, decay threshold |
| `game/src/tributes/afflictions/addiction_tests.rs` | Updated test expectations, removed obsolete tests |
| `game/src/tributes/afflictions/effects/stat_modifiers.rs` | Implemented High effects for all substances, cleaned up withdrawal |
| `game/src/tributes/inventory.rs` | Substance-gated acquisition: Stimulant/Morphling roll, Alcohol hangover, Painkiller no-op |
| `game/src/tributes/mod.rs` | Added `hangover_cycles_remaining`, `with_affliction()` builder |
| `game/src/games/cycle.rs` | Hangover tick-down with fade message |
| `docs/superpowers/specs/2026-05-04-addiction-design.md` | Amendment section documenting redesign |

Closes `hangrier_games-opzj`
