### PR TITLE
refactor(api): collapse verify_record_persisted into RETURN AFTER

### DIFF
--- a/api/src/games/handlers.rs
+++ b/api/src/games/handlers.rs
@@ -68,13 +68,23 @@ pub async fn create_game(
         ..Default::default()
     };
 
-    db.query("UPSERT $rid CONTENT $body")
+    let mut result = db
+        .query("UPSERT $rid CONTENT $body RETURN AFTER")
         .bind(("rid", game_rid.clone()))
         .bind(("body", body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create game: {e}")))?;
 
-    crate::verify_record_persisted(&db, &game_rid, "create_game").await?;
+    let persisted_game: Option<Game> = result
+        .take::<Option<SerdeWrapper<Game>>>(0)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to take game: {e}")))?
+        .map(|w| w.0);
+
+    if persisted_game.is_none() {
+        return Err(AppError::InternalServerError(
+            "Game persistence verification failed".into(),
+        ));
+    }
 
     let created_game = game;
 
@@ -140,13 +150,23 @@ pub async fn quickstart(
         "private": false,
     });
 
-    db.query("UPSERT $rid CONTENT $body")
+    let mut result = db
+        .query("UPSERT $rid CONTENT $body RETURN AFTER")
         .bind(("rid", game_rid.clone()))
         .bind(("body", body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create game: {e}")))?;
 
-    crate::verify_record_persisted(&db, &game_rid, "quickstart").await?;
+    let persisted_game: Option<Game> = result
+        .take::<Option<SerdeWrapper<Game>>>(0)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to take game: {e}")))?
+        .map(|w| w.0);
+
+    if persisted_game.is_none() {
+        return Err(AppError::InternalServerError(
+            "Game persistence verification failed".into(),
+        ));
+    }
 
     // Create 24 tributes
     let tribute_futures =

--- a/api/src/games/mod.rs
+++ b/api/src/games/mod.rs
@@ -109,12 +109,23 @@ async fn create_game_area(area: Area, db: &Surreal<Any>) -> Result<GameArea, App
     };
     let body = serde_json::to_value(&game_area)
         .map_err(|e| AppError::InternalServerError(format!("Failed to encode area: {}", e)))?;
-    db.query("UPSERT $rid CONTENT $body")
+    let mut result = db
+        .query("UPSERT $rid CONTENT $body RETURN AFTER")
         .bind(("rid", area_id.clone()))
         .bind(("body", body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create area: {}", e)))?;
-    crate::verify_record_persisted(db, &area_id, "create_game_area").await?;
+
+    let persisted_area: Option<GameArea> = result
+        .take::<Option<SerdeWrapper<GameArea>>>(0)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to take area: {}", e)))?
+        .map(|w| w.0);
+
+    if persisted_area.is_none() {
+        return Err(AppError::InternalServerError(
+            "Area persistence verification failed".into(),
+        ));
+    }
 
     Ok(game_area)
 }
@@ -228,18 +239,23 @@ async fn add_item_to_area(
     let new_item_id: RecordId = RecordId::new("item", new_item.identifier.as_str());
     let body = serde_json::to_value(&new_item)
         .map_err(|e| AppError::InternalServerError(format!("Failed to encode item: {}", e)))?;
-    if let Err(e) = db
-        .query("UPSERT $rid CONTENT $body")
+    let mut result = db
+        .query("UPSERT $rid CONTENT $body RETURN AFTER")
         .bind(("rid", new_item_id.clone()))
         .bind(("body", body))
         .await
-    {
-        return Err(AppError::InternalServerError(format!(
-            "Failed to create item: {}",
-            e
-        )));
+        .map_err(|e| AppError::InternalServerError(format!("Failed to create item: {}", e)))?;
+
+    let persisted_item: Option<Item> = result
+        .take::<Option<SerdeWrapper<Item>>>(0)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to take item: {}", e)))?
+        .map(|w| w.0);
+
+    if persisted_item.is_none() {
+        return Err(AppError::InternalServerError(
+            "Item persistence verification failed".into(),
+        ));
     }
-    crate::verify_record_persisted(db, &new_item_id, "add_item_to_area").await?;
 
     // Insert an area-item relationship via a raw RELATE query. RELATE always
     // returns an array, so the SDK's typed insert::<Vec<_>>().relation() path

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,12 +1,12 @@
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use serde::{Deserialize, Serialize};
+
 use serde_json::json;
 use std::sync::Arc;
 use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
-use surrealdb_types::{RecordId, RecordIdKey, SerdeWrapper};
+use surrealdb_types::{RecordId, RecordIdKey};
 use thiserror::Error;
 use tracing::error;
 
@@ -102,12 +102,6 @@ impl IntoResponse for AppError {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-struct VerifyRow {
-    #[allow(dead_code)]
-    id: RecordId,
-}
-
 /// Format a RecordId as a human-readable string (`table:key`).
 /// surrealdb_types::RecordId does not implement Display.
 pub fn rid_to_string(rid: &RecordId) -> String {
@@ -127,46 +121,4 @@ pub fn rid_key_to_string(rid: &RecordId) -> String {
         RecordIdKey::Uuid(u) => u.to_string(),
         k => format!("{k:?}"),
     }
-}
-
-/// Verify that a record exists at the given `RecordId` after a write that
-/// the SDK reports as successful. SurrealDB returns an empty result set
-/// (no `Err`) when a permission or schema check rejects the write, so we
-/// must read back the row to be sure it landed.
-///
-/// Returns `Err(InternalServerError)` with a `site`-tagged message when
-/// the row is missing.
-pub async fn verify_record_persisted(
-    db: &Surreal<Any>,
-    rid: &RecordId,
-    site: &'static str,
-) -> Result<(), AppError> {
-    let mut resp = db
-        .query("SELECT id FROM $rid")
-        .bind(("rid", rid.clone()))
-        .await
-        .map_err(|e| {
-            AppError::InternalServerError(format!(
-                "{}: persistence verify query failed for {}: {}",
-                site,
-                crate::rid_to_string(rid),
-                e
-            ))
-        })?;
-    let rows: Vec<SerdeWrapper<VerifyRow>> = resp.take(0).map_err(|e| {
-        AppError::InternalServerError(format!(
-            "{}: persistence verify decode failed for {}: {}",
-            site,
-            crate::rid_to_string(rid),
-            e
-        ))
-    })?;
-    if rows.is_empty() {
-        return Err(AppError::InternalServerError(format!(
-            "{}: persistence verification failed for {}",
-            site,
-            crate::rid_to_string(rid)
-        )));
-    }
-    Ok(())
 }

--- a/api/src/tributes.rs
+++ b/api/src/tributes.rs
@@ -68,12 +68,23 @@ pub async fn create_tribute(
     // save_game in api/src/games.rs.
     let body = serde_json::to_value(&tribute)
         .map_err(|e| AppError::InternalServerError(format!("Failed to encode tribute: {}", e)))?;
-    db.query("UPSERT $rid CONTENT $body")
+    let mut result = db
+        .query("UPSERT $rid CONTENT $body RETURN AFTER")
         .bind(("rid", id.clone()))
         .bind(("body", body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create tribute: {}", e)))?;
-    crate::verify_record_persisted(db, &id, "create_tribute").await?;
+
+    let persisted_tribute: Option<Tribute> = result
+        .take::<Option<SerdeWrapper<Tribute>>>(0)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to take tribute: {}", e)))?
+        .map(|w| w.0);
+
+    if persisted_tribute.is_none() {
+        return Err(AppError::InternalServerError(
+            "Tribute persistence verification failed".into(),
+        ));
+    }
     let new_tribute = Some(tribute);
 
     db.query("RELATE $tribute->playing_in->$game")
@@ -88,12 +99,23 @@ pub async fn create_tribute(
     let new_object_id: RecordId = RecordId::new("item", new_object.identifier.as_str());
     let item_body = serde_json::to_value(&new_object)
         .map_err(|e| AppError::InternalServerError(format!("Failed to encode item: {}", e)))?;
-    db.query("UPSERT $rid CONTENT $body")
+    let mut result = db
+        .query("UPSERT $rid CONTENT $body RETURN AFTER")
         .bind(("rid", new_object_id.clone()))
         .bind(("body", item_body))
         .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create item: {}", e)))?;
-    crate::verify_record_persisted(db, &new_object_id, "create_tribute: item").await?;
+
+    let persisted_item: Option<Item> = result
+        .take::<Option<SerdeWrapper<Item>>>(0)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to take item: {}", e)))?
+        .map(|w| w.0);
+
+    if persisted_item.is_none() {
+        return Err(AppError::InternalServerError(
+            "Item persistence verification failed".into(),
+        ));
+    }
     db.query("RELATE $tribute->owns->$item")
         .bind(("tribute", id.clone()))
         .bind(("item", new_object_id.clone()))


### PR DESCRIPTION
## Summary
- Collapsed the `verify_record_persisted` follow-up SELECT into `RETURN AFTER` on all UPSERT write operations, eliminating the N+1 round-trip pattern across game, tribute, and item creation.

## Changes
- **api/src/games/handlers.rs**: Added `RETURN AFTER` to `create_game` and `quickstart` UPSERT queries; verify the returned row inline.
- **api/src/games/mod.rs**: Added `RETURN AFTER` to `create_game_area` and `add_item_to_area` UPSERT queries; verify inline.
- **api/src/tributes.rs**: Added `RETURN AFTER` to both UPSERT queries in `create_tribute` (tribute + item); verify inline.
- **api/src/lib.rs**: Removed `verify_record_persisted` function, `VerifyRow` struct, and unused imports (`Deserialize`, `Serialize`, `SerdeWrapper`).

## Verification
- `cargo check --package api` passes with no errors
- `cargo fmt` applied

## Follow-ups
- hangrier_games-7hgs (completed)