### PR TITLE
fix: align auth page class names with CSS

### DIFF
--- a/api/templates/auth.html
+++ b/api/templates/auth.html
@@ -2,14 +2,15 @@
 {% block content %}
 <div class="auth-card">
   <div class="auth-logo">Hangry <span>Games</span></div>
-  <div class="tab-bar">
+  <div class="auth-tabs">
     {% set active_tab = tab | default(value="login") %}
-    <button class="tab-btn {% if active_tab == 'login' %}active{% endif %}" data-tab="login">Sign In</button>
-    <button class="tab-btn {% if active_tab == 'register' %}active{% endif %}" data-tab="register">Register</button>
-    <button class="tab-btn {% if active_tab == 'reset' %}active{% endif %}" data-tab="reset">Reset Password</button>
+    <button class="auth-tab {% if active_tab == 'login' %}active{% endif %}" data-tab="login">Sign In</button>
+    <button class="auth-tab {% if active_tab == 'register' %}active{% endif %}" data-tab="register">Register</button>
+    <button class="auth-tab {% if active_tab == 'reset' %}active{% endif %}" data-tab="reset">Reset Password</button>
   </div>
 
-  <div class="tab-panel {% if active_tab == 'login' %}active{% endif %}" id="login">
+  <div class="auth-body">
+  <div class="auth-form {% if active_tab == 'login' %}active{% endif %}" id="login">
     <h2 class="auth-title">Welcome back</h2>
     <p class="auth-subtitle">Sign in to your account to continue.</p>
 
@@ -57,7 +58,7 @@
     </div>
   </div>
 
-  <div class="tab-panel {% if active_tab == 'register' %}active{% endif %}" id="register">
+  <div class="auth-form {% if active_tab == 'register' %}active{% endif %}" id="register">
     <h2 class="auth-title">Create account</h2>
     <p class="auth-subtitle">Join the broadcast. No credit card required.</p>
 
@@ -107,7 +108,7 @@
     </div>
   </div>
 
-  <div class="tab-panel {% if active_tab == 'reset' %}active{% endif %}" id="reset">
+  <div class="auth-form {% if active_tab == 'reset' %}active{% endif %}" id="reset">
     <h2 class="auth-title">Reset password</h2>
     <p class="auth-subtitle">Enter your email and we'll send you a reset link.</p>
 
@@ -133,14 +134,14 @@
 <script>
   {% raw %}
   function switchTab(id) {
-    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-    document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+    document.querySelectorAll('.auth-tab').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.auth-form').forEach(p => p.classList.remove('active'));
     const btn = document.querySelector('[data-tab="'+id+'"]');
     if (btn) btn.classList.add('active');
     const panel = document.getElementById(id);
     if (panel) panel.classList.add('active');
   }
-  document.querySelectorAll('.tab-btn').forEach(btn => {
+  document.querySelectorAll('.auth-tab').forEach(btn => {
     btn.addEventListener('click', () => switchTab(btn.dataset.tab));
   });
   {% endraw %}


### PR DESCRIPTION
Auth page used class names (tab-bar, tab-btn, tab-panel) that didn't match CSS (auth-tabs, auth-tab, auth-form). Fixed class names, added auth-body wrapper, updated JS selectors.