### PR TITLE
refactor(shared): introduce DeathCause enum, retire string constants

### DIFF
--- a/announcers/examples/sample-prompt.rs
+++ b/announcers/examples/sample-prompt.rs
@@ -78,7 +78,7 @@ async fn main() {
                     identifier: "id-Cato".into(),
                     name: "Cato".into(),
                 }),
-                cause: "combat".into(),
+                cause: shared::afflictions::DeathCause::Combat,
             },
         },
         shared::messages::GameMessage {

--- a/announcers/src/broadcast.rs
+++ b/announcers/src/broadcast.rs
@@ -85,7 +85,7 @@ impl BroadcastPackageBuilder {
                     "killer": killer.as_ref().map(|k| {
                         serde_json::json!({ "id": k.identifier, "name": k.name })
                     }),
-                    "cause": cause,
+                    "cause": cause.to_string(),
                 });
                 Some(EventLine {
                     kind: EventKind::Death,
@@ -488,7 +488,7 @@ mod tests {
         let msg = make_msg(MessagePayload::TributeKilled {
             victim: tr("Katniss"),
             killer: Some(tr("Cato")),
-            cause: "combat".into(),
+            cause: shared::afflictions::DeathCause::Combat,
         });
         let line = BroadcastPackageBuilder::classify_event(&msg).unwrap();
         assert_eq!(line.kind, EventKind::Death);
@@ -612,7 +612,7 @@ mod tests {
             make_msg(MessagePayload::TributeKilled {
                 victim: tr("Marvel"),
                 killer: Some(tr("Katniss")),
-                cause: "combat".into(),
+                cause: shared::afflictions::DeathCause::Combat,
             }),
             make_msg(MessagePayload::TributeMoved {
                 tribute: tr("Katniss"),
@@ -642,7 +642,7 @@ mod tests {
         let msg = make_msg(MessagePayload::TributeKilled {
             victim: tr("Peeta"),
             killer: None,
-            cause: "starvation".into(),
+            cause: shared::afflictions::DeathCause::Starvation,
         });
         let line = BroadcastPackageBuilder::classify_event(&msg).unwrap();
         assert_eq!(line.kind, EventKind::Death);

--- a/announcers/src/history.rs
+++ b/announcers/src/history.rs
@@ -735,7 +735,7 @@ mod tests {
         h.update(&[make_msg(MessagePayload::TributeKilled {
             victim: tr("Katniss"),
             killer: None,
-            cause: "starvation".into(),
+            cause: shared::afflictions::DeathCause::Starvation,
         })]);
         let d = h.get("id-Katniss").unwrap();
         assert_eq!(d.status, "deceased");

--- a/announcers/tests/integration.rs
+++ b/announcers/tests/integration.rs
@@ -139,7 +139,7 @@ async fn full_pipeline_from_roster_to_package() {
         make_msg(MessagePayload::TributeKilled {
             victim: tr("Peeta"),
             killer: Some(tr("Cato")),
-            cause: "combat".into(),
+            cause: shared::afflictions::DeathCause::Combat,
         }),
         make_msg(MessagePayload::TributeMoved {
             tribute: tr("Katniss"),
@@ -206,7 +206,7 @@ async fn histories_accumulate_across_phases() {
     let phase1 = vec![make_msg(MessagePayload::TributeKilled {
         victim: tr("Peeta"),
         killer: Some(tr("Cato")),
-        cause: "combat".into(),
+        cause: shared::afflictions::DeathCause::Combat,
     })];
     histories.update(&phase1);
 
@@ -264,17 +264,17 @@ async fn package_includes_kill_leaders() {
         make_msg(MessagePayload::TributeKilled {
             victim: tr("Peeta"),
             killer: Some(tr("Cato")),
-            cause: "combat".into(),
+            cause: shared::afflictions::DeathCause::Combat,
         }),
         make_msg(MessagePayload::TributeKilled {
             victim: tr("Rue"),
             killer: Some(tr("Cato")),
-            cause: "combat".into(),
+            cause: shared::afflictions::DeathCause::Combat,
         }),
         make_msg(MessagePayload::TributeKilled {
             victim: tr("Clove"),
             killer: Some(tr("Katniss")),
-            cause: "combat".into(),
+            cause: shared::afflictions::DeathCause::Combat,
         }),
     ];
 
@@ -326,7 +326,7 @@ async fn generate_commentary_integration() {
     histories.update(&[make_msg(MessagePayload::TributeKilled {
         victim: tr("Peeta"),
         killer: Some(tr("Katniss")),
-        cause: "combat".into(),
+        cause: shared::afflictions::DeathCause::Combat,
     })]);
 
     let header = GameStateSnapshot {
@@ -375,7 +375,7 @@ async fn killing_spree_streak_rules() {
     histories.update(&[make_msg(MessagePayload::TributeKilled {
         victim: tr("Peeta"),
         killer: Some(tr("Cato")),
-        cause: "combat".into(),
+        cause: shared::afflictions::DeathCause::Combat,
     })]);
     let d = histories.digests();
     assert_eq!(d.iter().find(|d| d.name == "Cato").unwrap().kill_streak, 1);
@@ -393,7 +393,7 @@ async fn killing_spree_streak_rules() {
     histories.update(&[make_msg(MessagePayload::TributeKilled {
         victim: tr("Rue"),
         killer: Some(tr("Cato")),
-        cause: "combat".into(),
+        cause: shared::afflictions::DeathCause::Combat,
     })]);
     let d = histories.digests();
     assert_eq!(d.iter().find(|d| d.name == "Cato").unwrap().kill_streak, 2);
@@ -416,7 +416,7 @@ async fn killing_spree_streak_rules() {
     histories.update(&[make_msg(MessagePayload::TributeKilled {
         victim: tr("Marvel"),
         killer: Some(tr("Katniss")),
-        cause: "combat".into(),
+        cause: shared::afflictions::DeathCause::Combat,
     })]);
     let d = histories.digests();
     assert_eq!(
@@ -436,7 +436,7 @@ async fn spree_milestone_and_break_events() {
     histories.update(&[make_msg(MessagePayload::TributeKilled {
         victim: tr("Peeta"),
         killer: Some(tr("Cato")),
-        cause: "combat".into(),
+        cause: shared::afflictions::DeathCause::Combat,
     })]);
     let d = histories.digests();
     let cato = d.iter().find(|d| d.name == "Cato").unwrap();
@@ -446,7 +446,7 @@ async fn spree_milestone_and_break_events() {
     histories.update(&[make_msg(MessagePayload::TributeKilled {
         victim: tr("Rue"),
         killer: Some(tr("Cato")),
-        cause: "combat".into(),
+        cause: shared::afflictions::DeathCause::Combat,
     })]);
     let d = histories.digests();
     let cato = d.iter().find(|d| d.name == "Cato").unwrap();
@@ -458,12 +458,12 @@ async fn spree_milestone_and_break_events() {
         make_msg(MessagePayload::TributeKilled {
             victim: tr("Clove"),
             killer: Some(tr("Cato")),
-            cause: "combat".into(),
+            cause: shared::afflictions::DeathCause::Combat,
         }),
         make_msg(MessagePayload::TributeKilled {
             victim: tr("Marvel"),
             killer: Some(tr("Cato")),
-            cause: "combat".into(),
+            cause: shared::afflictions::DeathCause::Combat,
         }),
     ]);
     let d = histories.digests();
@@ -535,7 +535,7 @@ async fn permanent_highlights() {
         histories.update(&[make_msg(MessagePayload::TributeKilled {
             victim: tr(&format!("Victim{i}")),
             killer: Some(tr("Cato")),
-            cause: "combat".into(),
+            cause: shared::afflictions::DeathCause::Combat,
         })]);
     }
 

--- a/api/tests/commentary_tests.rs
+++ b/api/tests/commentary_tests.rs
@@ -100,7 +100,7 @@ async fn generate_commentary_pipeline() {
     let events = vec![make_msg(MessagePayload::TributeKilled {
         victim: tr("Peeta"),
         killer: Some(tr("Cato")),
-        cause: "combat".into(),
+        cause: shared::afflictions::DeathCause::Combat,
     })];
 
     let histories = vec![
@@ -162,7 +162,7 @@ fn broadcast_package_with_leaders_and_sprees() {
     let events = vec![make_msg(MessagePayload::TributeKilled {
         victim: tr("Marvel"),
         killer: Some(tr("Cato")),
-        cause: "combat".into(),
+        cause: shared::afflictions::DeathCause::Combat,
     })];
 
     let package = announcers::BroadcastPackageBuilder::build(header, &events, vec![]);

--- a/game/src/games/cycle.rs
+++ b/game/src/games/cycle.rs
@@ -157,7 +157,7 @@ impl Game {
                     apply_dehydration_drain, apply_starvation_drain, hunger_band, thirst_band,
                     tick_survival,
                 };
-                use shared::messages::{CAUSE_DEHYDRATION, CAUSE_STARVATION};
+                use shared::afflictions::DeathCause;
 
                 let weather = current_weather();
                 let phase_index: u32 = self.day.unwrap_or(1) * 2 + u32::from(!day);
@@ -271,7 +271,7 @@ impl Game {
                                         Some(MessagePayload::TributeKilled {
                                             victim: tref.clone(),
                                             killer: None,
-                                            cause: kind.to_string(),
+                                            cause: shared::afflictions::DeathCause::Affliction(kind.clone()),
                                         }),
                                         None,
                                     ));
@@ -386,9 +386,9 @@ impl Game {
                 // tick.
                 if tribute.attributes.health == 0 && (hp_lost_starv > 0 || hp_lost_dehy > 0) {
                     let cause = if hp_lost_dehy > 0 {
-                        CAUSE_DEHYDRATION
+                        DeathCause::Dehydration
                     } else {
-                        CAUSE_STARVATION
+                        DeathCause::Starvation
                     };
                     let line = format!("{} succumbs to {}.", tribute.name, cause);
                     collected_events.push((
@@ -398,7 +398,7 @@ impl Game {
                         Some(MessagePayload::TributeKilled {
                             victim: tref,
                             killer: None,
-                            cause: cause.to_string(),
+                            cause,
                         }),
                         None,
                     ));

--- a/game/src/games/cycle.rs
+++ b/game/src/games/cycle.rs
@@ -271,7 +271,9 @@ impl Game {
                                         Some(MessagePayload::TributeKilled {
                                             victim: tref.clone(),
                                             killer: None,
-                                            cause: shared::afflictions::DeathCause::Affliction(kind.clone()),
+                                            cause: shared::afflictions::DeathCause::Affliction(
+                                                kind.clone(),
+                                            ),
                                         }),
                                         None,
                                     ));

--- a/game/src/games/mod.rs
+++ b/game/src/games/mod.rs
@@ -699,8 +699,31 @@ impl Game {
                     let name = tribute.name.clone();
                     let id = tribute.identifier.clone();
                     tribute.attributes.health = 0;
-                    let cause = most_severe_event.to_string();
-                    tribute.statistics.killed_by = Some(cause.clone());
+                    let cause = match most_severe_event {
+                        crate::areas::events::AreaEvent::Wildfire => {
+                            shared::afflictions::DeathCause::Fire
+                        }
+                        crate::areas::events::AreaEvent::Flood
+                        | crate::areas::events::AreaEvent::Sinkhole => {
+                            shared::afflictions::DeathCause::Drowning
+                        }
+                        crate::areas::events::AreaEvent::Avalanche
+                        | crate::areas::events::AreaEvent::Rockslide => {
+                            shared::afflictions::DeathCause::Hazard(
+                                shared::afflictions::HazardKind::FallingDebris,
+                            )
+                        }
+                        crate::areas::events::AreaEvent::Earthquake
+                        | crate::areas::events::AreaEvent::Landslide => {
+                            shared::afflictions::DeathCause::Hazard(
+                                shared::afflictions::HazardKind::Other,
+                            )
+                        }
+                        _ => shared::afflictions::DeathCause::Hazard(
+                            shared::afflictions::HazardKind::Other,
+                        ),
+                    };
+                    tribute.statistics.killed_by = Some(cause.to_string());
                     tribute.status = crate::tributes::statuses::TributeStatus::RecentlyDead;
                     (name, id, cause)
                 };
@@ -792,8 +815,30 @@ impl Game {
                 // Apply results
                 if !result.survived {
                     tribute.attributes.health = 0;
-                    let cause = most_severe_event.to_string();
-                    tribute.statistics.killed_by = Some(cause.clone());
+                    let cause = match most_severe_event {
+                        crate::areas::events::AreaEvent::Wildfire => {
+                            shared::afflictions::DeathCause::Fire
+                        }
+                        crate::areas::events::AreaEvent::Flood => {
+                            shared::afflictions::DeathCause::Drowning
+                        }
+                        crate::areas::events::AreaEvent::Avalanche
+                        | crate::areas::events::AreaEvent::Rockslide => {
+                            shared::afflictions::DeathCause::Hazard(
+                                shared::afflictions::HazardKind::FallingDebris,
+                            )
+                        }
+                        crate::areas::events::AreaEvent::Earthquake
+                        | crate::areas::events::AreaEvent::Landslide => {
+                            shared::afflictions::DeathCause::Hazard(
+                                shared::afflictions::HazardKind::Other,
+                            )
+                        }
+                        _ => shared::afflictions::DeathCause::Hazard(
+                            shared::afflictions::HazardKind::Other,
+                        ),
+                    };
+                    tribute.statistics.killed_by = Some(cause.to_string());
                     // Mark as RecentlyDead so the end-of-cycle announcement
                     // and the alliance-cascade pipeline both pick this death
                     // up. Without this, env-killed tributes were silently

--- a/game/src/games/tests.rs
+++ b/game/src/games/tests.rs
@@ -1365,7 +1365,7 @@ fn survival_tick_increments_hunger_and_thirst_per_phase() {
 #[test]
 fn survival_tick_routes_dehydration_death_through_tribute_killed() {
     use crate::messages::MessagePayload;
-    use shared::messages::CAUSE_DEHYDRATION;
+    use shared::afflictions::DeathCause;
     let mut a = Tribute::new("Doomed".to_string(), Some(1), None);
     // Already at the dehydrated band with 1 HP and a high
     // dehydration drain step so the next tick definitely lands fatal
@@ -1378,7 +1378,7 @@ fn survival_tick_routes_dehydration_death_through_tribute_killed() {
     let _ = game.run_phase(crate::messages::Phase::Day);
     let killed = game.messages.iter().any(|m| {
         matches!(&m.payload,
-            MessagePayload::TributeKilled { cause, .. } if cause == CAUSE_DEHYDRATION)
+            MessagePayload::TributeKilled { cause, .. } if *cause == DeathCause::Dehydration)
     });
     assert!(killed, "expected a TributeKilled with cause=dehydration");
 }

--- a/game/src/sponsors/mod.rs
+++ b/game/src/sponsors/mod.rs
@@ -490,7 +490,9 @@ mod tests {
         let payload = MessagePayload::TributeKilled {
             victim: tref("v"),
             killer: None,
-            cause: shared::afflictions::DeathCause::Hazard(shared::afflictions::HazardKind::FallingDebris),
+            cause: shared::afflictions::DeathCause::Hazard(
+                shared::afflictions::HazardKind::FallingDebris,
+            ),
         };
         let events = translate(&payload, &ctx);
         assert_eq!(events.len(), 1);

--- a/game/src/sponsors/mod.rs
+++ b/game/src/sponsors/mod.rs
@@ -477,7 +477,7 @@ mod tests {
         let payload = MessagePayload::TributeKilled {
             victim: tref("v"),
             killer: Some(tref("k")),
-            cause: "spear".into(),
+            cause: shared::afflictions::DeathCause::Tribute("spear".into()),
         };
         let events = translate(&payload, &ctx);
         assert_eq!(events.len(), 2);
@@ -490,7 +490,7 @@ mod tests {
         let payload = MessagePayload::TributeKilled {
             victim: tref("v"),
             killer: None,
-            cause: "fall".into(),
+            cause: shared::afflictions::DeathCause::Hazard(shared::afflictions::HazardKind::FallingDebris),
         };
         let events = translate(&payload, &ctx);
         assert_eq!(events.len(), 1);

--- a/game/src/tributes/afflictions/phobia/triggers.rs
+++ b/game/src/tributes/afflictions/phobia/triggers.rs
@@ -247,7 +247,7 @@ mod tests {
                     name: "Victim".to_string(),
                 },
                 killer: None,
-                cause: "combat".into(),
+                cause: shared::afflictions::DeathCause::Combat,
             },
         }];
         let ctx = make_context(&area, false, &[], &messages);

--- a/game/src/tributes/afflictions/producers/shared.rs
+++ b/game/src/tributes/afflictions/producers/shared.rs
@@ -18,8 +18,8 @@ pub(super) struct TraumaEvent {
     pub(super) tribute_name: String,
     pub(super) source: TraumaSource,
     pub(super) severity: Severity,
-    /// Raw cause string for phobia co-acquire stub.
-    pub(super) cause_hint: String,
+    /// Death cause for phobia co-acquire stub.
+    pub(super) cause_hint: DeathCause,
 }
 
 /// Message data collected during trauma application, pushed afterwards.
@@ -121,18 +121,16 @@ fn format_trauma_content(name: &str, acquisition: &TraumaAcquisition) -> String 
     }
 }
 
-/// Map a killer reference and cause string to a `DeathCause`.
-pub(super) fn map_cause_to_death_cause(killer: Option<&TributeRef>, cause: &str) -> DeathCause {
+/// Map a killer reference and cause to a `DeathCause`. If a killer is present,
+/// their tribute identity takes priority; otherwise the original cause is returned.
+pub(super) fn map_cause_to_death_cause(
+    killer: Option<&TributeRef>,
+    cause: &DeathCause,
+) -> DeathCause {
     if let Some(k) = killer {
         return DeathCause::Tribute(k.identifier.clone());
     }
-    match cause.to_lowercase().as_str() {
-        "fire" | "wildfire" => DeathCause::Fire,
-        "drowning" | "flood" => DeathCause::Drowning,
-        "starvation" => DeathCause::Starvation,
-        "dehydration" => DeathCause::Dehydration,
-        _ => DeathCause::Unknown,
-    }
+    cause.clone()
 }
 
 /// Stub for phobia co-acquisition. No-op until phobia PR lands.
@@ -140,6 +138,6 @@ pub(super) fn map_cause_to_death_cause(killer: Option<&TributeRef>, cause: &str)
 /// TODO(phobia-pr1): wire to `try_acquire_phobia` when the phobia affliction
 /// system is implemented.
 #[allow(dead_code)]
-fn try_co_acquire_phobia(_tribute: &mut Tribute, _cause: &str) {
+fn try_co_acquire_phobia(_tribute: &mut Tribute, _cause: &DeathCause) {
     // No-op stub. Will trigger phobia acquisition once the phobia system exists.
 }

--- a/game/src/tributes/afflictions/producers/survive_betrayal.rs
+++ b/game/src/tributes/afflictions/producers/survive_betrayal.rs
@@ -36,7 +36,7 @@ pub(super) fn produce_survive_betrayal(game: &mut Game, phase: Phase) {
                 by: betrayer.identifier.clone(),
             },
             severity: Severity::Moderate,
-            cause_hint: betrayer.name.clone(),
+            cause_hint: shared::afflictions::DeathCause::Tribute(betrayer.name.clone()),
         });
     }
 

--- a/game/src/tributes/afflictions/producers/survive_near_death.rs
+++ b/game/src/tributes/afflictions/producers/survive_near_death.rs
@@ -45,7 +45,7 @@ pub(super) fn produce_survive_near_death(game: &mut Game, phase: Phase) {
                 tribute_name: tribute.name.clone(),
                 source: TraumaSource::NearDeath { cause: death_cause },
                 severity: Severity::Moderate,
-                cause_hint: String::new(),
+                cause_hint: shared::afflictions::DeathCause::Unknown,
             });
         }
     }

--- a/game/src/tributes/afflictions/producers/tests.rs
+++ b/game/src/tributes/afflictions/producers/tests.rs
@@ -29,7 +29,7 @@ fn make_killed_msg(victim_id: &str, victim_name: &str, phase: Phase) -> GameMess
                 name: victim_name.into(),
             },
             killer: None,
-            cause: "combat".into(),
+            cause: shared::afflictions::DeathCause::Combat,
         },
     )
 }
@@ -380,26 +380,26 @@ fn map_cause_to_death_cause_killer_takes_priority() {
         identifier: "tributes:killer".into(),
         name: "Killer".into(),
     };
-    let cause = map_cause_to_death_cause(Some(&killer), "fire");
+    let cause = map_cause_to_death_cause(Some(&killer), &DeathCause::Fire);
     assert!(matches!(cause, DeathCause::Tribute(id) if id == "tributes:killer"));
 }
 
 #[test]
-fn map_cause_to_death_cause_string_fallback() {
+fn map_cause_to_death_cause_passthrough() {
     assert!(matches!(
-        map_cause_to_death_cause(None, "fire"),
+        map_cause_to_death_cause(None, &DeathCause::Fire),
         DeathCause::Fire
     ));
     assert!(matches!(
-        map_cause_to_death_cause(None, "drowning"),
+        map_cause_to_death_cause(None, &DeathCause::Drowning),
         DeathCause::Drowning
     ));
     assert!(matches!(
-        map_cause_to_death_cause(None, "starvation"),
+        map_cause_to_death_cause(None, &DeathCause::Starvation),
         DeathCause::Starvation
     ));
     assert!(matches!(
-        map_cause_to_death_cause(None, "unknown_cause"),
+        map_cause_to_death_cause(None, &DeathCause::Unknown),
         DeathCause::Unknown
     ));
 }

--- a/game/src/tributes/afflictions/producers/witness_ally_death.rs
+++ b/game/src/tributes/afflictions/producers/witness_ally_death.rs
@@ -9,7 +9,7 @@ use super::shared::{TraumaEvent, apply_trauma_events, map_cause_to_death_cause};
 
 pub(super) fn produce_witness_ally_death(game: &mut Game, phase: Phase) {
     // Phase 1: collect killed tributes with area info
-    let killed: Vec<(String, Area, uuid::Uuid, Option<TributeRef>, String)> = game
+    let killed: Vec<(String, Area, uuid::Uuid, Option<TributeRef>, shared::afflictions::DeathCause)> = game
         .messages
         .iter()
         .filter(|m| m.phase == phase)

--- a/game/src/tributes/afflictions/producers/witness_ally_death.rs
+++ b/game/src/tributes/afflictions/producers/witness_ally_death.rs
@@ -9,7 +9,13 @@ use super::shared::{TraumaEvent, apply_trauma_events, map_cause_to_death_cause};
 
 pub(super) fn produce_witness_ally_death(game: &mut Game, phase: Phase) {
     // Phase 1: collect killed tributes with area info
-    let killed: Vec<(String, Area, uuid::Uuid, Option<TributeRef>, shared::afflictions::DeathCause)> = game
+    let killed: Vec<(
+        String,
+        Area,
+        uuid::Uuid,
+        Option<TributeRef>,
+        shared::afflictions::DeathCause,
+    )> = game
         .messages
         .iter()
         .filter(|m| m.phase == phase)

--- a/game/src/tributes/afflictions/producers/witness_mass_casualty.rs
+++ b/game/src/tributes/afflictions/producers/witness_mass_casualty.rs
@@ -54,7 +54,7 @@ pub(super) fn produce_witness_mass_casualty(game: &mut Game, phase: Phase) {
                         deaths_this_cycle: *death_count,
                     },
                     severity,
-                    cause_hint: String::new(),
+                    cause_hint: shared::afflictions::DeathCause::Unknown,
                 });
             }
         }

--- a/game/src/tributes/combat/mod.rs
+++ b/game/src/tributes/combat/mod.rs
@@ -187,7 +187,7 @@ impl Tribute {
                         MessagePayload::TributeKilled {
                             victim: tref(self),
                             killer: None,
-                            cause: "critical_fumble".into(),
+                            cause: shared::afflictions::DeathCause::CriticalFumble,
                         },
                     ));
                     let beat = mk_beat(SwingOutcome::FumbleDeath { self_damage: 5 }, 0, None);

--- a/game/src/tributes/combat/resolve.rs
+++ b/game/src/tributes/combat/resolve.rs
@@ -598,7 +598,7 @@ impl Tribute {
                 MessagePayload::TributeKilled {
                     victim: tref(self),
                     killer: None,
-                    cause: "suicide".into(),
+                    cause: shared::afflictions::DeathCause::Suicide,
                 },
             ));
             let mut beat = new_beat(self, target, SwingOutcome::Suicide { damage }, tuning);

--- a/game/src/tributes/lifecycle/status.rs
+++ b/game/src/tributes/lifecycle/status.rs
@@ -130,6 +130,21 @@ impl Tribute {
             let killer = self.status.clone();
             let line = GameOutput::TributeDiesFromStatus(self.name.as_str(), &killer.to_string())
                 .to_string();
+            let cause = match &killer {
+                TributeStatus::Mauled(animal) => {
+                    let beast = match animal {
+                        crate::threats::animals::Animal::Wolf
+                        | crate::threats::animals::Animal::Hyena => {
+                            shared::afflictions::BeastKind::Wolf
+                        }
+                        crate::threats::animals::Animal::Bear => shared::afflictions::BeastKind::Bear,
+                        crate::threats::animals::Animal::Snake => shared::afflictions::BeastKind::Snake,
+                        _ => shared::afflictions::BeastKind::Other,
+                    };
+                    shared::afflictions::DeathCause::Beast(beast)
+                }
+                _ => shared::afflictions::DeathCause::Unknown,
+            };
             events.push(TaggedEvent::new(
                 line,
                 MessagePayload::TributeKilled {
@@ -138,7 +153,7 @@ impl Tribute {
                         name: self.name.clone(),
                     },
                     killer: None,
-                    cause: killer.to_string(),
+                    cause,
                 },
             ));
             self.statistics.killed_by = Some(killer.to_string());

--- a/game/src/tributes/lifecycle/status.rs
+++ b/game/src/tributes/lifecycle/status.rs
@@ -137,8 +137,12 @@ impl Tribute {
                         | crate::threats::animals::Animal::Hyena => {
                             shared::afflictions::BeastKind::Wolf
                         }
-                        crate::threats::animals::Animal::Bear => shared::afflictions::BeastKind::Bear,
-                        crate::threats::animals::Animal::Snake => shared::afflictions::BeastKind::Snake,
+                        crate::threats::animals::Animal::Bear => {
+                            shared::afflictions::BeastKind::Bear
+                        }
+                        crate::threats::animals::Animal::Snake => {
+                            shared::afflictions::BeastKind::Snake
+                        }
                         _ => shared::afflictions::BeastKind::Other,
                     };
                     shared::afflictions::DeathCause::Beast(beast)

--- a/game/src/tributes/mod.rs
+++ b/game/src/tributes/mod.rs
@@ -539,7 +539,7 @@ impl Tribute {
                         name: self.name.clone(),
                     },
                     killer: None,
-                    cause: "untracked".into(),
+                    cause: shared::afflictions::DeathCause::Unknown,
                 },
             ));
             return;
@@ -790,7 +790,7 @@ impl Tribute {
                                 name: self.name.clone(),
                             },
                             killer: None,
-                            cause: "suicide".into(),
+                            cause: shared::afflictions::DeathCause::Suicide,
                         },
                     ));
                     Some(self.clone())

--- a/game/tests/sponsor_affinity_snapshot.rs
+++ b/game/tests/sponsor_affinity_snapshot.rs
@@ -70,7 +70,9 @@ fn three_cycle_affinity() {
     let cycle3_payloads = vec![MessagePayload::TributeKilled {
         victim: tref("Tribute4"),
         killer: None,
-        cause: shared::afflictions::DeathCause::Hazard(shared::afflictions::HazardKind::FallingDebris),
+        cause: shared::afflictions::DeathCause::Hazard(
+            shared::afflictions::HazardKind::FallingDebris,
+        ),
     }];
 
     for payloads in [cycle1_payloads, cycle2_payloads, cycle3_payloads] {

--- a/game/tests/sponsor_affinity_snapshot.rs
+++ b/game/tests/sponsor_affinity_snapshot.rs
@@ -53,7 +53,7 @@ fn three_cycle_affinity() {
         MessagePayload::TributeKilled {
             victim: tref("Tribute0"),
             killer: Some(tref("Tribute1")),
-            cause: "spear".into(),
+            cause: shared::afflictions::DeathCause::Tribute("spear".into()),
         },
         MessagePayload::AllianceFormed {
             members: vec![tref("Tribute2"), tref("Tribute3")],
@@ -70,7 +70,7 @@ fn three_cycle_affinity() {
     let cycle3_payloads = vec![MessagePayload::TributeKilled {
         victim: tref("Tribute4"),
         killer: None,
-        cause: "fall".into(),
+        cause: shared::afflictions::DeathCause::Hazard(shared::afflictions::HazardKind::FallingDebris),
     }];
 
     for payloads in [cycle1_payloads, cycle2_payloads, cycle3_payloads] {

--- a/shared/src/afflictions/source.rs
+++ b/shared/src/afflictions/source.rs
@@ -19,6 +19,20 @@ pub enum BeastKind {
     Other,
 }
 
+impl std::fmt::Display for BeastKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BeastKind::Tracker => write!(f, "tracker"),
+            BeastKind::Mutt => write!(f, "mutt"),
+            BeastKind::Wolf => write!(f, "wolf"),
+            BeastKind::Bear => write!(f, "bear"),
+            BeastKind::Snake => write!(f, "snake"),
+            BeastKind::Bird => write!(f, "bird"),
+            BeastKind::Other => write!(f, "beast"),
+        }
+    }
+}
+
 /// Coarse hazard taxonomy used by `DeathCause::Hazard`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -31,13 +45,29 @@ pub enum HazardKind {
     Other,
 }
 
+impl std::fmt::Display for HazardKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HazardKind::Trap => write!(f, "trap"),
+            HazardKind::Pit => write!(f, "pit"),
+            HazardKind::FallingDebris => write!(f, "falling debris"),
+            HazardKind::ToxicGas => write!(f, "toxic gas"),
+            HazardKind::Quicksand => write!(f, "quicksand"),
+            HazardKind::Other => write!(f, "hazard"),
+        }
+    }
+}
+
 /// Coarse classification of how a tribute died, used as the keying source for
-/// trauma acquisition (spec §4). Stored on `TraumaSource` variants. Resolution
-/// finer than this lives in messages, not in trauma state.
+/// trauma acquisition (spec §4). Stored on `TraumaSource` variants and as
+/// the `cause` field of `MessagePayload::TributeKilled`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 pub enum DeathCause {
     Tribute(String),
+    Combat,
+    Suicide,
+    CriticalFumble,
     Fire,
     Drowning,
     Beast(BeastKind),
@@ -47,6 +77,26 @@ pub enum DeathCause {
     Affliction(AfflictionKind),
     Gamemaker,
     Unknown,
+}
+
+impl std::fmt::Display for DeathCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeathCause::Tribute(name) => write!(f, "{name}"),
+            DeathCause::Combat => write!(f, "combat"),
+            DeathCause::Suicide => write!(f, "suicide"),
+            DeathCause::CriticalFumble => write!(f, "critical_fumble"),
+            DeathCause::Fire => write!(f, "fire"),
+            DeathCause::Drowning => write!(f, "drowning"),
+            DeathCause::Beast(kind) => write!(f, "{kind}"),
+            DeathCause::Hazard(kind) => write!(f, "{kind}"),
+            DeathCause::Starvation => write!(f, "starvation"),
+            DeathCause::Dehydration => write!(f, "dehydration"),
+            DeathCause::Affliction(kind) => write!(f, "{kind}"),
+            DeathCause::Gamemaker => write!(f, "gamemaker"),
+            DeathCause::Unknown => write!(f, "unknown"),
+        }
+    }
 }
 
 /// Coarse class of mass-casualty event source (spec §4, §7.1).

--- a/shared/src/messages/mod.rs
+++ b/shared/src/messages/mod.rs
@@ -3,10 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use uuid::Uuid;
 
-/// Cause string used in `MessagePayload::TributeKilled` for starvation deaths.
-pub const CAUSE_STARVATION: &str = "starvation";
-/// Cause string used in `MessagePayload::TributeKilled` for dehydration deaths.
-pub const CAUSE_DEHYDRATION: &str = "dehydration";
+
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "value")]
@@ -335,7 +332,7 @@ pub enum MessagePayload {
     TributeKilled {
         victim: TributeRef,
         killer: Option<TributeRef>,
-        cause: String,
+        cause: crate::afflictions::DeathCause,
     },
     TributeWounded {
         victim: TributeRef,

--- a/shared/src/messages/mod.rs
+++ b/shared/src/messages/mod.rs
@@ -3,8 +3,6 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use uuid::Uuid;
 
-
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "value")]
 pub enum MessageSource {

--- a/shared/src/messages/survival_event_tests.rs
+++ b/shared/src/messages/survival_event_tests.rs
@@ -109,12 +109,6 @@ fn foraged_drank_ate_round_trip_and_kind() {
 }
 
 #[test]
-fn cause_constants_exist() {
-    assert_eq!(CAUSE_STARVATION, "starvation");
-    assert_eq!(CAUSE_DEHYDRATION, "dehydration");
-}
-
-#[test]
 fn survival_payloads_involve_tribute() {
     let p = MessagePayload::Ate {
         tribute: tref(),

--- a/shared/src/messages/tests.rs
+++ b/shared/src/messages/tests.rs
@@ -69,7 +69,7 @@ fn kind_lifecycle_variants_map_correctly() {
     let p = MessagePayload::TributeKilled {
         victim: t("v"),
         killer: None,
-        cause: "fall".into(),
+        cause: crate::afflictions::DeathCause::Hazard(crate::afflictions::HazardKind::FallingDebris),
     };
     assert_eq!(p.kind(), MessageKind::Death);
 
@@ -266,7 +266,7 @@ fn summarize_groups_by_day_and_phase() {
     let killed = MessagePayload::TributeKilled {
         victim: tref.clone(),
         killer: None,
-        cause: "x".into(),
+        cause: crate::afflictions::DeathCause::Unknown,
     };
     let moved = MessagePayload::TributeHidden {
         tribute: tref.clone(),

--- a/shared/src/messages/tests.rs
+++ b/shared/src/messages/tests.rs
@@ -69,7 +69,9 @@ fn kind_lifecycle_variants_map_correctly() {
     let p = MessagePayload::TributeKilled {
         victim: t("v"),
         killer: None,
-        cause: crate::afflictions::DeathCause::Hazard(crate::afflictions::HazardKind::FallingDebris),
+        cause: crate::afflictions::DeathCause::Hazard(
+            crate::afflictions::HazardKind::FallingDebris,
+        ),
     };
     assert_eq!(p.kind(), MessageKind::Death);
 


### PR DESCRIPTION
## Summary
- Reuse existing DeathCause enum from afflictions/source.rs for TributeKilled.cause
- Remove CAUSE_STARVATION/CAUSE_DEHYDRATION string constants
- Add Display impl for DeathCause
- Update all call sites across shared, game, announcers, api

## Changes
- shared/src/afflictions/source.rs: add Combat, Suicide, CriticalFumble variants
- shared/src/messages/mod.rs: change cause field type, remove constants
- game/src/: update death cause construction
- announcers/src/: update test assertions

## Verification
- cargo test --package shared (95 tests)
- cargo test --package game (1143 tests)
- cargo test --package announcers (42 tests)

## Note
Wire format changes from plain strings to tagged JSON objects.