### PR TITLE
refactor(shared): introduce newtype identifiers TributeId/GameId/AreaId/ItemId

### DIFF
--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,4 +10,4 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 rand = "0.10"
 validator = { version = "0.20", features = ["derive"] }
-uuid = { version = "1.23.1", features = ["v4"] }
+uuid = { version = "1.23.1", features = ["v4", "serde"] }

--- a/shared/src/audience.rs
+++ b/shared/src/audience.rs
@@ -149,10 +149,12 @@ impl AudienceEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ids::TributeId;
+    use uuid::Uuid;
 
     fn t(name: &str) -> TributeRef {
         TributeRef {
-            identifier: name.into(),
+            identifier: TributeId(Uuid::new_v4()),
             name: name.into(),
         }
     }

--- a/shared/src/combat_beat.rs
+++ b/shared/src/combat_beat.rs
@@ -98,11 +98,13 @@ pub struct CombatBeat {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ids::{ItemId, TributeId};
     use crate::messages::ItemRef;
+    use uuid::Uuid;
 
     fn t(name: &str) -> TributeRef {
         TributeRef {
-            identifier: "id".into(),
+            identifier: TributeId(Uuid::new_v4()),
             name: name.into(),
         }
     }
@@ -112,7 +114,7 @@ mod tests {
         let report = WearReport {
             owner: t("A"),
             item: ItemRef {
-                identifier: "sword-1".into(),
+                identifier: ItemId(Uuid::new_v4()),
                 name: "Iron Sword".into(),
             },
             outcome: WearOutcomeReport::Broken,

--- a/shared/src/ids.rs
+++ b/shared/src/ids.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use uuid::Uuid;
+
+macro_rules! define_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(pub Uuid);
+
+        impl FromStr for $name {
+            type Err = uuid::Error;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(Self(Uuid::parse_str(s)?))
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl From<Uuid> for $name {
+            fn from(uuid: Uuid) -> Self {
+                Self(uuid)
+            }
+        }
+    };
+}
+
+define_id!(TributeId);
+define_id!(GameId);
+define_id!(AreaId);
+define_id!(ItemId);

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -6,6 +6,7 @@ use validator::{Validate, ValidationError};
 pub mod afflictions;
 pub mod audience;
 pub mod combat_beat;
+pub mod ids;
 pub mod messages;
 pub mod sponsors;
 

--- a/shared/src/messages/impls.rs
+++ b/shared/src/messages/impls.rs
@@ -90,8 +90,9 @@ impl MessagePayload {
     /// are kept while everything else is dropped.
     pub fn involves(&self, tribute_identifier: &str) -> bool {
         use MessagePayload::*;
+        let tid = tribute_identifier.parse::<crate::ids::TributeId>().ok();
+        let r = |t: &TributeRef| tid.as_ref().is_some_and(|id| t.identifier == *id);
         let id = tribute_identifier;
-        let r = |t: &TributeRef| t.identifier == id;
         match self {
             TributeKilled { victim, killer, .. } => r(victim) || killer.as_ref().is_some_and(r),
             TributeWounded {

--- a/shared/src/messages/mod.rs
+++ b/shared/src/messages/mod.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use uuid::Uuid;
 
+use crate::ids::{AreaId, ItemId, TributeId};
+
 /// Cause string used in `MessagePayload::TributeKilled` for starvation deaths.
 pub const CAUSE_STARVATION: &str = "starvation";
 /// Cause string used in `MessagePayload::TributeKilled` for dehydration deaths.
@@ -102,19 +104,19 @@ impl FromStr for Phase {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TributeRef {
-    pub identifier: String,
+    pub identifier: TributeId,
     pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AreaRef {
-    pub identifier: String,
+    pub identifier: AreaId,
     pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ItemRef {
-    pub identifier: String,
+    pub identifier: ItemId,
     pub name: String,
 }
 

--- a/shared/src/messages/survival_event_tests.rs
+++ b/shared/src/messages/survival_event_tests.rs
@@ -1,19 +1,25 @@
 use super::*;
+use uuid::Uuid;
+
+const TEST_TRIBUTE_ID: Uuid = uuid::uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8");
+const TEST_AREA_ID: Uuid = uuid::uuid!("67e55044-10b1-426f-9247-bb680e5fe0c9");
+const TEST_ITEM_ID: Uuid = uuid::uuid!("67e55044-10b1-426f-9247-bb680e5fe0ca");
+
 fn tref() -> TributeRef {
     TributeRef {
-        identifier: "t1".into(),
+        identifier: TributeId(TEST_TRIBUTE_ID),
         name: "Cato".into(),
     }
 }
 fn aref() -> AreaRef {
     AreaRef {
-        identifier: "a1".into(),
+        identifier: AreaId(TEST_AREA_ID),
         name: "Forest".into(),
     }
 }
 fn iref() -> ItemRef {
     ItemRef {
-        identifier: "i1".into(),
+        identifier: ItemId(TEST_ITEM_ID),
         name: "Berries".into(),
     }
 }
@@ -61,7 +67,7 @@ fn stamina_band_change_round_trips_and_routes_to_state() {
     let back: MessagePayload = serde_json::from_str(&json).unwrap();
     assert_eq!(format!("{:?}", p), format!("{:?}", back));
     assert_eq!(p.kind(), MessageKind::State);
-    assert!(p.involves(&tref().identifier));
+    assert!(p.involves(&tref().identifier.to_string()));
 }
 
 #[test]
@@ -121,7 +127,8 @@ fn survival_payloads_involve_tribute() {
         item: iref(),
         debt_recovered: 1,
     };
-    assert!(p.involves("t1"));
+    let id_str = TEST_TRIBUTE_ID.to_string();
+    assert!(p.involves(&id_str));
     assert!(!p.involves("other"));
 }
 
@@ -139,7 +146,7 @@ fn wake_reason_serde_roundtrip_interrupted_variants() {
         WakeReason::Interrupted {
             event: InterruptionKind::Ambush {
                 attacker: TributeRef {
-                    identifier: "a".into(),
+                    identifier: TributeId(Uuid::new_v4()),
                     name: "A".into(),
                 },
             },
@@ -152,7 +159,7 @@ fn wake_reason_serde_roundtrip_interrupted_variants() {
         WakeReason::Interrupted {
             event: InterruptionKind::AllianceSummons {
                 ally: TributeRef {
-                    identifier: "b".into(),
+                    identifier: TributeId(Uuid::new_v4()),
                     name: "B".into(),
                 },
             },
@@ -195,9 +202,10 @@ fn tribute_slept_woke_involves_tribute() {
         phase: Phase::Dawn,
         reason: WakeReason::Rested,
     };
-    assert!(slept.involves("t1"));
+    let id_str = TEST_TRIBUTE_ID.to_string();
+    assert!(slept.involves(&id_str));
     assert!(!slept.involves("other"));
-    assert!(woke.involves("t1"));
+    assert!(woke.involves(&id_str));
     assert!(!woke.involves("other"));
 }
 

--- a/shared/src/messages/tests.rs
+++ b/shared/src/messages/tests.rs
@@ -1,7 +1,9 @@
 use super::*;
+use uuid::Uuid;
+
 fn t(name: &str) -> TributeRef {
     TributeRef {
-        identifier: format!("id-{name}"),
+        identifier: TributeId(Uuid::new_v4()),
         name: name.into(),
     }
 }
@@ -122,7 +124,7 @@ fn kind_alliance_variants_map_correctly() {
 #[test]
 fn kind_movement_variants_map_correctly() {
     let area = AreaRef {
-        identifier: "a1".into(),
+        identifier: AreaId(Uuid::new_v4()),
         name: "A".into(),
     };
     for p in [
@@ -149,11 +151,11 @@ fn kind_movement_variants_map_correctly() {
 #[test]
 fn kind_item_variants_map_correctly() {
     let area = AreaRef {
-        identifier: "a1".into(),
+        identifier: AreaId(Uuid::new_v4()),
         name: "A".into(),
     };
     let item = ItemRef {
-        identifier: "i1".into(),
+        identifier: ItemId(Uuid::new_v4()),
         name: "I".into(),
     };
     for p in [
@@ -260,7 +262,7 @@ fn summarize_empty_input_with_current_day_zero() {
 #[test]
 fn summarize_groups_by_day_and_phase() {
     let tref = TributeRef {
-        identifier: "t".into(),
+        identifier: TributeId(Uuid::new_v4()),
         name: "T".into(),
     };
     let killed = MessagePayload::TributeKilled {
@@ -271,7 +273,7 @@ fn summarize_groups_by_day_and_phase() {
     let moved = MessagePayload::TributeHidden {
         tribute: tref.clone(),
         area: AreaRef {
-            identifier: "a".into(),
+            identifier: AreaId(Uuid::new_v4()),
             name: "A".into(),
         },
     };
@@ -380,7 +382,7 @@ fn summarize_counts_combat_kills_as_deaths() {
 #[test]
 fn summarize_is_current_flag_set_correctly() {
     let tref = TributeRef {
-        identifier: "t".into(),
+        identifier: TributeId(Uuid::new_v4()),
         name: "T".into(),
     };
     let p = MessagePayload::TributeRested {


### PR DESCRIPTION
## Summary
- Introduce newtype wrappers: TributeId, GameId, AreaId, ItemId (wrapping Uuid)
- serde(transparent) for wire format compatibility
- FromStr/Display/From<Uuid> implementations
- Update TributeRef/AreaRef/ItemRef to use new types

## Changes
- shared/src/ids.rs: new file with newtype definitions
- shared/src/lib.rs: add pub mod ids
- shared/src/messages/mod.rs: update ref structs
- shared/src/messages/impls.rs: update methods

## Verification
- cargo test --package shared