### PR TITLE
fix(api): build minimal JSON body for quickstart game UPSERT; match SCHEMAFULL schema

### DIFF
--- a/api/src/routes/games.rs
+++ b/api/src/routes/games.rs
@@ -428,27 +428,16 @@ pub async fn create_game_post_handler(
     let game_name = form.name.filter(|n| !n.is_empty()).unwrap_or(game.name);
     let is_private = form.private.is_some_and(|v| v == "true");
 
-    let new_game = Game {
-        identifier: game_identifier.clone(),
-        name: game_name,
-        status: shared::GameStatus::NotStarted,
-        day: None,
-        tributes: vec![],
-        areas: vec![],
-        private: is_private,
-        config: Default::default(),
-        messages: vec![],
-        alliance_events: vec![],
-        ..Default::default()
-    };
-
     use surrealdb_types::RecordId;
 
     let game_rid = RecordId::new("game", game_identifier.as_str());
-    let body = match serde_json::to_value(&new_game) {
-        Ok(b) => b,
-        Err(_) => return Redirect::to("/games/new").into_response(),
-    };
+    let body = serde_json::json!({
+        "identifier": &game_identifier,
+        "name": &game_name,
+        "status": "NotStarted",
+        "day": null,
+        "private": is_private,
+    });
 
     if user_db
         .query("UPSERT $rid CONTENT $body")


### PR DESCRIPTION
## Summary

Quickstart button created games that immediately 404ed on redirect.

## Root Cause

`create_game_post_handler` serialized the full `Game` struct (10+ fields) into the SurrealDB UPSERT body. The `game` table is SCHEMAFULL — only 5 fields defined. Extra fields like `areas`, `tributes`, `config`, `combat_tuning`, `sponsors` were silently rejected, the game never persisted, and the redirect to `/games/{uuid}` got a 404.

## Fix

Replaced full struct serialization with hand-crafted `serde_json::json!({...})` body containing only the 5 schema-allowed fields — matching the pattern already used by the API handler in `games/handlers.rs`.

## Verification

- `cargo check --package api` passes clean
- No logic changes to game name fallback or tribute/area creation

## Follow-up

- The same bug likely affects the `POST /games/new` path from the "Create" form (same handler). Fixed together.