### PR TITLE
refactor(shared): derive MessagePayload::kind() via strum, extract tribute_refs()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,6 +5130,8 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "uuid",
  "validator",
 ]
@@ -5348,6 +5350,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -5362,6 +5373,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/api/src/routes/games.rs
+++ b/api/src/routes/games.rs
@@ -576,12 +576,23 @@ pub async fn timeline_handler(
             if !filter_str.is_empty() {
                 let kind = m.payload.kind();
                 let kind_str = match kind {
-                    shared::messages::MessageKind::Death => "death",
+                    shared::messages::MessageKind::TributeKilled => "death",
                     shared::messages::MessageKind::Combat
-                    | shared::messages::MessageKind::CombatSwing => "combat",
-                    shared::messages::MessageKind::Alliance => "alliance",
-                    shared::messages::MessageKind::Movement => "movement",
-                    shared::messages::MessageKind::Item
+                    | shared::messages::MessageKind::CombatSwing
+                    | shared::messages::MessageKind::TributeAttacked
+                    | shared::messages::MessageKind::TributeWounded => "combat",
+                    shared::messages::MessageKind::AllianceFormed
+                    | shared::messages::MessageKind::AllianceProposed
+                    | shared::messages::MessageKind::AllianceDissolved
+                    | shared::messages::MessageKind::BetrayalTriggered
+                    | shared::messages::MessageKind::TrustShockBreak => "alliance",
+                    shared::messages::MessageKind::TributeMoved
+                    | shared::messages::MessageKind::TributeHidden
+                    | shared::messages::MessageKind::AreaClosed
+                    | shared::messages::MessageKind::AreaEvent => "movement",
+                    shared::messages::MessageKind::ItemFound
+                    | shared::messages::MessageKind::ItemUsed
+                    | shared::messages::MessageKind::ItemDropped
                     | shared::messages::MessageKind::SponsorGift => "items",
                     _ => "",
                 };

--- a/api/src/templates/game_detail.rs
+++ b/api/src/templates/game_detail.rs
@@ -25,20 +25,37 @@ pub fn current_broadcast_phase(
 }
 
 fn message_archetype(payload: &shared::messages::MessagePayload) -> &'static str {
-    use shared::messages::MessageKind;
+    use shared::messages::MessageKind::*;
     match payload.kind() {
-        MessageKind::Death => "death",
-        MessageKind::Combat | MessageKind::CombatSwing => "action",
-        MessageKind::Alliance => "commentary",
-        MessageKind::Movement => "commentary",
-        MessageKind::Item | MessageKind::SponsorGift => "event",
-        MessageKind::State => "commentary",
-        MessageKind::Trauma => "commentary",
-        MessageKind::Affliction => "commentary",
-        MessageKind::Phobia => "commentary",
-        MessageKind::Fixation => "commentary",
-        MessageKind::Trapped => "event",
-        MessageKind::Sleep => "commentary",
+        TributeKilled => "death",
+        Combat | CombatSwing | TributeAttacked | TributeWounded | TrapSet | TrapTriggered => {
+            "action"
+        }
+        AllianceFormed | AllianceProposed | AllianceDissolved | BetrayalTriggered
+        | TrustShockBreak => "commentary",
+        TributeMoved | TributeHidden | AreaClosed | AreaEvent => "commentary",
+        ItemFound | ItemUsed | ItemDropped | SponsorGift => "event",
+        TributeRested | TributeStarved | TributeDehydrated | SanityBreak | HungerBandChanged
+        | ThirstBandChanged | StaminaBandChanged | ShelterSought | Foraged | Drank | Ate
+        | TributeSlept | TributeWoke | CycleStart | CycleEnd | PhaseStarted | PhaseEnded
+        | GameEnded | Generic => "commentary",
+        TraumaAcquired | TraumaReinforced | TraumaEscalated | TraumaFlashback | TraumaAvoidance
+        | TraumaObserved | TraumaForgotten | TraumaHabituated => "commentary",
+        PhobiaAcquired | PhobiaTriggered | PhobiaEscalated | PhobiaHabituated | PhobiaObserved
+        | PhobiaForgotten => "commentary",
+        FixationAcquired | FixationEscalated | FixationFired | FixationConsummated
+        | FixationThwarted | FixationFaded => "commentary",
+        AfflictionAcquired | AfflictionProgressed | AfflictionHealed | AfflictionCascaded
+        | SubstanceUsed | AddictionAcquired | AddictionReinforced | AddictionEscalated
+        | AddictionResisted | AddictionRelapse | AddictionCraving | AddictionObserved
+        | AddictionForgotten | AddictionHabituated => "commentary",
+        TributeTrapped
+        | Struggling
+        | TrappedEscaped
+        | TributeDiedWhileTrapped
+        | RescueAttempted
+        | PartialRescueProgress => "event",
+        SleepIncident => "commentary",
     }
 }
 
@@ -53,40 +70,72 @@ fn archetype_label(archetype: &str) -> &'static str {
 }
 
 fn message_kind_label(payload: &shared::messages::MessagePayload) -> &'static str {
-    use shared::messages::MessageKind;
+    use shared::messages::MessageKind::*;
     match payload.kind() {
-        MessageKind::Death => "Death",
-        MessageKind::Combat => "Combat",
-        MessageKind::CombatSwing => "Combat",
-        MessageKind::Alliance => "Alliance",
-        MessageKind::Movement => "Movement",
-        MessageKind::Item => "Item",
-        MessageKind::SponsorGift => "Sponsor",
-        MessageKind::State => "State",
-        MessageKind::Trauma => "Trauma",
-        MessageKind::Affliction => "Health",
-        MessageKind::Phobia => "Fear",
-        MessageKind::Fixation => "Fixation",
-        MessageKind::Trapped => "Trapped",
-        MessageKind::Sleep => "Sleep",
+        TributeKilled => "Death",
+        Combat | TributeAttacked | TributeWounded | TrapSet | TrapTriggered => "Combat",
+        CombatSwing => "Combat",
+        AllianceFormed | AllianceProposed | AllianceDissolved | BetrayalTriggered
+        | TrustShockBreak => "Alliance",
+        TributeMoved | TributeHidden | AreaClosed | AreaEvent => "Movement",
+        ItemFound | ItemUsed | ItemDropped => "Item",
+        SponsorGift => "Sponsor",
+        TributeRested | TributeStarved | TributeDehydrated | SanityBreak | HungerBandChanged
+        | ThirstBandChanged | StaminaBandChanged | ShelterSought | Foraged | Drank | Ate
+        | TributeSlept | TributeWoke | CycleStart | CycleEnd | PhaseStarted | PhaseEnded
+        | GameEnded | Generic => "State",
+        TraumaAcquired | TraumaReinforced | TraumaEscalated | TraumaFlashback | TraumaAvoidance
+        | TraumaObserved | TraumaForgotten | TraumaHabituated => "Trauma",
+        PhobiaAcquired | PhobiaTriggered | PhobiaEscalated | PhobiaHabituated | PhobiaObserved
+        | PhobiaForgotten => "Fear",
+        FixationAcquired | FixationEscalated | FixationFired | FixationConsummated
+        | FixationThwarted | FixationFaded => "Fixation",
+        AfflictionAcquired | AfflictionProgressed | AfflictionHealed | AfflictionCascaded
+        | SubstanceUsed | AddictionAcquired | AddictionReinforced | AddictionEscalated
+        | AddictionResisted | AddictionRelapse | AddictionCraving | AddictionObserved
+        | AddictionForgotten | AddictionHabituated => "Health",
+        TributeTrapped
+        | Struggling
+        | TrappedEscaped
+        | TributeDiedWhileTrapped
+        | RescueAttempted
+        | PartialRescueProgress => "Trapped",
+        SleepIncident => "Sleep",
     }
 }
 
 fn kind_color(payload: &shared::messages::MessagePayload) -> &'static str {
-    use shared::messages::MessageKind;
+    use shared::messages::MessageKind::*;
     match payload.kind() {
-        MessageKind::Death => "var(--danger)",
-        MessageKind::Combat | MessageKind::CombatSwing => "var(--waiting)",
-        MessageKind::Alliance => "var(--info)",
-        MessageKind::Movement => "var(--accent)",
-        MessageKind::Item | MessageKind::SponsorGift => "var(--gold)",
-        MessageKind::State => "var(--muted)",
-        MessageKind::Trauma => "var(--purple)",
-        MessageKind::Affliction => "var(--warning)",
-        MessageKind::Phobia => "var(--purple)",
-        MessageKind::Fixation => "var(--purple)",
-        MessageKind::Trapped => "var(--warning)",
-        MessageKind::Sleep => "var(--info)",
+        TributeKilled => "var(--danger)",
+        Combat | CombatSwing | TributeAttacked | TributeWounded | TrapSet | TrapTriggered => {
+            "var(--waiting)"
+        }
+        AllianceFormed | AllianceProposed | AllianceDissolved | BetrayalTriggered
+        | TrustShockBreak => "var(--info)",
+        TributeMoved | TributeHidden | AreaClosed | AreaEvent => "var(--accent)",
+        ItemFound | ItemUsed | ItemDropped | SponsorGift => "var(--gold)",
+        TributeRested | TributeStarved | TributeDehydrated | SanityBreak | HungerBandChanged
+        | ThirstBandChanged | StaminaBandChanged | ShelterSought | Foraged | Drank | Ate
+        | TributeSlept | TributeWoke | CycleStart | CycleEnd | PhaseStarted | PhaseEnded
+        | GameEnded | Generic => "var(--muted)",
+        TraumaAcquired | TraumaReinforced | TraumaEscalated | TraumaFlashback | TraumaAvoidance
+        | TraumaObserved | TraumaForgotten | TraumaHabituated => "var(--purple)",
+        PhobiaAcquired | PhobiaTriggered | PhobiaEscalated | PhobiaHabituated | PhobiaObserved
+        | PhobiaForgotten => "var(--purple)",
+        FixationAcquired | FixationEscalated | FixationFired | FixationConsummated
+        | FixationThwarted | FixationFaded => "var(--purple)",
+        AfflictionAcquired | AfflictionProgressed | AfflictionHealed | AfflictionCascaded
+        | SubstanceUsed | AddictionAcquired | AddictionReinforced | AddictionEscalated
+        | AddictionResisted | AddictionRelapse | AddictionCraving | AddictionObserved
+        | AddictionForgotten | AddictionHabituated => "var(--warning)",
+        TributeTrapped
+        | Struggling
+        | TrappedEscaped
+        | TributeDiedWhileTrapped
+        | RescueAttempted
+        | PartialRescueProgress => "var(--warning)",
+        SleepIncident => "var(--info)",
     }
 }
 

--- a/game/src/messages.rs
+++ b/game/src/messages.rs
@@ -339,7 +339,7 @@ mod tests {
         };
         let ev = TaggedEvent::new("T1 snaps", payload);
         assert_eq!(ev.content, "T1 snaps");
-        assert_eq!(ev.payload.kind(), MessageKind::State);
+        assert_eq!(ev.payload.kind(), MessageKind::SanityBreak);
     }
 
     #[test]

--- a/game/src/tributes/afflictions/snapshots/game__tributes__afflictions__integration_tests__tests__message_stream_order_seed_100.snap
+++ b/game/src/tributes/afflictions/snapshots/game__tributes__afflictions__integration_tests__tests__message_stream_order_seed_100.snap
@@ -2,6 +2,6 @@
 source: game/src/tributes/afflictions/integration_tests.rs
 expression: payload_kinds
 ---
-- Affliction
+- AfflictionAcquired
 - Combat
 - CombatSwing

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,4 +10,6 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 rand = "0.10"
 validator = { version = "0.20", features = ["derive"] }
+strum = { version = "0.26", features = ["derive"] }
+strum_macros = "0.26"
 uuid = { version = "1.23.1", features = ["v4"] }

--- a/shared/src/messages/impls.rs
+++ b/shared/src/messages/impls.rs
@@ -2,108 +2,49 @@ use super::*;
 
 impl MessagePayload {
     pub fn kind(&self) -> MessageKind {
-        use MessagePayload::*;
-        match self {
-            TributeKilled { .. } => MessageKind::Death,
-            Combat(_) => MessageKind::Combat,
-            TributeAttacked { .. } => MessageKind::Combat,
-            CombatSwing(_) => MessageKind::CombatSwing,
-            AllianceFormed { .. }
-            | AllianceProposed { .. }
-            | AllianceDissolved { .. }
-            | BetrayalTriggered { .. }
-            | TrustShockBreak { .. } => MessageKind::Alliance,
-            TributeMoved { .. } | TributeHidden { .. } | AreaClosed { .. } | AreaEvent { .. } => {
-                MessageKind::Movement
-            }
-            ItemFound { .. } | ItemUsed { .. } | ItemDropped { .. } => MessageKind::Item,
-            SponsorGift { .. } => MessageKind::SponsorGift,
-            CycleStart { .. }
-            | CycleEnd { .. }
-            | PhaseStarted { .. }
-            | PhaseEnded { .. }
-            | GameEnded { .. } => MessageKind::State,
-            TributeWounded { .. }
-            | TributeRested { .. }
-            | TributeStarved { .. }
-            | TributeDehydrated { .. }
-            | SanityBreak { .. }
-            | HungerBandChanged { .. }
-            | ThirstBandChanged { .. }
-            | StaminaBandChanged { .. }
-            | ShelterSought { .. }
-            | Foraged { .. }
-            | Drank { .. }
-            | Ate { .. }
-            | TributeSlept { .. }
-            | TributeWoke { .. } => MessageKind::State,
-            TraumaAcquired { .. }
-            | TraumaReinforced { .. }
-            | TraumaEscalated { .. }
-            | TraumaFlashback { .. }
-            | TraumaAvoidance { .. }
-            | TraumaObserved { .. }
-            | TraumaForgotten { .. }
-            | TraumaHabituated { .. } => MessageKind::Trauma,
-            PhobiaAcquired { .. }
-            | PhobiaTriggered { .. }
-            | PhobiaEscalated { .. }
-            | PhobiaHabituated { .. }
-            | PhobiaObserved { .. }
-            | PhobiaForgotten { .. } => MessageKind::Phobia,
-            FixationAcquired { .. }
-            | FixationEscalated { .. }
-            | FixationFired { .. }
-            | FixationConsummated { .. }
-            | FixationThwarted { .. }
-            | FixationFaded { .. } => MessageKind::Fixation,
-            AfflictionAcquired { .. }
-            | AfflictionProgressed { .. }
-            | AfflictionHealed { .. }
-            | AfflictionCascaded { .. }
-            | SubstanceUsed { .. }
-            | AddictionAcquired { .. }
-            | AddictionReinforced { .. }
-            | AddictionEscalated { .. }
-            | AddictionResisted { .. }
-            | AddictionRelapse { .. }
-            | AddictionCraving { .. }
-            | AddictionObserved { .. }
-            | AddictionForgotten { .. }
-            | AddictionHabituated { .. } => MessageKind::Affliction,
-            TributeTrapped { .. }
-            | Struggling { .. }
-            | TrappedEscaped { .. }
-            | TributeDiedWhileTrapped { .. }
-            | RescueAttempted { .. }
-            | PartialRescueProgress { .. } => MessageKind::Trapped,
-            MessagePayload::TrapSet { .. } => MessageKind::Combat,
-            MessagePayload::TrapTriggered { .. } => MessageKind::Combat,
-            SleepIncident { .. } => MessageKind::Sleep,
-            Generic => MessageKind::State,
-        }
+        MessageKind::from(self)
     }
 
-    /// True if the payload references the tribute (by identifier). Used by
-    /// the per-tribute timeline filter so events involving a given tribute
-    /// — as victim, killer, attacker, ally, mover, item handler, etc. —
-    /// are kept while everything else is dropped.
-    pub fn involves(&self, tribute_identifier: &str) -> bool {
+    pub fn tribute_refs(&self) -> Vec<&TributeRef> {
         use MessagePayload::*;
-        let id = tribute_identifier;
-        let r = |t: &TributeRef| t.identifier == id;
+        let mut refs = Vec::new();
         match self {
-            TributeKilled { victim, killer, .. } => r(victim) || killer.as_ref().is_some_and(r),
+            TributeKilled { victim, killer, .. } => {
+                refs.push(victim);
+                if let Some(k) = killer {
+                    refs.push(k);
+                }
+            }
             TributeWounded {
                 victim, attacker, ..
             }
-            | TributeAttacked { victim, attacker } => r(victim) || attacker.as_ref().is_some_and(r),
-            Combat(engagement) => r(&engagement.attacker) || r(&engagement.target),
-            CombatSwing(beat) => r(&beat.attacker) || r(&beat.target),
-            AllianceFormed { members } | AllianceDissolved { members, .. } => members.iter().any(r),
-            AllianceProposed { proposer, target } => r(proposer) || r(target),
-            BetrayalTriggered { betrayer, victim } => r(betrayer) || r(victim),
-            TrustShockBreak { tribute, partner } => r(tribute) || r(partner),
+            | TributeAttacked { victim, attacker } => {
+                refs.push(victim);
+                if let Some(a) = attacker {
+                    refs.push(a);
+                }
+            }
+            Combat(e) => {
+                refs.push(&e.attacker);
+                refs.push(&e.target);
+            }
+            CombatSwing(b) => {
+                refs.push(&b.attacker);
+                refs.push(&b.target);
+            }
+            AllianceFormed { members } | AllianceDissolved { members, .. } => refs.extend(members),
+            AllianceProposed { proposer, target } => {
+                refs.push(proposer);
+                refs.push(target);
+            }
+            BetrayalTriggered { betrayer, victim } => {
+                refs.push(betrayer);
+                refs.push(victim);
+            }
+            TrustShockBreak { tribute, partner } => {
+                refs.push(tribute);
+                refs.push(partner);
+            }
             TributeMoved { tribute, .. }
             | TributeHidden { tribute, .. }
             | ItemFound { tribute, .. }
@@ -122,7 +63,73 @@ impl MessagePayload {
             | Ate { tribute, .. }
             | TributeSlept { tribute, .. }
             | TributeWoke { tribute, .. }
-            | SleepIncident { tribute, .. } => r(tribute),
+            | SleepIncident { tribute, .. }
+            | TrapSet { tribute, .. } => refs.push(tribute),
+            TrapTriggered { victim, .. } => refs.push(victim),
+            SponsorGift { recipient, .. } => refs.push(recipient),
+            GameEnded { winner } => {
+                if let Some(w) = winner {
+                    refs.push(w);
+                }
+            }
+            AfflictionAcquired { .. }
+            | AfflictionProgressed { .. }
+            | AfflictionHealed { .. }
+            | AfflictionCascaded { .. }
+            | TraumaAcquired { .. }
+            | TraumaReinforced { .. }
+            | TraumaEscalated { .. }
+            | TraumaFlashback { .. }
+            | TraumaAvoidance { .. }
+            | TraumaHabituated { .. }
+            | PhobiaAcquired { .. }
+            | PhobiaTriggered { .. }
+            | PhobiaEscalated { .. }
+            | PhobiaHabituated { .. }
+            | FixationAcquired { .. }
+            | FixationEscalated { .. }
+            | FixationFired { .. }
+            | FixationConsummated { .. }
+            | FixationThwarted { .. }
+            | FixationFaded { .. }
+            | SubstanceUsed { .. }
+            | AddictionAcquired { .. }
+            | AddictionReinforced { .. }
+            | AddictionEscalated { .. }
+            | AddictionResisted { .. }
+            | AddictionRelapse { .. }
+            | AddictionCraving { .. }
+            | AddictionHabituated { .. }
+            | TributeTrapped { .. }
+            | Struggling { .. }
+            | TrappedEscaped { .. }
+            | TributeDiedWhileTrapped { .. }
+            | RescueAttempted { .. }
+            | PartialRescueProgress { .. }
+            | PhobiaObserved { .. }
+            | PhobiaForgotten { .. }
+            | TraumaObserved { .. }
+            | TraumaForgotten { .. }
+            | AddictionObserved { .. }
+            | AddictionForgotten { .. }
+            | Generic
+            | AreaClosed { .. }
+            | AreaEvent { .. }
+            | CycleStart { .. }
+            | CycleEnd { .. }
+            | PhaseStarted { .. }
+            | PhaseEnded { .. } => {}
+        }
+        refs
+    }
+
+    pub fn involves(&self, tribute_identifier: &str) -> bool {
+        let id = tribute_identifier;
+        if self.tribute_refs().iter().any(|t| t.identifier == id) {
+            return true;
+        }
+        use MessagePayload::*;
+        match self {
             AfflictionAcquired { tribute_id, .. }
             | AfflictionProgressed { tribute_id, .. }
             | AfflictionHealed { tribute_id, .. }
@@ -172,49 +179,80 @@ impl MessagePayload {
             | FixationFired { tribute_id, .. }
             | FixationConsummated { tribute_id, .. }
             | FixationThwarted { tribute_id, .. }
-            | FixationFaded { tribute_id, .. } => tribute_id == id,
+            | FixationFaded { tribute_id, .. }
+            | SubstanceUsed {
+                tribute: tribute_id,
+                ..
+            }
+            | AddictionAcquired {
+                tribute: tribute_id,
+                ..
+            }
+            | AddictionReinforced {
+                tribute: tribute_id,
+                ..
+            }
+            | AddictionEscalated {
+                tribute: tribute_id,
+                ..
+            }
+            | AddictionResisted {
+                tribute: tribute_id,
+                ..
+            }
+            | AddictionRelapse {
+                tribute: tribute_id,
+                ..
+            }
+            | AddictionCraving {
+                tribute: tribute_id,
+                ..
+            }
+            | AddictionHabituated {
+                tribute: tribute_id,
+                ..
+            }
+            | TributeTrapped {
+                tribute: tribute_id,
+                ..
+            }
+            | Struggling {
+                tribute: tribute_id,
+                ..
+            }
+            | TrappedEscaped {
+                tribute: tribute_id,
+                ..
+            }
+            | TributeDiedWhileTrapped {
+                tribute: tribute_id,
+                ..
+            } => tribute_id == id,
             PhobiaObserved {
                 observer, subject, ..
-            } => observer == id || subject == id,
-            PhobiaForgotten {
+            }
+            | PhobiaForgotten {
+                observer, subject, ..
+            }
+            | TraumaObserved {
+                observer, subject, ..
+            }
+            | TraumaForgotten {
+                observer, subject, ..
+            }
+            | AddictionObserved {
+                observer, subject, ..
+            }
+            | AddictionForgotten {
                 observer, subject, ..
             } => observer == id || subject == id,
-            TraumaObserved {
-                observer, subject, ..
-            } => observer == id || subject == id,
-            TraumaForgotten {
-                observer, subject, ..
-            } => observer == id || subject == id,
-            SubstanceUsed { tribute, .. }
-            | AddictionAcquired { tribute, .. }
-            | AddictionReinforced { tribute, .. }
-            | AddictionEscalated { tribute, .. }
-            | AddictionResisted { tribute, .. }
-            | AddictionRelapse { tribute, .. }
-            | AddictionCraving { tribute, .. } => tribute == id,
-            AddictionObserved {
-                observer, subject, ..
-            } => observer == id || subject == id,
-            AddictionForgotten {
-                observer, subject, ..
-            } => observer == id || subject == id,
-            AddictionHabituated { tribute, .. } => tribute == id,
-            TributeTrapped { tribute, .. }
-            | Struggling { tribute, .. }
-            | TrappedEscaped { tribute, .. }
-            | TributeDiedWhileTrapped { tribute, .. } => tribute == id,
             RescueAttempted {
                 rescuer, target, ..
-            } => rescuer == id || target == id,
-            PartialRescueProgress {
+            }
+            | PartialRescueProgress {
                 rescuer, target, ..
             } => rescuer == id || target == id,
-            MessagePayload::TrapSet { tribute, .. } => r(tribute),
-            MessagePayload::TrapTriggered { victim, .. } => r(victim),
-            SponsorGift { recipient, .. } => r(recipient),
-            Generic | AreaClosed { .. } | AreaEvent { .. } => false,
-            CycleStart { .. } | CycleEnd { .. } | PhaseStarted { .. } | PhaseEnded { .. } => false,
-            GameEnded { winner } => winner.as_ref().is_some_and(r),
+            _ => false,
         }
     }
 }

--- a/shared/src/messages/mod.rs
+++ b/shared/src/messages/mod.rs
@@ -155,34 +155,6 @@ pub enum DrinkSource {
     Item { item: ItemRef },
 }
 
-/// Coarse-grained category for a `GameMessage`. Derived from `MessagePayload`
-/// via `MessagePayload::kind()`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum MessageKind {
-    Death,
-    Combat,
-    /// One swing of physical combat (see `CombatBeat`).
-    CombatSwing,
-    Alliance,
-    Movement,
-    Item,
-    State,
-    /// Sponsor gift delivery.
-    SponsorGift,
-    /// Trauma acquisition or reinforcement.
-    Trauma,
-    /// Phobia acquired, triggered, observed, escalated, habituated, or forgotten.
-    Phobia,
-    /// Affliction acquired, progressed, healed, or cascaded.
-    /// Fixation acquired, escalated, fired, consummated, thwarted, or faded.
-    Fixation,
-    /// Trapped affliction events: tribute trapped, struggling, escaped, or died.
-    Trapped,
-    Affliction,
-    /// Sleep incident (nightmare, night terror, animal encounter, etc.).
-    Sleep,
-}
-
 /// Visible fatigue band derived from a tribute's stamina/max_stamina ratio.
 /// Lives in `shared/` because it is wire-visible via
 /// `MessagePayload::StaminaBandChanged`.
@@ -329,6 +301,9 @@ pub enum PhobiaEffect {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
+#[derive(strum::EnumDiscriminants)]
+#[strum_discriminants(name(MessageKind))]
+#[strum_discriminants(derive(Serialize, Deserialize))]
 pub enum MessagePayload {
     /// Generic narrative event — prose-only, no structured payload consumers.
     Generic,

--- a/shared/src/messages/survival_event_tests.rs
+++ b/shared/src/messages/survival_event_tests.rs
@@ -29,7 +29,7 @@ fn shelter_sought_round_trip() {
     let json = serde_json::to_string(&p).unwrap();
     let back: MessagePayload = serde_json::from_str(&json).unwrap();
     assert_eq!(format!("{:?}", p), format!("{:?}", back));
-    assert_eq!(p.kind(), MessageKind::State);
+    assert_eq!(p.kind(), MessageKind::ShelterSought);
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn stamina_band_change_round_trips_and_routes_to_state() {
     let json = serde_json::to_string(&p).unwrap();
     let back: MessagePayload = serde_json::from_str(&json).unwrap();
     assert_eq!(format!("{:?}", p), format!("{:?}", back));
-    assert_eq!(p.kind(), MessageKind::State);
+    assert_eq!(p.kind(), MessageKind::StaminaBandChanged);
     assert!(p.involves(&tref().identifier));
 }
 
@@ -100,11 +100,17 @@ fn foraged_drank_ate_round_trip_and_kind() {
         item: iref(),
         debt_recovered: 4,
     };
-    for p in [foraged, drank, drank_item, ate] {
+    let payloads = [
+        (foraged, MessageKind::Foraged),
+        (drank, MessageKind::Drank),
+        (drank_item, MessageKind::Drank),
+        (ate, MessageKind::Ate),
+    ];
+    for (p, expected) in payloads {
         let back: MessagePayload =
             serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
         assert_eq!(format!("{:?}", p), format!("{:?}", back));
-        assert_eq!(p.kind(), MessageKind::State);
+        assert_eq!(p.kind(), expected);
     }
 }
 
@@ -178,8 +184,8 @@ fn tribute_slept_woke_payload_kind_is_state() {
         phase: Phase::Dawn,
         reason: WakeReason::Rested,
     };
-    assert_eq!(slept.kind(), MessageKind::State);
-    assert_eq!(woke.kind(), MessageKind::State);
+    assert_eq!(slept.kind(), MessageKind::TributeSlept);
+    assert_eq!(woke.kind(), MessageKind::TributeWoke);
 }
 
 #[test]
@@ -212,7 +218,7 @@ fn phobia_acquired_round_trips_and_kind() {
     let json = serde_json::to_string(&p).unwrap();
     let back: MessagePayload = serde_json::from_str(&json).unwrap();
     assert_eq!(format!("{:?}", p), format!("{:?}", back));
-    assert_eq!(p.kind(), MessageKind::Phobia);
+    assert_eq!(p.kind(), MessageKind::PhobiaAcquired);
     assert!(p.involves("t1"));
     assert!(!p.involves("other"));
 }
@@ -228,7 +234,7 @@ fn phobia_triggered_round_trips_and_kind() {
     let json = serde_json::to_string(&p).unwrap();
     let back: MessagePayload = serde_json::from_str(&json).unwrap();
     assert_eq!(format!("{:?}", p), format!("{:?}", back));
-    assert_eq!(p.kind(), MessageKind::Phobia);
+    assert_eq!(p.kind(), MessageKind::PhobiaTriggered);
     assert!(p.involves("t1"));
     assert!(!p.involves("other"));
 }

--- a/shared/src/messages/tests.rs
+++ b/shared/src/messages/tests.rs
@@ -50,12 +50,12 @@ fn phase_ord_and_next_canonical_cycle() {
 #[test]
 fn message_kind_serde_roundtrip() {
     for kind in [
-        MessageKind::Death,
+        MessageKind::TributeKilled,
         MessageKind::Combat,
-        MessageKind::Alliance,
-        MessageKind::Movement,
-        MessageKind::Item,
-        MessageKind::State,
+        MessageKind::AllianceFormed,
+        MessageKind::TributeMoved,
+        MessageKind::ItemFound,
+        MessageKind::TributeRested,
         MessageKind::CombatSwing,
     ] {
         let s = serde_json::to_string(&kind).unwrap();
@@ -71,14 +71,14 @@ fn kind_lifecycle_variants_map_correctly() {
         killer: None,
         cause: "fall".into(),
     };
-    assert_eq!(p.kind(), MessageKind::Death);
+    assert_eq!(p.kind(), MessageKind::TributeKilled);
 
     let p = MessagePayload::TributeWounded {
         victim: t("v"),
         attacker: None,
         hp_lost: 5,
     };
-    assert_eq!(p.kind(), MessageKind::State);
+    assert_eq!(p.kind(), MessageKind::TributeWounded);
 }
 
 #[test]
@@ -94,29 +94,45 @@ fn kind_combat_maps_to_combat() {
 
 #[test]
 fn kind_alliance_variants_map_correctly() {
-    for p in [
+    assert_eq!(
         MessagePayload::AllianceFormed {
             members: vec![t("a"), t("b")],
-        },
+        }
+        .kind(),
+        MessageKind::AllianceFormed
+    );
+    assert_eq!(
         MessagePayload::AllianceProposed {
             proposer: t("a"),
             target: t("b"),
-        },
+        }
+        .kind(),
+        MessageKind::AllianceProposed
+    );
+    assert_eq!(
         MessagePayload::AllianceDissolved {
             members: vec![t("a")],
             reason: "x".into(),
-        },
+        }
+        .kind(),
+        MessageKind::AllianceDissolved
+    );
+    assert_eq!(
         MessagePayload::BetrayalTriggered {
             betrayer: t("a"),
             victim: t("b"),
-        },
+        }
+        .kind(),
+        MessageKind::BetrayalTriggered
+    );
+    assert_eq!(
         MessagePayload::TrustShockBreak {
             tribute: t("a"),
             partner: t("b"),
-        },
-    ] {
-        assert_eq!(p.kind(), MessageKind::Alliance);
-    }
+        }
+        .kind(),
+        MessageKind::TrustShockBreak
+    );
 }
 
 #[test]
@@ -125,25 +141,36 @@ fn kind_movement_variants_map_correctly() {
         identifier: "a1".into(),
         name: "A".into(),
     };
-    for p in [
+    assert_eq!(
         MessagePayload::TributeMoved {
             tribute: t("a"),
             from: area.clone(),
             to: area.clone(),
-        },
+        }
+        .kind(),
+        MessageKind::TributeMoved
+    );
+    assert_eq!(
         MessagePayload::TributeHidden {
             tribute: t("a"),
             area: area.clone(),
-        },
-        MessagePayload::AreaClosed { area: area.clone() },
+        }
+        .kind(),
+        MessageKind::TributeHidden
+    );
+    assert_eq!(
+        MessagePayload::AreaClosed { area: area.clone() }.kind(),
+        MessageKind::AreaClosed
+    );
+    assert_eq!(
         MessagePayload::AreaEvent {
             area: area.clone(),
             kind: AreaEventKind::Storm,
             description: "x".into(),
-        },
-    ] {
-        assert_eq!(p.kind(), MessageKind::Movement);
-    }
+        }
+        .kind(),
+        MessageKind::AreaEvent
+    );
 }
 
 #[test]
@@ -156,24 +183,32 @@ fn kind_item_variants_map_correctly() {
         identifier: "i1".into(),
         name: "I".into(),
     };
-    for p in [
+    assert_eq!(
         MessagePayload::ItemFound {
             tribute: t("a"),
             item: item.clone(),
             area: area.clone(),
-        },
+        }
+        .kind(),
+        MessageKind::ItemFound
+    );
+    assert_eq!(
         MessagePayload::ItemUsed {
             tribute: t("a"),
             item: item.clone(),
-        },
+        }
+        .kind(),
+        MessageKind::ItemUsed
+    );
+    assert_eq!(
         MessagePayload::ItemDropped {
             tribute: t("a"),
             item: item.clone(),
             area: area.clone(),
-        },
-    ] {
-        assert_eq!(p.kind(), MessageKind::Item);
-    }
+        }
+        .kind(),
+        MessageKind::ItemDropped
+    );
     let sponsor = MessagePayload::SponsorGift {
         recipient: t("a"),
         item: item.clone(),
@@ -184,23 +219,34 @@ fn kind_item_variants_map_correctly() {
 
 #[test]
 fn kind_state_variants_map_correctly() {
-    for p in [
+    assert_eq!(
         MessagePayload::TributeRested {
             tribute: t("a"),
             hp_restored: 3,
-        },
+        }
+        .kind(),
+        MessageKind::TributeRested
+    );
+    assert_eq!(
         MessagePayload::TributeStarved {
             tribute: t("a"),
             hp_lost: 1,
-        },
+        }
+        .kind(),
+        MessageKind::TributeStarved
+    );
+    assert_eq!(
         MessagePayload::TributeDehydrated {
             tribute: t("a"),
             hp_lost: 2,
-        },
-        MessagePayload::SanityBreak { tribute: t("a") },
-    ] {
-        assert_eq!(p.kind(), MessageKind::State);
-    }
+        }
+        .kind(),
+        MessageKind::TributeDehydrated
+    );
+    assert_eq!(
+        MessagePayload::SanityBreak { tribute: t("a") }.kind(),
+        MessageKind::SanityBreak
+    );
 }
 
 #[test]
@@ -226,7 +272,7 @@ fn game_message_new_populates_required_fields() {
     assert_eq!(msg.phase, Phase::Night);
     assert_eq!(msg.tick, 3);
     assert_eq!(msg.emit_index, 0);
-    assert_eq!(msg.payload.kind(), MessageKind::State);
+    assert_eq!(msg.payload.kind(), MessageKind::SanityBreak);
 }
 
 fn make_msg(day: u32, phase: Phase, payload: MessagePayload) -> GameMessage {


### PR DESCRIPTION
## Summary
- Add strum EnumDiscriminants derive to MessagePayload for automatic kind() generation
- Extract tribute_refs() helper to deduplicate tribute reference extraction
- Update involves() to use tribute_refs()

## Changes
- shared/Cargo.toml: add strum/strum_macros dependencies
- shared/src/messages/mod.rs: add derive, kind(), tribute_refs()
- shared/src/messages/impls.rs: update involves()
- api/src/: update MessageKind callers for 1:1 variant mapping

## Verification
- cargo test --package shared
- cargo test --package game