### PR TITLE
fix(api): persist game.day as i64 to avoid SDK dropping Option<u32>

### DIFF
--- a/api/src/games/persist.rs
+++ b/api/src/games/persist.rs
@@ -194,7 +194,7 @@ pub(crate) async fn save_game(
     if let Err(e) = db
         .query("UPDATE $record_id SET day = $day, status = $status")
         .bind(("record_id", game_identifier.clone()))
-        .bind(("day", game.day))
+        .bind(("day", game.day.unwrap_or(0) as i64))
         .bind(("status", game.status.to_string()))
         .await
     {


### PR DESCRIPTION
## Summary
`save_game` in `api/src/games/persist.rs` binds `game.day` (type `Option<u32>`) directly. SurrealDB SDK v3.1.2 bespoke serializer silently drops Option fields — documented in 6 comments across the codebase.

Every other bind site works around this with `serde_json::Value` or a scalar. Day was the one exception.

## Change
- `api/src/games/persist.rs:197`: convert `Option<u32>` to `i64` before binding

## Verification
- `cargo fmt --all` — PASS
- `cargo check --workspace` — PASS
- `cargo clippy --workspace --tests -- -D warnings` — PASS
- `cargo test --package game` — 1137 tests + 1 doctest, 0 failures

Closes hangrier_games-tek6