### PR TITLE
feat(ui): Phase 5 — alliance-grouped tribute roster

### DIFF
--- a/api/assets/src/main.css
+++ b/api/assets/src/main.css
@@ -1558,3 +1558,101 @@ body.broadcast {
 .roster-scroll::-webkit-scrollbar { width: 4px; }
 .roster-scroll::-webkit-scrollbar-track { background: transparent; }
 .roster-scroll::-webkit-scrollbar-thumb { background: var(--broad-border); }
+
+/* Alliance group */
+.alliance-group { display: flex; flex-direction: column; gap: 3px; }
+.alliance-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  border-left: 3px solid var(--broad-accent);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--broad-fg-muted);
+  font-family: var(--font-condensed);
+  font-weight: 600;
+}
+.alliance-name { color: var(--broad-fg); }
+.alliance-count { font-weight: 400; }
+
+/* Compact roster row */
+.roster-row {
+  display: grid;
+  grid-template-columns: 28px 1fr 60px 42px;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--broad-bg);
+  border: 1px solid transparent;
+  transition: border-color 0.1s;
+}
+.roster-row:hover {
+  border-color: var(--broad-border);
+}
+.roster-row.dead {
+  opacity: 0.45;
+}
+.roster-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid;
+  display: grid;
+  place-items: center;
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  font-family: var(--font-condensed);
+}
+.roster-info {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+.roster-name {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: var(--broad-fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.roster-district {
+  font-size: 10px;
+  color: var(--broad-fg-muted);
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+}
+.roster-health {
+  display: flex;
+  align-items: center;
+}
+.roster-health-bar {
+  width: 100%;
+  height: 4px;
+  background: var(--broad-border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.roster-health-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+.roster-health-fill.high { background: var(--running); }
+.roster-health-fill.mid { background: var(--waiting); }
+.roster-health-fill.low { background: var(--danger); }
+.roster-health-fill.empty { background: var(--broad-fg-muted); }
+.roster-status {
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  text-align: right;
+  font-family: var(--font-condensed);
+}
+.roster-status.alive { color: var(--running); }
+.roster-status.dead { color: oklch(48% 0.22 25); }

--- a/api/src/routes/games.rs
+++ b/api/src/routes/games.rs
@@ -249,10 +249,11 @@ pub async fn game_detail_handler(
         event_cards.push_str(&game_detail::render_commentary_card(seg));
     }
 
-    // Pre-render tribute rows
+    // Pre-render tribute rows — grouped by alliance
+    let alliance_groups = game_detail::build_alliance_groups(&sorted_tributes);
     let mut tribute_rows = String::new();
-    for tribute in &sorted_tributes {
-        tribute_rows.push_str(&game_detail::render_tribute_row(tribute));
+    for group in &alliance_groups {
+        tribute_rows.push_str(&game_detail::render_alliance_group(group, &sorted_tributes));
     }
 
     // SSE events string

--- a/api/src/templates/game_detail.rs
+++ b/api/src/templates/game_detail.rs
@@ -242,21 +242,21 @@ pub fn render_tribute_row(tribute: &game::tributes::Tribute) -> String {
     let dead_class = if !is_alive { " dead" } else { "" };
 
     format!(
-        r#"<div class="tribute-card{dead_class}">
-          <div class="tribute-avatar" style="border-color:{avatar_color};color:{avatar_color}">{initial}</div>
-          <div class="tribute-info">
-            <div class="tribute-name">{name}</div>
-            <div class="tribute-meta">
-              <div class="health-bar">
-                <div class="health-fill {health_class}" style="width:{health}%;"></div>
-              </div>
+        r#"<div class="roster-row{dead_class}">
+          <div class="roster-avatar" style="border-color:{avatar_color};color:{avatar_color}">{initial}</div>
+          <div class="roster-info">
+            <span class="roster-name">{name}</span>
+            <span class="roster-district">D{district}</span>
+          </div>
+          <div class="roster-health">
+            <div class="roster-health-bar">
+              <div class="roster-health-fill {health_class}" style="width:{health}%;"></div>
             </div>
           </div>
-          <div class="tribute-stats">
-            <span class="tribute-status {status_class}">{status_text}</span>
-          </div>
+          <span class="roster-status {status_class}">{status_text}</span>
         </div>"#,
-        name = html_escape(&tribute.name)
+        name = html_escape(&tribute.name),
+        district = tribute.district,
     )
 }
 
@@ -393,5 +393,124 @@ pub fn render_tribute_detail(tribute: &game::tributes::Tribute, _game_id: &str) 
         intelligence = tribute.attributes.intelligence,
         items = items_html,
         afflictions = afflictions_html,
+    )
+}
+
+const ALLIANCE_COLORS: &[&str] = &[
+    "var(--broad-accent)",
+    "var(--info)",
+    "var(--gold)",
+    "var(--purple)",
+    "var(--waiting)",
+    "var(--running)",
+    "var(--danger)",
+];
+
+pub struct AllianceGroup {
+    pub name: String,
+    pub color: &'static str,
+    pub tributes: Vec<usize>,
+}
+
+pub fn build_alliance_groups(tributes: &[&game::tributes::Tribute]) -> Vec<AllianceGroup> {
+    let n = tributes.len();
+    let mut parent: Vec<usize> = (0..n).collect();
+
+    fn find(parent: &mut [usize], x: usize) -> usize {
+        if parent[x] != x {
+            parent[x] = find(parent, parent[x]);
+        }
+        parent[x]
+    }
+
+    fn union(parent: &mut [usize], a: usize, b: usize) {
+        let ra = find(parent, a);
+        let rb = find(parent, b);
+        if ra != rb {
+            parent[ra] = rb;
+        }
+    }
+
+    let id_to_idx: std::collections::HashMap<String, usize> = tributes
+        .iter()
+        .enumerate()
+        .map(|(i, t)| (t.id.to_string(), i))
+        .collect();
+
+    for (i, tribute) in tributes.iter().enumerate() {
+        for ally_id in &tribute.allies {
+            if let Some(&j) = id_to_idx.get(&ally_id.to_string()) {
+                union(&mut parent, i, j);
+            }
+        }
+    }
+
+    let mut groups: std::collections::HashMap<usize, Vec<usize>> = std::collections::HashMap::new();
+    for i in 0..n {
+        let root = find(&mut parent, i);
+        groups.entry(root).or_default().push(i);
+    }
+
+    let mut alliance_groups: Vec<AllianceGroup> = groups
+        .into_iter()
+        .enumerate()
+        .map(|(color_idx, (_, indices))| {
+            let color = ALLIANCE_COLORS[color_idx % ALLIANCE_COLORS.len()];
+            let name = if indices.len() == 1 {
+                "SOLO".to_string()
+            } else {
+                format!("ALLIANCE {}", color_idx + 1)
+            };
+            AllianceGroup {
+                name,
+                color,
+                tributes: indices,
+            }
+        })
+        .collect();
+
+    alliance_groups.sort_by(|a, b| {
+        let a_alive = a
+            .tributes
+            .iter()
+            .filter(|&&i| tributes[i].is_alive())
+            .count();
+        let b_alive = b
+            .tributes
+            .iter()
+            .filter(|&&i| tributes[i].is_alive())
+            .count();
+        b_alive.cmp(&a_alive)
+    });
+
+    alliance_groups
+}
+
+pub fn render_alliance_group(
+    group: &AllianceGroup,
+    tributes: &[&game::tributes::Tribute],
+) -> String {
+    let alive_count = group
+        .tributes
+        .iter()
+        .filter(|&&i| tributes[i].is_alive())
+        .count();
+
+    let mut rows = String::new();
+    for &idx in &group.tributes {
+        rows.push_str(&render_tribute_row(tributes[idx]));
+    }
+
+    format!(
+        r#"<div class="alliance-group">
+          <div class="alliance-header" style="border-left-color:{color};">
+            <span class="alliance-name">{name}</span>
+            <span class="alliance-count">{alive_count}/{total} alive</span>
+          </div>
+          {rows}
+        </div>"#,
+        color = group.color,
+        name = group.name,
+        total = group.tributes.len(),
     )
 }

--- a/api/templates/game_detail.html
+++ b/api/templates/game_detail.html
@@ -136,7 +136,7 @@
         <div class="roster-section">
           <div class="section-header">
             <span class="title">TRIBUTE ROSTER</span>
-            <span class="count">{{ total }} TRIBUTES</span>
+            <span class="count">{{ alive }}/{{ total }} TRIBUTES</span>
           </div>
           <div class="roster-scroll">
             {% if tribute_rows | length == 0 %}


### PR DESCRIPTION
## Summary
Alliance-grouped tribute roster for the broadcast left panel.

## Changes
- **Alliance grouping**: Union-find on `Tribute.allies` to build connected components. Each group gets a colored left-border header with alive/total count.
- **Compact roster rows**: Avatar initial, name, district number, health bar (color-coded by %), status pill (ALIVE/DEAD). Grid layout: `28px | 1fr | 60px | 42px`.
- **Dead tributes**: 45% opacity, red avatar border, "DEAD" pill.
- **Solo tributes**: Labeled "SOLO" instead of "ALLIANCE N".
- **CSS**: `.alliance-group`, `.alliance-header`, `.roster-row`, `.roster-health-bar` components using broadcast theme variables.

## Files
- `api/src/templates/game_detail.rs` — `build_alliance_groups()`, `render_alliance_group()`, updated `render_tribute_row()`
- `api/src/routes/games.rs` — handler builds alliance groups
- `api/templates/game_detail.html` — roster header shows alive/total
- `api/assets/src/main.css` + `dist/main.css` — roster row + alliance group styles

## Verification
- `just quality` passes
- Alliance groups form correctly from pairwise ally connections
- Compact rows fit the broadcast 50/50 left panel