### PR TITLE
feat(ui): Phase 6 — hex arena map SVG

### DIFF
--- a/api/assets/src/main.css
+++ b/api/assets/src/main.css
@@ -1516,6 +1516,18 @@ body.broadcast {
   min-height: 120px;
 }
 .map-container:active { cursor: grabbing; }
+.hex-map {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.hex-map polygon {
+  transition: opacity 0.15s;
+}
+.hex-map polygon:hover {
+  opacity: 1 !important;
+  filter: brightness(1.15);
+}
 @media (max-width: 1100px) { .map-section { height: 260px; } }
 @media (max-width: 720px) { .map-section { height: 220px; } }
 

--- a/api/src/routes/games.rs
+++ b/api/src/routes/games.rs
@@ -183,6 +183,32 @@ pub async fn game_detail_handler(
         Err(_) => vec![],
     };
 
+    // Fetch areas with terrain + tribute slot assignments
+    let areas_result = state
+        .db
+        .query(
+            r#"
+SELECT (
+    SELECT *, ->items->item[*] AS items
+    FROM ->areas->area
+) AS areas FROM game WHERE identifier = $identifier;
+"#,
+        )
+        .bind(("identifier", identifier.clone()))
+        .await;
+
+    let areas: Vec<game::areas::AreaDetails> = match areas_result {
+        Ok(mut result) => {
+            let rows: Vec<Vec<SerdeWrapper<game::areas::AreaDetails>>> =
+                result.take("areas").unwrap_or_default();
+            rows.into_iter()
+                .next()
+                .map(|inner| inner.into_iter().map(|w| w.0).collect())
+                .unwrap_or_default()
+        }
+        Err(_) => vec![],
+    };
+
     let messages_result = state
         .db
         .query(
@@ -256,6 +282,9 @@ pub async fn game_detail_handler(
         tribute_rows.push_str(&game_detail::render_alliance_group(group, &sorted_tributes));
     }
 
+    // Build hex arena map SVG
+    let hex_map = game_detail::render_hex_map(&areas, &sorted_tributes);
+
     // SSE events string
     let sse_events = "death,wound,attack,combat,alliance_formed,alliance_proposed,alliance_dissolved,betrayal,trust_shock_break,sponsor_gift,movement,hidden,area_closed,area_event,item_found,item_used,item_dropped,rested,starved,dehydrated,sanity_break,hunger_band_changed,thirst_band_changed,stamina_band_changed,shelter_sought,foraged,drank,ate,cycle_start,cycle_end,phase_started,phase_ended,slept,woke,game_ended,wounded,attacked,affliction_acquired,affliction_progressed,affliction_healed,affliction_cascaded,trauma_acquired,trauma_reinforced,trauma_escalated,trauma_flashback,trauma_avoidance,trauma_observed,trauma_forgotten,trauma_habituated,phobia_acquired,phobia_triggered,phobia_escalated,phobia_habituated,phobia_observed,phobia_forgotten,fixation_acquired,fixation_escalated,fixation_fired,fixation_consummated,fixation_thwarted,fixation_faded,generic,trapped,struggling,trapped_escaped,died_while_trapped,trap_set,trap_triggered,rescue_attempted,sleep_incident,partial_rescue_progress";
 
@@ -270,6 +299,7 @@ pub async fn game_detail_handler(
     ctx.insert("current_day", &current_day);
     ctx.insert("sse_events", sse_events);
     ctx.insert("tribute_rows", &tribute_rows);
+    ctx.insert("hex_map", &hex_map);
     ctx.insert("event_cards", &event_cards);
     ctx.insert("messages", &messages);
     ctx.insert("segments", &segments);

--- a/api/src/templates/game_detail.rs
+++ b/api/src/templates/game_detail.rs
@@ -514,3 +514,134 @@ pub fn render_alliance_group(
         total = group.tributes.len(),
     )
 }
+
+fn terrain_color(terrain: &game::terrain::BaseTerrain) -> &'static str {
+    use game::terrain::BaseTerrain::*;
+    match terrain {
+        Forest => "#2d5a27",
+        Desert => "#c4a35a",
+        Tundra => "#8fa8b8",
+        Wetlands => "#3a7a6e",
+        Mountains => "#6b7280",
+        UrbanRuins => "#78716c",
+        Jungle => "#1a6b3c",
+        Grasslands => "#6b8e3a",
+        Badlands => "#8b6914",
+        Highlands => "#5b7553",
+        Geothermal => "#b45309",
+        Clearing => "#4a6741",
+    }
+}
+
+const HEX_SIZE: f64 = 52.0;
+const HEX_H: f64 = 104.0;
+const HEX_W: f64 = 90.0;
+const CENTER_X: f64 = 160.0;
+const CENTER_Y: f64 = 150.0;
+
+fn hex_corners(cx: f64, cy: f64) -> [(f64, f64); 6] {
+    let mut corners = [(0.0, 0.0); 6];
+    for (i, corner) in corners.iter_mut().enumerate() {
+        let angle = std::f64::consts::PI / 180.0 * (60.0 * i as f64 - 30.0);
+        *corner = (cx + HEX_SIZE * angle.cos(), cy + HEX_SIZE * angle.sin());
+    }
+    corners
+}
+
+fn hex_center(area_idx: usize) -> (f64, f64) {
+    match area_idx {
+        0 => (CENTER_X, CENTER_Y),
+        1 => (CENTER_X + HEX_W, CENTER_Y),
+        2 => (CENTER_X + HEX_W * 0.5, CENTER_Y - HEX_H * 0.75),
+        3 => (CENTER_X - HEX_W * 0.5, CENTER_Y - HEX_H * 0.75),
+        4 => (CENTER_X - HEX_W, CENTER_Y),
+        5 => (CENTER_X - HEX_W * 0.5, CENTER_Y + HEX_H * 0.75),
+        6 => (CENTER_X + HEX_W * 0.5, CENTER_Y + HEX_H * 0.75),
+        _ => (CENTER_X, CENTER_Y),
+    }
+}
+
+pub fn render_hex_map(
+    areas: &[game::areas::AreaDetails],
+    tributes: &[&game::tributes::Tribute],
+) -> String {
+    let area_order = [
+        game::areas::Area::Cornucopia,
+        game::areas::Area::Sector1,
+        game::areas::Area::Sector2,
+        game::areas::Area::Sector3,
+        game::areas::Area::Sector4,
+        game::areas::Area::Sector5,
+        game::areas::Area::Sector6,
+    ];
+
+    let area_map: std::collections::HashMap<game::areas::Area, &game::areas::AreaDetails> = areas
+        .iter()
+        .filter_map(|a| a.area.map(|area| (area, a)))
+        .collect();
+
+    let mut hexes = String::new();
+
+    for (idx, area_type) in area_order.iter().enumerate() {
+        let (cx, cy) = hex_center(idx);
+        let corners = hex_corners(cx, cy);
+        let points: String = corners
+            .iter()
+            .map(|(x, y)| format!("{x:.1},{y:.1}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let terrain = area_map
+            .get(area_type)
+            .map(|a| a.terrain.base)
+            .unwrap_or(game::terrain::BaseTerrain::Clearing);
+        let fill = terrain_color(&terrain);
+
+        let terrain_label = format!("{:?}", terrain).to_uppercase();
+        let area_name = area_type.to_string();
+
+        let tribute_count = tributes
+            .iter()
+            .filter(|t| t.is_alive() && *area_type == t.area)
+            .count();
+
+        hexes.push_str(&format!(
+            r#"<polygon points="{points}" fill="{fill}" stroke="var(--broad-border-strong)" stroke-width="2" opacity="0.85"/>
+            <text x="{cx}" y="{cy:.1}" text-anchor="middle" dominant-baseline="middle" fill="rgba(255,255,255,0.9)" font-size="9" font-family="var(--font-condensed)" font-weight="600" letter-spacing="1">{terrain_label}</text>
+            <text x="{cx}" y="{cy:.1}" text-anchor="middle" dominant-baseline="middle" fill="rgba(255,255,255,0.5)" font-size="7" font-family="var(--font-condensed)" dy="12">{area_name}</text>"#,
+        ));
+
+        // Tribute dots in this hex
+        let in_hex: Vec<_> = tributes
+            .iter()
+            .filter(|t| t.is_alive() && *area_type == t.area)
+            .enumerate()
+            .map(|(i, t)| {
+                let angle = std::f64::consts::PI * 2.0 * i as f64 / tribute_count.max(1) as f64;
+                let r = if tribute_count <= 1 { 0.0 } else { 16.0 };
+                (t, cx + r * angle.cos(), cy + r * angle.sin())
+            })
+            .collect();
+
+        for (tribute, dx, dy) in in_hex {
+            let dot_color = if tribute.is_alive() {
+                "var(--broad-accent)"
+            } else {
+                "var(--broad-fg-muted)"
+            };
+            let r = if tribute.is_alive() { 4.0 } else { 2.5 };
+            hexes.push_str(&format!(
+                r#"<circle cx="{dx:.1}" cy="{dy:.1}" r="{r}" fill="{dot_color}" stroke="var(--broad-bg)" stroke-width="1"/>"#,
+            ));
+        }
+    }
+
+    let view_w = CENTER_X * 2.0 + HEX_W + 20.0;
+    let view_h = CENTER_Y * 2.0 + HEX_H + 20.0;
+
+    format!(
+        r#"<svg viewBox="0 0 {view_w:.0} {view_h:.0}" xmlns="http://www.w3.org/2000/svg" class="hex-map">
+          {hexes}
+        </svg>"#,
+    )
+}

--- a/api/templates/game_detail.html
+++ b/api/templates/game_detail.html
@@ -127,9 +127,7 @@
             <span class="title">ARENA SURVEILLANCE</span>
           </div>
           <div class="map-container">
-            <div style="display:grid;place-items:center;height:100%;color:var(--broad-fg-muted);font-size:var(--fs-xs);font-family:var(--font-condensed);letter-spacing:2px;text-transform:uppercase;">
-              MAP COMING IN PHASE 6
-            </div>
+            {{ hex_map | safe }}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Server-rendered SVG hex grid map for the broadcast left panel.

## Changes
- **7 hexagons**: Cornucopia center + Sectors 1-6 in concentric honeycomb layout
- **Terrain coloring**: Each hex colored by BaseTerrain (forest green, desert yellow, mountain gray, etc.)
- **Tribute dots**: Positioned in center of their area's hex, distributed radially when multiple tributes share a hex
- **Area labels**: Terrain type + area name centered in each hex
- **Handler**: Fetches area data with terrain for the map
- **CSS**: Hex hover effect (brightness boost, opacity)

## Files
- `api/src/templates/game_detail.rs` — `render_hex_map()`, hex layout math (`hex_corners`, `hex_center`, `terrain_color`)
- `api/src/routes/games.rs` — area query added to `game_detail_handler`
- `api/templates/game_detail.html` — replaced placeholder with `{{ hex_map | safe }}`
- `api/assets/src/main.css` + `dist/main.css` — `.hex-map` hover styles

## Verification
- `just quality` passes
- Hex grid renders with correct terrain colors
- Tribute dots appear in the correct hexagons