### PR TITLE
refactor(game): extract pure resolve() from Tribute::attacks()

### DIFF
--- a/game/src/tributes/combat/mod.rs
+++ b/game/src/tributes/combat/mod.rs
@@ -84,272 +84,272 @@ impl Tribute {
             return self.handle_self_attack(target, events, tuning);
         }
 
-    let tribute_name = self.name.clone();
-    let target_name = target.name.clone();
+        let tribute_name = self.name.clone();
+        let target_name = target.name.clone();
 
-    let mut detail_lines: Vec<String> = Vec::new();
-    let mut sub_events: Vec<TaggedEvent> = Vec::new();
+        let mut detail_lines: Vec<String> = Vec::new();
+        let mut sub_events: Vec<TaggedEvent> = Vec::new();
 
-    let (contest, beat) = resolve(self, target, rng, &mut sub_events, tuning);
-    let result = contest.result;
-    let target_inflicts = contest.inflicts;
-    let attacker_inflicts = contest.attacker_inflicts;
+        let (contest, beat) = resolve(self, target, rng, &mut sub_events, tuning);
+        let result = contest.result;
+        let target_inflicts = contest.inflicts;
+        let attacker_inflicts = contest.attacker_inflicts;
 
-    for ev in sub_events.drain(..) {
-        detail_lines.push(ev.content);
-    }
-
-    match result {
-        AttackResult::CriticalHit => {
-            detail_lines.push(
-                GameOutput::TributeCriticalHit(tribute_name.as_str(), target_name.as_str())
-                    .to_string(),
-            );
-            let _ = apply_combat_results(
-                self,
-                target,
-                self.attributes.strength * 3,
-                GameOutput::TributeAttackWin(tribute_name.as_str(), target_name.as_str()),
-                &mut sub_events,
-                tuning,
-            );
-            for ev in sub_events.drain(..) {
-                detail_lines.push(ev.content);
-            }
+        for ev in sub_events.drain(..) {
+            detail_lines.push(ev.content);
         }
-        AttackResult::CriticalFumble => {
-            let fumble_content =
-                GameOutput::TributeCriticalFumble(tribute_name.as_str()).to_string();
-            self.takes_physical_damage(5);
-            self.statistics.defeats += 1;
 
-            if self.attributes.health == 0 {
-                self.statistics.killed_by = Some("themselves (fumble)".to_string());
-                self.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
-                self.recently_killed_by = Some(self.id);
-                let died_content =
-                    GameOutput::TributeAttackDied(tribute_name.as_str(), "themselves")
-                        .to_string();
-                let combined = format!("{fumble_content} {died_content}");
+        match result {
+            AttackResult::CriticalHit => {
+                detail_lines.push(
+                    GameOutput::TributeCriticalHit(tribute_name.as_str(), target_name.as_str())
+                        .to_string(),
+                );
+                let _ = apply_combat_results(
+                    self,
+                    target,
+                    self.attributes.strength * 3,
+                    GameOutput::TributeAttackWin(tribute_name.as_str(), target_name.as_str()),
+                    &mut sub_events,
+                    tuning,
+                );
+                for ev in sub_events.drain(..) {
+                    detail_lines.push(ev.content);
+                }
+            }
+            AttackResult::CriticalFumble => {
+                let fumble_content =
+                    GameOutput::TributeCriticalFumble(tribute_name.as_str()).to_string();
+                self.takes_physical_damage(5);
+                self.statistics.defeats += 1;
+
+                if self.attributes.health == 0 {
+                    self.statistics.killed_by = Some("themselves (fumble)".to_string());
+                    self.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
+                    self.recently_killed_by = Some(self.id);
+                    let died_content =
+                        GameOutput::TributeAttackDied(tribute_name.as_str(), "themselves")
+                            .to_string();
+                    let combined = format!("{fumble_content} {died_content}");
+                    events.push(TaggedEvent::new(
+                        combined,
+                        MessagePayload::TributeKilled {
+                            victim: tref(self),
+                            killer: None,
+                            cause: "critical_fumble".into(),
+                        },
+                    ));
+                    events.push(TaggedEvent::new(
+                        String::new(),
+                        MessagePayload::CombatSwing(beat),
+                    ));
+                    return AttackOutcome::Kill(target.clone(), self.clone());
+                }
+
                 events.push(TaggedEvent::new(
-                    combined,
-                    MessagePayload::TributeKilled {
+                    fumble_content,
+                    MessagePayload::TributeWounded {
                         victim: tref(self),
-                        killer: None,
-                        cause: "critical_fumble".into(),
+                        attacker: None,
+                        hp_lost: 5,
                     },
                 ));
                 events.push(TaggedEvent::new(
                     String::new(),
                     MessagePayload::CombatSwing(beat),
                 ));
-                return AttackOutcome::Kill(target.clone(), self.clone());
+                return AttackOutcome::Wound(self.clone(), target.clone());
             }
+            AttackResult::PerfectBlock => {
+                detail_lines.push(
+                    GameOutput::TributePerfectBlock(target_name.as_str(), tribute_name.as_str())
+                        .to_string(),
+                );
+                let _ = apply_combat_results(
+                    target,
+                    self,
+                    target.attributes.strength * 2,
+                    GameOutput::TributeAttackLose(tribute_name.as_str(), target_name.as_str()),
+                    &mut sub_events,
+                    tuning,
+                );
+                for ev in sub_events.drain(..) {
+                    detail_lines.push(ev.content);
+                }
+            }
+            AttackResult::AttackerWins => {
+                let _ = apply_combat_results(
+                    self,
+                    target,
+                    self.attributes.strength,
+                    GameOutput::TributeAttackWin(tribute_name.as_str(), target_name.as_str()),
+                    &mut sub_events,
+                    tuning,
+                );
+                for ev in sub_events.drain(..) {
+                    detail_lines.push(ev.content);
+                }
+            }
+            AttackResult::AttackerWinsDecisively => {
+                let _ = apply_combat_results(
+                    self,
+                    target,
+                    self.attributes.strength * 2,
+                    GameOutput::TributeAttackWinExtra(tribute_name.as_str(), target_name.as_str()),
+                    &mut sub_events,
+                    tuning,
+                );
+                for ev in sub_events.drain(..) {
+                    detail_lines.push(ev.content);
+                }
+            }
+            AttackResult::DefenderWins => {
+                let _ = apply_combat_results(
+                    target,
+                    self,
+                    target.attributes.strength,
+                    GameOutput::TributeAttackLose(tribute_name.as_str(), target_name.as_str()),
+                    &mut sub_events,
+                    tuning,
+                );
+                for ev in sub_events.drain(..) {
+                    detail_lines.push(ev.content);
+                }
+            }
+            AttackResult::DefenderWinsDecisively => {
+                let _ = apply_combat_results(
+                    target,
+                    self,
+                    target.attributes.strength * 2,
+                    GameOutput::TributeAttackLoseExtra(tribute_name.as_str(), target_name.as_str()),
+                    &mut sub_events,
+                    tuning,
+                );
+                for ev in sub_events.drain(..) {
+                    detail_lines.push(ev.content);
+                }
+            }
+            AttackResult::Miss => {
+                self.statistics.draws += 1;
+                target.statistics.draws += 1;
 
-            events.push(TaggedEvent::new(
-                fumble_content,
-                MessagePayload::TributeWounded {
-                    victim: tref(self),
-                    attacker: None,
-                    hp_lost: 5,
-                },
-            ));
-            events.push(TaggedEvent::new(
-                String::new(),
-                MessagePayload::CombatSwing(beat),
-            ));
-            return AttackOutcome::Wound(self.clone(), target.clone());
+                detail_lines.push(
+                    GameOutput::TributeAttackMiss(tribute_name.as_str(), target_name.as_str())
+                        .to_string(),
+                );
+
+                let outcome = CombatOutcome::Stalemate;
+                let summary = format!("{} attacks {} ({:?})", self.name, target.name, outcome);
+                events.push(TaggedEvent::new(
+                    summary,
+                    MessagePayload::Combat(CombatEngagement {
+                        attacker: tref(self),
+                        target: tref(target),
+                        outcome,
+                        detail_lines,
+                    }),
+                ));
+                events.push(TaggedEvent::new(
+                    String::new(),
+                    MessagePayload::CombatSwing(beat),
+                ));
+
+                return AttackOutcome::Miss(self.clone(), target.clone());
+            }
+        };
+
+        for draft in &target_inflicts {
+            let resolution = target.try_acquire_affliction(draft.clone());
+            if matches!(
+                resolution,
+                crate::tributes::afflictions::AcquireResolution::Insert
+                    | crate::tributes::afflictions::AcquireResolution::Upgrade(_)
+                    | crate::tributes::afflictions::AcquireResolution::Supersede(_)
+            ) {
+                events.push(TaggedEvent::new(
+                    String::new(),
+                    MessagePayload::AfflictionAcquired {
+                        tribute_id: target.identifier.clone(),
+                        affliction: draft.kind.to_string(),
+                        severity: draft.severity.to_string(),
+                    },
+                ));
+            }
         }
-        AttackResult::PerfectBlock => {
+        for draft in &attacker_inflicts {
+            let resolution = self.try_acquire_affliction(draft.clone());
+            if matches!(
+                resolution,
+                crate::tributes::afflictions::AcquireResolution::Insert
+                    | crate::tributes::afflictions::AcquireResolution::Upgrade(_)
+                    | crate::tributes::afflictions::AcquireResolution::Supersede(_)
+            ) {
+                events.push(TaggedEvent::new(
+                    String::new(),
+                    MessagePayload::AfflictionAcquired {
+                        tribute_id: self.identifier.clone(),
+                        affliction: draft.kind.to_string(),
+                        severity: draft.severity.to_string(),
+                    },
+                ));
+            }
+        }
+
+        let (outcome, attack_outcome) = if self.attributes.health == 0 {
+            self.statistics.killed_by = Some(target_name.clone());
+            self.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
+            self.recently_killed_by = Some(target.id);
+
             detail_lines.push(
-                GameOutput::TributePerfectBlock(target_name.as_str(), tribute_name.as_str())
+                GameOutput::TributeAttackDied(tribute_name.as_str(), target_name.as_str())
                     .to_string(),
             );
-            let _ = apply_combat_results(
-                target,
-                self,
-                target.attributes.strength * 2,
-                GameOutput::TributeAttackLose(tribute_name.as_str(), target_name.as_str()),
-                &mut sub_events,
-                tuning,
-            );
-            for ev in sub_events.drain(..) {
-                detail_lines.push(ev.content);
-            }
-        }
-        AttackResult::AttackerWins => {
-            let _ = apply_combat_results(
-                self,
-                target,
-                self.attributes.strength,
-                GameOutput::TributeAttackWin(tribute_name.as_str(), target_name.as_str()),
-                &mut sub_events,
-                tuning,
-            );
-            for ev in sub_events.drain(..) {
-                detail_lines.push(ev.content);
-            }
-        }
-        AttackResult::AttackerWinsDecisively => {
-            let _ = apply_combat_results(
-                self,
-                target,
-                self.attributes.strength * 2,
-                GameOutput::TributeAttackWinExtra(tribute_name.as_str(), target_name.as_str()),
-                &mut sub_events,
-                tuning,
-            );
-            for ev in sub_events.drain(..) {
-                detail_lines.push(ev.content);
-            }
-        }
-        AttackResult::DefenderWins => {
-            let _ = apply_combat_results(
-                target,
-                self,
-                target.attributes.strength,
-                GameOutput::TributeAttackLose(tribute_name.as_str(), target_name.as_str()),
-                &mut sub_events,
-                tuning,
-            );
-            for ev in sub_events.drain(..) {
-                detail_lines.push(ev.content);
-            }
-        }
-        AttackResult::DefenderWinsDecisively => {
-            let _ = apply_combat_results(
-                target,
-                self,
-                target.attributes.strength * 2,
-                GameOutput::TributeAttackLoseExtra(tribute_name.as_str(), target_name.as_str()),
-                &mut sub_events,
-                tuning,
-            );
-            for ev in sub_events.drain(..) {
-                detail_lines.push(ev.content);
-            }
-        }
-        AttackResult::Miss => {
-            self.statistics.draws += 1;
-            target.statistics.draws += 1;
+
+            (
+                CombatOutcome::Killed,
+                AttackOutcome::Kill(target.clone(), self.clone()),
+            )
+        } else if target.attributes.health == 0 {
+            target.statistics.killed_by = Some(tribute_name.clone());
+            target.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
+            target.recently_killed_by = Some(self.id);
 
             detail_lines.push(
-                GameOutput::TributeAttackMiss(tribute_name.as_str(), target_name.as_str())
+                GameOutput::TributeAttackSuccessKill(tribute_name.as_str(), target_name.as_str())
                     .to_string(),
             );
 
-            let outcome = CombatOutcome::Stalemate;
-            let summary = format!("{} attacks {} ({:?})", self.name, target.name, outcome);
-            events.push(TaggedEvent::new(
-                summary,
-                MessagePayload::Combat(CombatEngagement {
-                    attacker: tref(self),
-                    target: tref(target),
-                    outcome,
-                    detail_lines,
-                }),
-            ));
-            events.push(TaggedEvent::new(
-                String::new(),
-                MessagePayload::CombatSwing(beat),
-            ));
+            (
+                CombatOutcome::Killed,
+                AttackOutcome::Kill(self.clone(), target.clone()),
+            )
+        } else {
+            detail_lines.push(
+                GameOutput::TributeAttackWound(tribute_name.as_str(), target_name.as_str())
+                    .to_string(),
+            );
+            (
+                CombatOutcome::Wounded,
+                AttackOutcome::Wound(self.clone(), target.clone()),
+            )
+        };
 
-            return AttackOutcome::Miss(self.clone(), target.clone());
-        }
-    };
+        let summary = format!("{} attacks {} ({:?})", self.name, target.name, outcome);
+        events.push(TaggedEvent::new(
+            summary,
+            MessagePayload::Combat(CombatEngagement {
+                attacker: tref(self),
+                target: tref(target),
+                outcome,
+                detail_lines,
+            }),
+        ));
 
-    for draft in &target_inflicts {
-        let resolution = target.try_acquire_affliction(draft.clone());
-        if matches!(
-            resolution,
-            crate::tributes::afflictions::AcquireResolution::Insert
-                | crate::tributes::afflictions::AcquireResolution::Upgrade(_)
-                | crate::tributes::afflictions::AcquireResolution::Supersede(_)
-        ) {
-            events.push(TaggedEvent::new(
-                String::new(),
-                MessagePayload::AfflictionAcquired {
-                    tribute_id: target.identifier.clone(),
-                    affliction: draft.kind.to_string(),
-                    severity: draft.severity.to_string(),
-                },
-            ));
-        }
+        events.push(TaggedEvent::new(
+            String::new(),
+            MessagePayload::CombatSwing(beat),
+        ));
+
+        attack_outcome
     }
-    for draft in &attacker_inflicts {
-        let resolution = self.try_acquire_affliction(draft.clone());
-        if matches!(
-            resolution,
-            crate::tributes::afflictions::AcquireResolution::Insert
-                | crate::tributes::afflictions::AcquireResolution::Upgrade(_)
-                | crate::tributes::afflictions::AcquireResolution::Supersede(_)
-        ) {
-            events.push(TaggedEvent::new(
-                String::new(),
-                MessagePayload::AfflictionAcquired {
-                    tribute_id: self.identifier.clone(),
-                    affliction: draft.kind.to_string(),
-                    severity: draft.severity.to_string(),
-                },
-            ));
-        }
-    }
-
-    let (outcome, attack_outcome) = if self.attributes.health == 0 {
-        self.statistics.killed_by = Some(target_name.clone());
-        self.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
-        self.recently_killed_by = Some(target.id);
-
-        detail_lines.push(
-            GameOutput::TributeAttackDied(tribute_name.as_str(), target_name.as_str())
-                .to_string(),
-        );
-
-        (
-            CombatOutcome::Killed,
-            AttackOutcome::Kill(target.clone(), self.clone()),
-        )
-    } else if target.attributes.health == 0 {
-        target.statistics.killed_by = Some(tribute_name.clone());
-        target.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
-        target.recently_killed_by = Some(self.id);
-
-        detail_lines.push(
-            GameOutput::TributeAttackSuccessKill(tribute_name.as_str(), target_name.as_str())
-                .to_string(),
-        );
-
-        (
-            CombatOutcome::Killed,
-            AttackOutcome::Kill(self.clone(), target.clone()),
-        )
-    } else {
-        detail_lines.push(
-            GameOutput::TributeAttackWound(tribute_name.as_str(), target_name.as_str())
-                .to_string(),
-        );
-        (
-            CombatOutcome::Wounded,
-            AttackOutcome::Wound(self.clone(), target.clone()),
-        )
-    };
-
-    let summary = format!("{} attacks {} ({:?})", self.name, target.name, outcome);
-    events.push(TaggedEvent::new(
-        summary,
-        MessagePayload::Combat(CombatEngagement {
-            attacker: tref(self),
-            target: tref(target),
-            outcome,
-            detail_lines,
-        }),
-    ));
-
-    events.push(TaggedEvent::new(
-        String::new(),
-        MessagePayload::CombatSwing(beat),
-    ));
-
-    attack_outcome
-}
 }

--- a/game/src/tributes/combat/mod.rs
+++ b/game/src/tributes/combat/mod.rs
@@ -14,7 +14,7 @@ pub mod stats;
 mod tests;
 
 // Re-exports for public API.
-pub use resolve::{AttackContestOutcome, attack_contest};
+pub use resolve::{AttackContestOutcome, attack_contest, resolve};
 pub use stats::update_stats;
 
 // Re-export for tests (pub(crate) items from resolve).
@@ -25,9 +25,7 @@ use crate::output::GameOutput;
 use crate::tributes::Tribute;
 use crate::tributes::actions::{AttackOutcome, AttackResult};
 use rand::prelude::*;
-use shared::combat_beat::{CombatBeat, StressReport, SwingOutcome};
-
-use resolve::{iref, tref};
+use resolve::tref;
 
 // ---------------------------------------------------------------------------
 // Tribute::attacks — the combat orchestrator
@@ -86,383 +84,272 @@ impl Tribute {
             return self.handle_self_attack(target, events, tuning);
         }
 
-        let tribute_name = self.name.clone();
-        let target_name = target.name.clone();
+    let tribute_name = self.name.clone();
+    let target_name = target.name.clone();
 
-        // Snapshot equipment refs at swing start so post-mutation values
-        // (e.g. broken items removed from inventory) don't pollute the beat.
-        let weapon_at_start = self
-            .items
-            .iter()
-            .rfind(|i| i.is_weapon() && i.current_durability > 0)
-            .map(iref);
-        let shield_at_start = target
-            .items
-            .iter()
-            .rfind(|i| i.is_defensive() && i.current_durability > 0)
-            .map(iref);
-        let attacker_ref_at_start = tref(self);
-        let target_ref_at_start = tref(target);
+    let mut detail_lines: Vec<String> = Vec::new();
+    let mut sub_events: Vec<TaggedEvent> = Vec::new();
 
-        // Local accumulator for prose lines that become this engagement's
-        // `detail_lines`. Helpers (`attack_contest`, `apply_combat_results`,
-        // `apply_violence_stress`) push `TaggedEvent`s into a sub-buffer; we
-        // then flatten their `.content` into `detail_lines`.
-        let mut detail_lines: Vec<String> = Vec::new();
-        let mut sub_events: Vec<TaggedEvent> = Vec::new();
+    let (contest, beat) = resolve(self, target, rng, &mut sub_events, tuning);
+    let result = contest.result;
+    let target_inflicts = contest.inflicts;
+    let attacker_inflicts = contest.attacker_inflicts;
 
-        // `self` is the attacker
-        let contest = attack_contest(self, target, rng, &mut sub_events, tuning);
-        let result = contest.result;
-        let wear_records = contest.wear;
-        let target_inflicts = contest.inflicts;
-        let attacker_inflicts = contest.attacker_inflicts;
-        // Stress applied to the swing's winner via apply_violence_stress; set
-        // by each branch below before mk_beat is invoked. Initialised to 0
-        // because Miss / fumble paths never apply stress.
-        #[allow(unused_assignments)]
-        let mut stress_damage: u32 = 0;
-        // Tracks which combatant absorbed the stress so the horrified line
-        // renders with the correct name. None = no horrified line.
-        let mut stressed: Option<TributeRef> = None;
-        let mk_beat =
-            |outcome: SwingOutcome, stress_damage: u32, stressed: Option<TributeRef>| CombatBeat {
-                attacker: attacker_ref_at_start.clone(),
-                target: target_ref_at_start.clone(),
-                weapon: weapon_at_start.clone(),
-                shield: shield_at_start.clone(),
-                wear: wear_records.clone(),
-                outcome,
-                stress: StressReport {
-                    stress_damage,
-                    stressed,
-                },
-                attacker_stamina_cost: tuning.stamina_cost_attacker,
-                target_stamina_cost: tuning.stamina_cost_target,
-            };
-        for ev in sub_events.drain(..) {
-            detail_lines.push(ev.content);
-        }
-
-        match result {
-            AttackResult::CriticalHit => {
-                // Triple damage on critical hit!
-                detail_lines.push(
-                    GameOutput::TributeCriticalHit(tribute_name.as_str(), target_name.as_str())
-                        .to_string(),
-                );
-                stress_damage = apply_combat_results(
-                    self,
-                    target,
-                    self.attributes.strength * 3, // triple damage
-                    GameOutput::TributeAttackWin(tribute_name.as_str(), target_name.as_str()),
-                    &mut sub_events,
-                    tuning,
-                );
-                if stress_damage > 0 {
-                    stressed = Some(tref(self));
-                }
-                for ev in sub_events.drain(..) {
-                    detail_lines.push(ev.content);
-                }
-            }
-            AttackResult::CriticalFumble => {
-                // Fumble! Attacker hurts themself. Standalone (non-engagement) event.
-                let fumble_content =
-                    GameOutput::TributeCriticalFumble(tribute_name.as_str()).to_string();
-                self.takes_physical_damage(5); // Fixed fumble damage
-                self.statistics.defeats += 1;
-
-                // If the attacker killed themselves with the fumble
-                if self.attributes.health == 0 {
-                    self.statistics.killed_by = Some("themselves (fumble)".to_string());
-                    self.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
-                    self.recently_killed_by = Some(self.id);
-                    let died_content =
-                        GameOutput::TributeAttackDied(tribute_name.as_str(), "themselves")
-                            .to_string();
-                    let combined = format!("{fumble_content} {died_content}");
-                    events.push(TaggedEvent::new(
-                        combined,
-                        MessagePayload::TributeKilled {
-                            victim: tref(self),
-                            killer: None,
-                            cause: "critical_fumble".into(),
-                        },
-                    ));
-                    let beat = mk_beat(SwingOutcome::FumbleDeath { self_damage: 5 }, 0, None);
-                    events.push(TaggedEvent::new(
-                        String::new(),
-                        MessagePayload::CombatSwing(beat),
-                    ));
-                    return AttackOutcome::Kill(target.clone(), self.clone());
-                }
-
-                events.push(TaggedEvent::new(
-                    fumble_content,
-                    MessagePayload::TributeWounded {
-                        victim: tref(self),
-                        attacker: None,
-                        hp_lost: 5,
-                    },
-                ));
-                let beat = mk_beat(SwingOutcome::FumbleSurvive { self_damage: 5 }, 0, None);
-                events.push(TaggedEvent::new(
-                    String::new(),
-                    MessagePayload::CombatSwing(beat),
-                ));
-                return AttackOutcome::Wound(self.clone(), target.clone());
-            }
-            AttackResult::PerfectBlock => {
-                // Perfect block! Defender counters
-                detail_lines.push(
-                    GameOutput::TributePerfectBlock(target_name.as_str(), tribute_name.as_str())
-                        .to_string(),
-                );
-                stress_damage = apply_combat_results(
-                    target,
-                    self,
-                    target.attributes.strength * 2, // double damage counter
-                    GameOutput::TributeAttackLose(tribute_name.as_str(), target_name.as_str()),
-                    &mut sub_events,
-                    tuning,
-                );
-                if stress_damage > 0 {
-                    stressed = Some(tref(target));
-                }
-                for ev in sub_events.drain(..) {
-                    detail_lines.push(ev.content);
-                }
-            }
-            AttackResult::AttackerWins => {
-                stress_damage = apply_combat_results(
-                    self,
-                    target,
-                    self.attributes.strength,
-                    GameOutput::TributeAttackWin(tribute_name.as_str(), target_name.as_str()),
-                    &mut sub_events,
-                    tuning,
-                );
-                if stress_damage > 0 {
-                    stressed = Some(tref(self));
-                }
-                for ev in sub_events.drain(..) {
-                    detail_lines.push(ev.content);
-                }
-            }
-            AttackResult::AttackerWinsDecisively => {
-                stress_damage = apply_combat_results(
-                    self,
-                    target,
-                    self.attributes.strength * 2, // double damage
-                    GameOutput::TributeAttackWinExtra(tribute_name.as_str(), target_name.as_str()),
-                    &mut sub_events,
-                    tuning,
-                );
-                if stress_damage > 0 {
-                    stressed = Some(tref(self));
-                }
-                for ev in sub_events.drain(..) {
-                    detail_lines.push(ev.content);
-                }
-            }
-            AttackResult::DefenderWins => {
-                stress_damage = apply_combat_results(
-                    target,
-                    self,
-                    target.attributes.strength,
-                    GameOutput::TributeAttackLose(tribute_name.as_str(), target_name.as_str()),
-                    &mut sub_events,
-                    tuning,
-                );
-                if stress_damage > 0 {
-                    stressed = Some(tref(target));
-                }
-                for ev in sub_events.drain(..) {
-                    detail_lines.push(ev.content);
-                }
-            }
-            AttackResult::DefenderWinsDecisively => {
-                stress_damage = apply_combat_results(
-                    target,
-                    self,
-                    target.attributes.strength * 2, // double damage
-                    GameOutput::TributeAttackLoseExtra(tribute_name.as_str(), target_name.as_str()),
-                    &mut sub_events,
-                    tuning,
-                );
-                if stress_damage > 0 {
-                    stressed = Some(tref(target));
-                }
-                for ev in sub_events.drain(..) {
-                    detail_lines.push(ev.content);
-                }
-            }
-            AttackResult::Miss => {
-                self.statistics.draws += 1;
-                target.statistics.draws += 1;
-
-                detail_lines.push(
-                    GameOutput::TributeAttackMiss(tribute_name.as_str(), target_name.as_str())
-                        .to_string(),
-                );
-
-                let outcome = CombatOutcome::Stalemate;
-                let summary = format!("{} attacks {} ({:?})", self.name, target.name, outcome);
-                events.push(TaggedEvent::new(
-                    summary,
-                    MessagePayload::Combat(CombatEngagement {
-                        attacker: tref(self),
-                        target: tref(target),
-                        outcome,
-                        detail_lines,
-                    }),
-                ));
-                let beat = mk_beat(SwingOutcome::Miss, 0, None);
-                events.push(TaggedEvent::new(
-                    String::new(),
-                    MessagePayload::CombatSwing(beat),
-                ));
-
-                return AttackOutcome::Miss(self.clone(), target.clone());
-            }
-        };
-
-        // Phase 3: apply affliction inflicts from the inflict table.
-        // Target inflicts go to the target; attacker inflicts (BreakMidSwing recoil) go to self.
-        for draft in &target_inflicts {
-            let resolution = target.try_acquire_affliction(draft.clone());
-            if matches!(
-                resolution,
-                crate::tributes::afflictions::AcquireResolution::Insert
-                    | crate::tributes::afflictions::AcquireResolution::Upgrade(_)
-                    | crate::tributes::afflictions::AcquireResolution::Supersede(_)
-            ) {
-                events.push(TaggedEvent::new(
-                    String::new(),
-                    MessagePayload::AfflictionAcquired {
-                        tribute_id: target.identifier.clone(),
-                        affliction: draft.kind.to_string(),
-                        severity: draft.severity.to_string(),
-                    },
-                ));
-            }
-        }
-        for draft in &attacker_inflicts {
-            let resolution = self.try_acquire_affliction(draft.clone());
-            if matches!(
-                resolution,
-                crate::tributes::afflictions::AcquireResolution::Insert
-                    | crate::tributes::afflictions::AcquireResolution::Upgrade(_)
-                    | crate::tributes::afflictions::AcquireResolution::Supersede(_)
-            ) {
-                events.push(TaggedEvent::new(
-                    String::new(),
-                    MessagePayload::AfflictionAcquired {
-                        tribute_id: self.identifier.clone(),
-                        affliction: draft.kind.to_string(),
-                        severity: draft.severity.to_string(),
-                    },
-                ));
-            }
-        }
-
-        // Capture damage applied this swing for the typed beat. Computed from
-        // the resolved branch so the beat's damage matches what was applied.
-        let swing_damage: u32 = match result {
-            AttackResult::CriticalHit => self.attributes.strength * 3,
-            AttackResult::AttackerWins => self.attributes.strength,
-            AttackResult::AttackerWinsDecisively => self.attributes.strength * 2,
-            AttackResult::PerfectBlock => target.attributes.strength * 2,
-            AttackResult::DefenderWins => target.attributes.strength,
-            AttackResult::DefenderWinsDecisively => target.attributes.strength * 2,
-            // Unreachable: handled above with early returns.
-            AttackResult::CriticalFumble | AttackResult::Miss => 0,
-        };
-
-        // Determine outcome and finalise. Prefer death over flee/wound.
-        let (outcome, attack_outcome) = if self.attributes.health == 0 {
-            // Target killed attacker
-            self.statistics.killed_by = Some(target_name.clone());
-            self.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
-            self.recently_killed_by = Some(target.id);
-
-            detail_lines.push(
-                GameOutput::TributeAttackDied(tribute_name.as_str(), target_name.as_str())
-                    .to_string(),
-            );
-
-            (
-                CombatOutcome::Killed,
-                AttackOutcome::Kill(target.clone(), self.clone()),
-            )
-        } else if target.attributes.health == 0 {
-            // Attacker killed Target
-            target.statistics.killed_by = Some(tribute_name.clone());
-            target.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
-            target.recently_killed_by = Some(self.id);
-
-            detail_lines.push(
-                GameOutput::TributeAttackSuccessKill(tribute_name.as_str(), target_name.as_str())
-                    .to_string(),
-            );
-
-            (
-                CombatOutcome::Killed,
-                AttackOutcome::Kill(self.clone(), target.clone()),
-            )
-        } else {
-            detail_lines.push(
-                GameOutput::TributeAttackWound(tribute_name.as_str(), target_name.as_str())
-                    .to_string(),
-            );
-            (
-                CombatOutcome::Wounded,
-                AttackOutcome::Wound(self.clone(), target.clone()),
-            )
-        };
-
-        let summary = format!("{} attacks {} ({:?})", self.name, target.name, outcome);
-        events.push(TaggedEvent::new(
-            summary,
-            MessagePayload::Combat(CombatEngagement {
-                attacker: tref(self),
-                target: tref(target),
-                outcome,
-                detail_lines,
-            }),
-        ));
-
-        // Map (AttackResult, post-resolution alive state) → typed SwingOutcome.
-        let swing_outcome = match (&attack_outcome, result) {
-            (AttackOutcome::Kill(winner, _loser), _) if winner.id == self.id => {
-                SwingOutcome::Kill {
-                    damage: swing_damage,
-                }
-            }
-            (AttackOutcome::Kill(_, _), _) => SwingOutcome::AttackerDied {
-                damage: swing_damage,
-            },
-            (AttackOutcome::Wound(_, _), AttackResult::CriticalHit) => {
-                SwingOutcome::CriticalHitWound {
-                    damage: swing_damage,
-                }
-            }
-            (AttackOutcome::Wound(_, _), AttackResult::PerfectBlock) => SwingOutcome::BlockWound {
-                damage: swing_damage,
-            },
-            (AttackOutcome::Wound(_, _), _) => SwingOutcome::Wound {
-                damage: swing_damage,
-            },
-            // Miss already returned above.
-            (AttackOutcome::Miss(_, _), _) => SwingOutcome::Miss,
-        };
-        let beat = mk_beat(swing_outcome, stress_damage, stressed);
-        events.push(TaggedEvent::new(
-            String::new(),
-            MessagePayload::CombatSwing(beat),
-        ));
-
-        attack_outcome
+    for ev in sub_events.drain(..) {
+        detail_lines.push(ev.content);
     }
+
+    match result {
+        AttackResult::CriticalHit => {
+            detail_lines.push(
+                GameOutput::TributeCriticalHit(tribute_name.as_str(), target_name.as_str())
+                    .to_string(),
+            );
+            let _ = apply_combat_results(
+                self,
+                target,
+                self.attributes.strength * 3,
+                GameOutput::TributeAttackWin(tribute_name.as_str(), target_name.as_str()),
+                &mut sub_events,
+                tuning,
+            );
+            for ev in sub_events.drain(..) {
+                detail_lines.push(ev.content);
+            }
+        }
+        AttackResult::CriticalFumble => {
+            let fumble_content =
+                GameOutput::TributeCriticalFumble(tribute_name.as_str()).to_string();
+            self.takes_physical_damage(5);
+            self.statistics.defeats += 1;
+
+            if self.attributes.health == 0 {
+                self.statistics.killed_by = Some("themselves (fumble)".to_string());
+                self.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
+                self.recently_killed_by = Some(self.id);
+                let died_content =
+                    GameOutput::TributeAttackDied(tribute_name.as_str(), "themselves")
+                        .to_string();
+                let combined = format!("{fumble_content} {died_content}");
+                events.push(TaggedEvent::new(
+                    combined,
+                    MessagePayload::TributeKilled {
+                        victim: tref(self),
+                        killer: None,
+                        cause: "critical_fumble".into(),
+                    },
+                ));
+                events.push(TaggedEvent::new(
+                    String::new(),
+                    MessagePayload::CombatSwing(beat),
+                ));
+                return AttackOutcome::Kill(target.clone(), self.clone());
+            }
+
+            events.push(TaggedEvent::new(
+                fumble_content,
+                MessagePayload::TributeWounded {
+                    victim: tref(self),
+                    attacker: None,
+                    hp_lost: 5,
+                },
+            ));
+            events.push(TaggedEvent::new(
+                String::new(),
+                MessagePayload::CombatSwing(beat),
+            ));
+            return AttackOutcome::Wound(self.clone(), target.clone());
+        }
+        AttackResult::PerfectBlock => {
+            detail_lines.push(
+                GameOutput::TributePerfectBlock(target_name.as_str(), tribute_name.as_str())
+                    .to_string(),
+            );
+            let _ = apply_combat_results(
+                target,
+                self,
+                target.attributes.strength * 2,
+                GameOutput::TributeAttackLose(tribute_name.as_str(), target_name.as_str()),
+                &mut sub_events,
+                tuning,
+            );
+            for ev in sub_events.drain(..) {
+                detail_lines.push(ev.content);
+            }
+        }
+        AttackResult::AttackerWins => {
+            let _ = apply_combat_results(
+                self,
+                target,
+                self.attributes.strength,
+                GameOutput::TributeAttackWin(tribute_name.as_str(), target_name.as_str()),
+                &mut sub_events,
+                tuning,
+            );
+            for ev in sub_events.drain(..) {
+                detail_lines.push(ev.content);
+            }
+        }
+        AttackResult::AttackerWinsDecisively => {
+            let _ = apply_combat_results(
+                self,
+                target,
+                self.attributes.strength * 2,
+                GameOutput::TributeAttackWinExtra(tribute_name.as_str(), target_name.as_str()),
+                &mut sub_events,
+                tuning,
+            );
+            for ev in sub_events.drain(..) {
+                detail_lines.push(ev.content);
+            }
+        }
+        AttackResult::DefenderWins => {
+            let _ = apply_combat_results(
+                target,
+                self,
+                target.attributes.strength,
+                GameOutput::TributeAttackLose(tribute_name.as_str(), target_name.as_str()),
+                &mut sub_events,
+                tuning,
+            );
+            for ev in sub_events.drain(..) {
+                detail_lines.push(ev.content);
+            }
+        }
+        AttackResult::DefenderWinsDecisively => {
+            let _ = apply_combat_results(
+                target,
+                self,
+                target.attributes.strength * 2,
+                GameOutput::TributeAttackLoseExtra(tribute_name.as_str(), target_name.as_str()),
+                &mut sub_events,
+                tuning,
+            );
+            for ev in sub_events.drain(..) {
+                detail_lines.push(ev.content);
+            }
+        }
+        AttackResult::Miss => {
+            self.statistics.draws += 1;
+            target.statistics.draws += 1;
+
+            detail_lines.push(
+                GameOutput::TributeAttackMiss(tribute_name.as_str(), target_name.as_str())
+                    .to_string(),
+            );
+
+            let outcome = CombatOutcome::Stalemate;
+            let summary = format!("{} attacks {} ({:?})", self.name, target.name, outcome);
+            events.push(TaggedEvent::new(
+                summary,
+                MessagePayload::Combat(CombatEngagement {
+                    attacker: tref(self),
+                    target: tref(target),
+                    outcome,
+                    detail_lines,
+                }),
+            ));
+            events.push(TaggedEvent::new(
+                String::new(),
+                MessagePayload::CombatSwing(beat),
+            ));
+
+            return AttackOutcome::Miss(self.clone(), target.clone());
+        }
+    };
+
+    for draft in &target_inflicts {
+        let resolution = target.try_acquire_affliction(draft.clone());
+        if matches!(
+            resolution,
+            crate::tributes::afflictions::AcquireResolution::Insert
+                | crate::tributes::afflictions::AcquireResolution::Upgrade(_)
+                | crate::tributes::afflictions::AcquireResolution::Supersede(_)
+        ) {
+            events.push(TaggedEvent::new(
+                String::new(),
+                MessagePayload::AfflictionAcquired {
+                    tribute_id: target.identifier.clone(),
+                    affliction: draft.kind.to_string(),
+                    severity: draft.severity.to_string(),
+                },
+            ));
+        }
+    }
+    for draft in &attacker_inflicts {
+        let resolution = self.try_acquire_affliction(draft.clone());
+        if matches!(
+            resolution,
+            crate::tributes::afflictions::AcquireResolution::Insert
+                | crate::tributes::afflictions::AcquireResolution::Upgrade(_)
+                | crate::tributes::afflictions::AcquireResolution::Supersede(_)
+        ) {
+            events.push(TaggedEvent::new(
+                String::new(),
+                MessagePayload::AfflictionAcquired {
+                    tribute_id: self.identifier.clone(),
+                    affliction: draft.kind.to_string(),
+                    severity: draft.severity.to_string(),
+                },
+            ));
+        }
+    }
+
+    let (outcome, attack_outcome) = if self.attributes.health == 0 {
+        self.statistics.killed_by = Some(target_name.clone());
+        self.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
+        self.recently_killed_by = Some(target.id);
+
+        detail_lines.push(
+            GameOutput::TributeAttackDied(tribute_name.as_str(), target_name.as_str())
+                .to_string(),
+        );
+
+        (
+            CombatOutcome::Killed,
+            AttackOutcome::Kill(target.clone(), self.clone()),
+        )
+    } else if target.attributes.health == 0 {
+        target.statistics.killed_by = Some(tribute_name.clone());
+        target.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
+        target.recently_killed_by = Some(self.id);
+
+        detail_lines.push(
+            GameOutput::TributeAttackSuccessKill(tribute_name.as_str(), target_name.as_str())
+                .to_string(),
+        );
+
+        (
+            CombatOutcome::Killed,
+            AttackOutcome::Kill(self.clone(), target.clone()),
+        )
+    } else {
+        detail_lines.push(
+            GameOutput::TributeAttackWound(tribute_name.as_str(), target_name.as_str())
+                .to_string(),
+        );
+        (
+            CombatOutcome::Wounded,
+            AttackOutcome::Wound(self.clone(), target.clone()),
+        )
+    };
+
+    let summary = format!("{} attacks {} ({:?})", self.name, target.name, outcome);
+    events.push(TaggedEvent::new(
+        summary,
+        MessagePayload::Combat(CombatEngagement {
+            attacker: tref(self),
+            target: tref(target),
+            outcome,
+            detail_lines,
+        }),
+    ));
+
+    events.push(TaggedEvent::new(
+        String::new(),
+        MessagePayload::CombatSwing(beat),
+    ));
+
+    attack_outcome
+}
 }

--- a/game/src/tributes/combat/resolve.rs
+++ b/game/src/tributes/combat/resolve.rs
@@ -405,6 +405,138 @@ pub fn attack_contest(
     }
 }
 
+// ---------------------------------------------------------------------------
+// resolve — pure combat resolution
+// ---------------------------------------------------------------------------
+
+/// Pure combat resolution. Calls `attack_contest()` and builds the
+/// `CombatBeat` from the result. Does NOT apply damage, stress, events,
+/// or afflictions — the caller handles those side effects.
+///
+/// Returns the contest outcome (result, wear, inflicts) and the fully
+/// constructed beat (including swing outcome and stress report).
+pub fn resolve(
+    attacker: &mut Tribute,
+    defender: &mut Tribute,
+    rng: &mut impl Rng,
+    sub_events: &mut Vec<TaggedEvent>,
+    tuning: &crate::tributes::combat_tuning::CombatTuning,
+) -> (AttackContestOutcome, CombatBeat) {
+    // Snapshot equipment before attack_contest mutates durability / removes items.
+    let weapon = attacker
+        .items
+        .iter()
+        .rfind(|i| i.is_weapon() && i.current_durability > 0)
+        .map(iref);
+    let shield = defender
+        .items
+        .iter()
+        .rfind(|i| i.is_defensive() && i.current_durability > 0)
+        .map(iref);
+
+    // Run the attack contest (dice rolling, equipment wear, inflict lookup).
+    let contest = attack_contest(attacker, defender, rng, sub_events, tuning);
+    let result = &contest.result;
+
+    // Compute damage based on result.
+    let damage: u32 = match result {
+        AttackResult::CriticalHit => attacker.attributes.strength * 3,
+        AttackResult::AttackerWins => attacker.attributes.strength,
+        AttackResult::AttackerWinsDecisively => attacker.attributes.strength * 2,
+        AttackResult::PerfectBlock => defender.attributes.strength * 2,
+        AttackResult::DefenderWins => defender.attributes.strength,
+        AttackResult::DefenderWinsDecisively => defender.attributes.strength * 2,
+        AttackResult::CriticalFumble | AttackResult::Miss => 0,
+    };
+
+    // Determine SwingOutcome from result and pre-damage health.
+    let swing_outcome = match result {
+        AttackResult::Miss => SwingOutcome::Miss,
+        AttackResult::CriticalFumble => {
+            if attacker.attributes.health <= 5 {
+                SwingOutcome::FumbleDeath { self_damage: 5 }
+            } else {
+                SwingOutcome::FumbleSurvive { self_damage: 5 }
+            }
+        }
+        _ => {
+            let is_counter = matches!(
+                result,
+                AttackResult::PerfectBlock
+                    | AttackResult::DefenderWins
+                    | AttackResult::DefenderWinsDecisively
+            );
+            let victim_health = if is_counter {
+                attacker.attributes.health
+            } else {
+                defender.attributes.health
+            };
+
+            if victim_health <= damage {
+                if is_counter {
+                    SwingOutcome::AttackerDied { damage }
+                } else {
+                    SwingOutcome::Kill { damage }
+                }
+            } else {
+                match result {
+                    AttackResult::CriticalHit => SwingOutcome::CriticalHitWound { damage },
+                    AttackResult::PerfectBlock => SwingOutcome::BlockWound { damage },
+                    _ => SwingOutcome::Wound { damage },
+                }
+            }
+        }
+    };
+
+    // Compute stress damage (pure calculation matching apply_violence_stress).
+    let stress_damage = if matches!(result, AttackResult::Miss | AttackResult::CriticalFumble) {
+        0
+    } else {
+        let (winner_kills, winner_wins, winner_sanity) = match result {
+            AttackResult::CriticalHit
+            | AttackResult::AttackerWins
+            | AttackResult::AttackerWinsDecisively => (
+                attacker.statistics.kills,
+                attacker.statistics.wins + 1,
+                attacker.attributes.sanity,
+            ),
+            _ => (
+                defender.statistics.kills,
+                defender.statistics.wins + 1,
+                defender.attributes.sanity,
+            ),
+        };
+        calculate_violence_stress(winner_kills, winner_wins, winner_sanity, tuning)
+    };
+    let stressed = if stress_damage > 0 {
+        Some(match result {
+            AttackResult::CriticalHit
+            | AttackResult::AttackerWins
+            | AttackResult::AttackerWinsDecisively => tref(attacker),
+            _ => tref(defender),
+        })
+    } else {
+        None
+    };
+
+    let beat = CombatBeat {
+        attacker: tref(attacker),
+        target: tref(defender),
+        weapon,
+        shield,
+        wear: contest.wear.clone(),
+        outcome: swing_outcome,
+        stress: StressReport {
+            stress_damage,
+            stressed,
+        },
+        attacker_stamina_cost: tuning.stamina_cost_attacker,
+        target_stamina_cost: tuning.stamina_cost_target,
+    };
+
+    (contest, beat)
+}
+
 /// Map an AttackResult to the inflict table's severity band.
 fn result_to_hit_severity(result: &AttackResult) -> HitSeverity {
     match result {


### PR DESCRIPTION
## Summary
- Extract pure computation core from Tribute::attacks() into standalone resolve() function
- resolve() returns (AttackContestOutcome, CombatBeat) without side effects
- attacks() now calls resolve() and handles damage, stats, events, afflictions

## Changes
- game/src/tributes/combat/resolve.rs: add pub fn resolve()
- game/src/tributes/combat/mod.rs: refactor attacks() to use resolve()

## Verification
- cargo test --package game (snapshot tests unchanged)